### PR TITLE
Syno fix, cool down fix, token advancement.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57
 	golift.io/cnfg v0.0.8-0.20201101095209-9c9085f1bf93
 	golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9
-	golift.io/starr v0.9.10-0.20210407032405-6ef17f97fbaa
+	golift.io/starr v0.9.10-0.20210410042602-a2a6bc274f63
 	golift.io/version v0.0.2
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57
 	golift.io/cnfg v0.0.8-0.20201101095209-9c9085f1bf93
 	golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9
-	golift.io/starr v0.9.10-0.20210410042602-a2a6bc274f63
+	golift.io/starr v0.9.10
 	golift.io/version v0.0.2
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ golift.io/cnfg v0.0.8-0.20201101095209-9c9085f1bf93 h1:6zgmt5vpnqltfJ7Wfj16NT+rg
 golift.io/cnfg v0.0.8-0.20201101095209-9c9085f1bf93/go.mod h1:AsB0DJe7nv0bizKaoy3e3MjjOF7upTpMOMvsfv4CNNk=
 golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9 h1:j/WeLF6Ew1lc/m8/bh5qleZ66aSeJ72B1fUWigF69OE=
 golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9/go.mod h1:EZevRvIGRh8jDMwuYL0/tlPns0KynquPZzb0SerIC1s=
-golift.io/starr v0.9.10-0.20210407032405-6ef17f97fbaa h1:b8nzXPOu89TVCmbju5hsMHKlddJWQea2TSAmakpdDes=
-golift.io/starr v0.9.10-0.20210407032405-6ef17f97fbaa/go.mod h1:oaAjRa9vIpsj0lTR79vDDRVqXuq6ID6RXbQIoFljhbM=
+golift.io/starr v0.9.10-0.20210410042602-a2a6bc274f63 h1:E2CmEtDeNVVFrMRvmEV55SPXf/cZEbBC+yZKiO4Ffyg=
+golift.io/starr v0.9.10-0.20210410042602-a2a6bc274f63/go.mod h1:oaAjRa9vIpsj0lTR79vDDRVqXuq6ID6RXbQIoFljhbM=
 golift.io/version v0.0.2 h1:i0gXRuSDHKs4O0sVDUg4+vNIuOxYoXhaxspftu2FRTE=
 golift.io/version v0.0.2/go.mod h1:76aHNz8/Pm7CbuxIsDi97jABL5Zui3f2uZxDm4vB6hU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9 h1:j/WeLF6Ew1lc/m8/bh5qleZ
 golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9/go.mod h1:EZevRvIGRh8jDMwuYL0/tlPns0KynquPZzb0SerIC1s=
 golift.io/starr v0.9.10-0.20210410042602-a2a6bc274f63 h1:E2CmEtDeNVVFrMRvmEV55SPXf/cZEbBC+yZKiO4Ffyg=
 golift.io/starr v0.9.10-0.20210410042602-a2a6bc274f63/go.mod h1:oaAjRa9vIpsj0lTR79vDDRVqXuq6ID6RXbQIoFljhbM=
+golift.io/starr v0.9.10 h1:1XJRImHcIrr8iTzoH0e439XTwnlhnYt5J/LwyAAH92U=
+golift.io/starr v0.9.10/go.mod h1:oaAjRa9vIpsj0lTR79vDDRVqXuq6ID6RXbQIoFljhbM=
 golift.io/version v0.0.2 h1:i0gXRuSDHKs4O0sVDUg4+vNIuOxYoXhaxspftu2FRTE=
 golift.io/version v0.0.2/go.mod h1:76aHNz8/Pm7CbuxIsDi97jABL5Zui3f2uZxDm4vB6hU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -91,7 +91,7 @@ func (a *Apps) handleAPI(app App, api APIHandler) http.HandlerFunc {
 			start = time.Now()
 		)
 
-		// disccordnotifier.com uses 1-indexes; subtract 1 from the ID (turn 1 into 0 generally).
+		// notifiarr.com uses 1-indexes; subtract 1 from the ID (turn 1 into 0 generally).
 		switch id--; {
 		// Make sure the id is within range of the available service.
 		case app == Radarr && (id >= len(a.Radarr) || id < 0):

--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -117,7 +117,8 @@ func (a *Apps) handleAPI(app App, api APIHandler) http.HandlerFunc {
 			code, msg = api(r) // unknown app, just run the handler.
 		}
 
-		a.Respond(w, code, msg, time.Since(start))
+		r.Header.Set("X-Request-Time", fmt.Sprintf("%dms", time.Since(start).Milliseconds()))
+		a.Respond(w, code, msg)
 	}
 }
 
@@ -162,9 +163,7 @@ func (a *Apps) Setup(timeout time.Duration) {
 }
 
 // Respond sends a standard response to our caller. JSON encoded blobs.
-func (a *Apps) Respond(w http.ResponseWriter, stat int, msg interface{}, reqTime time.Duration) {
-	w.Header().Set("X-Request-Time", fmt.Sprintf("%dms", reqTime.Milliseconds()))
-
+func (a *Apps) Respond(w http.ResponseWriter, stat int, msg interface{}) {
 	if stat == http.StatusFound || stat == http.StatusMovedPermanently ||
 		stat == http.StatusPermanentRedirect || stat == http.StatusTemporaryRedirect {
 		w.Header().Set("Location", msg.(string))

--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -58,7 +58,6 @@ var (
 	ErrNoSonarr  = fmt.Errorf("configured %s ID not found", Sonarr)
 	ErrNoLidarr  = fmt.Errorf("configured %s ID not found", Lidarr)
 	ErrNoReadarr = fmt.Errorf("configured %s ID not found", Readarr)
-	ErrExists    = fmt.Errorf("the requested item already exists")
 	ErrNotFound  = fmt.Errorf("the request returned an empty payload")
 )
 

--- a/pkg/apps/lidarr.go
+++ b/pkg/apps/lidarr.go
@@ -96,7 +96,7 @@ func lidarrCheckAlbum(r *http.Request) (int, interface{}) {
 	if err != nil {
 		return http.StatusServiceUnavailable, fmt.Errorf("checking album: %w", err)
 	} else if len(m) > 0 {
-		return http.StatusConflict, fmt.Errorf("%s: %w", id, ErrExists)
+		return http.StatusConflict, fmt.Errorf("%d: %w", m[0].ID, ErrExists)
 	}
 
 	return http.StatusOK, http.StatusText(http.StatusNotFound)

--- a/pkg/apps/lidarr.go
+++ b/pkg/apps/lidarr.go
@@ -67,7 +67,7 @@ func lidarrAddAlbum(r *http.Request) (int, interface{}) {
 	if err != nil {
 		return http.StatusServiceUnavailable, fmt.Errorf("checking album: %w", err)
 	} else if len(m) > 0 {
-		return http.StatusConflict, fmt.Errorf("%s: %w", payload.ForeignAlbumID, ErrExists)
+		return http.StatusConflict, m[0].ID
 	}
 
 	album, err := app.AddAlbum(&payload)
@@ -96,7 +96,7 @@ func lidarrCheckAlbum(r *http.Request) (int, interface{}) {
 	if err != nil {
 		return http.StatusServiceUnavailable, fmt.Errorf("checking album: %w", err)
 	} else if len(m) > 0 {
-		return http.StatusConflict, fmt.Errorf("%d: %w", m[0].ID, ErrExists)
+		return http.StatusConflict, m[0].ID
 	}
 
 	return http.StatusOK, http.StatusText(http.StatusNotFound)

--- a/pkg/apps/lidarr.go
+++ b/pkg/apps/lidarr.go
@@ -34,6 +34,7 @@ func (a *Apps) lidarrHandlers() {
 	a.HandleAPIpath(Lidarr, "/tag/{label}", lidarrSetTag, "PUT")
 	a.HandleAPIpath(Lidarr, "/update", lidarrUpdateAlbum, "PUT")
 	a.HandleAPIpath(Lidarr, "/updateartist", lidarrUpdateArtist, "PUT")
+	a.HandleAPIpath(Lidarr, "/command/search/{albumid:[0-9]+}", lidarrTriggerSearchAlbum, "GET")
 }
 
 // LidarrConfig represents the input data for a Lidarr server.
@@ -67,7 +68,7 @@ func lidarrAddAlbum(r *http.Request) (int, interface{}) {
 	if err != nil {
 		return http.StatusServiceUnavailable, fmt.Errorf("checking album: %w", err)
 	} else if len(m) > 0 {
-		return http.StatusConflict, m[0].ID
+		return http.StatusConflict, lidarrData(m[0])
 	}
 
 	album, err := app.AddAlbum(&payload)
@@ -89,6 +90,19 @@ func lidarrGetArtist(r *http.Request) (int, interface{}) {
 	return http.StatusOK, artist
 }
 
+func lidarrData(album *lidarr.Album) map[string]interface{} {
+	hasFile := false
+	if album.Statistics != nil {
+		hasFile = album.Statistics.SizeOnDisk > 0
+	}
+
+	return map[string]interface{}{
+		"id":        album.ID,
+		"hasFile":   hasFile,
+		"monitored": album.Monitored,
+	}
+}
+
 func lidarrCheckAlbum(r *http.Request) (int, interface{}) {
 	id := mux.Vars(r)["mbid"]
 
@@ -96,7 +110,7 @@ func lidarrCheckAlbum(r *http.Request) (int, interface{}) {
 	if err != nil {
 		return http.StatusServiceUnavailable, fmt.Errorf("checking album: %w", err)
 	} else if len(m) > 0 {
-		return http.StatusConflict, m[0].ID
+		return http.StatusConflict, lidarrData(m[0])
 	}
 
 	return http.StatusOK, http.StatusText(http.StatusNotFound)
@@ -111,6 +125,20 @@ func lidarrGetAlbum(r *http.Request) (int, interface{}) {
 	}
 
 	return http.StatusOK, album
+}
+
+func lidarrTriggerSearchAlbum(r *http.Request) (int, interface{}) {
+	albumID, _ := strconv.ParseInt(mux.Vars(r)["albumid"], 10, 64)
+
+	output, err := getLidarr(r).SendCommand(&lidarr.CommandRequest{
+		Name:     "AlbumSearch",
+		AlbumIDs: []int64{albumID},
+	})
+	if err != nil {
+		return http.StatusServiceUnavailable, fmt.Errorf("triggering album search: %w", err)
+	}
+
+	return http.StatusOK, output.Status
 }
 
 func lidarrMetadata(r *http.Request) (int, interface{}) {

--- a/pkg/apps/radarr.go
+++ b/pkg/apps/radarr.go
@@ -66,7 +66,7 @@ func radarrAddMovie(r *http.Request) (int, interface{}) {
 	if err != nil {
 		return http.StatusServiceUnavailable, fmt.Errorf("checking movie: %w", err)
 	} else if len(m) > 0 {
-		return http.StatusConflict, fmt.Errorf("%d: %w", payload.TmdbID, ErrExists)
+		return http.StatusConflict, m[0].ID
 	}
 
 	if payload.Title == "" {
@@ -94,7 +94,7 @@ func radarrCheckMovie(r *http.Request) (int, interface{}) {
 	if err != nil {
 		return http.StatusServiceUnavailable, fmt.Errorf("checking movie: %w", err)
 	} else if len(m) > 0 {
-		return http.StatusConflict, fmt.Errorf("%d: %w", m[0].ID, ErrExists)
+		return http.StatusConflict, m[0].ID
 	}
 
 	return http.StatusOK, http.StatusText(http.StatusNotFound)

--- a/pkg/apps/radarr.go
+++ b/pkg/apps/radarr.go
@@ -94,7 +94,7 @@ func radarrCheckMovie(r *http.Request) (int, interface{}) {
 	if err != nil {
 		return http.StatusServiceUnavailable, fmt.Errorf("checking movie: %w", err)
 	} else if len(m) > 0 {
-		return http.StatusConflict, fmt.Errorf("%d: %w", tmdbID, ErrExists)
+		return http.StatusConflict, fmt.Errorf("%d: %w", m[0].ID, ErrExists)
 	}
 
 	return http.StatusOK, http.StatusText(http.StatusNotFound)

--- a/pkg/apps/readarr.go
+++ b/pkg/apps/readarr.go
@@ -62,7 +62,7 @@ func readarrAddBook(r *http.Request) (int, interface{}) {
 	if err != nil {
 		return http.StatusServiceUnavailable, fmt.Errorf("checking book: %w", err)
 	} else if len(m) > 0 {
-		return http.StatusConflict, fmt.Errorf("%s: %w", payload.ForeignBookID, ErrExists)
+		return http.StatusConflict, m[0].ID
 	}
 
 	// Add book using payload.
@@ -93,7 +93,7 @@ func readarrCheckBook(r *http.Request) (int, interface{}) {
 	if err != nil {
 		return http.StatusServiceUnavailable, fmt.Errorf("checking book: %w", err)
 	} else if len(m) > 0 {
-		return http.StatusConflict, fmt.Errorf("%d: %w", m[0].ID, ErrExists)
+		return http.StatusConflict, m[0].ID
 	}
 
 	return http.StatusOK, http.StatusText(http.StatusNotFound)

--- a/pkg/apps/readarr.go
+++ b/pkg/apps/readarr.go
@@ -29,6 +29,7 @@ func (a *Apps) readarrHandlers() {
 	a.HandleAPIpath(Readarr, "/tag/{tid:[0-9]+}/{label}", readarrUpdateTag, "PUT")
 	a.HandleAPIpath(Readarr, "/tag/{label}", readarrSetTag, "PUT")
 	a.HandleAPIpath(Readarr, "/updateauthor", readarrUpdateAuthor, "PUT")
+	a.HandleAPIpath(Readarr, "/command/search/{bookid:[0-9]+}", readarrTriggerSearchBook, "GET")
 }
 
 // ReadarrConfig represents the input data for a Readarr server.
@@ -62,7 +63,7 @@ func readarrAddBook(r *http.Request) (int, interface{}) {
 	if err != nil {
 		return http.StatusServiceUnavailable, fmt.Errorf("checking book: %w", err)
 	} else if len(m) > 0 {
-		return http.StatusConflict, m[0].ID
+		return http.StatusConflict, readarrData(m[0])
 	}
 
 	// Add book using payload.
@@ -85,6 +86,19 @@ func readarrGetAuthor(r *http.Request) (int, interface{}) {
 	return http.StatusOK, author
 }
 
+func readarrData(book *readarr.Book) map[string]interface{} {
+	hasFile := false
+	if book.Statistics != nil {
+		hasFile = book.Statistics.SizeOnDisk > 0
+	}
+
+	return map[string]interface{}{
+		"id":        book.ID,
+		"hasFile":   hasFile,
+		"monitored": book.Monitored,
+	}
+}
+
 // Check for existing book.
 func readarrCheckBook(r *http.Request) (int, interface{}) {
 	grid := mux.Vars(r)["grid"]
@@ -93,7 +107,7 @@ func readarrCheckBook(r *http.Request) (int, interface{}) {
 	if err != nil {
 		return http.StatusServiceUnavailable, fmt.Errorf("checking book: %w", err)
 	} else if len(m) > 0 {
-		return http.StatusConflict, m[0].ID
+		return http.StatusConflict, readarrData(m[0])
 	}
 
 	return http.StatusOK, http.StatusText(http.StatusNotFound)
@@ -108,6 +122,20 @@ func readarrGetBook(r *http.Request) (int, interface{}) {
 	}
 
 	return http.StatusOK, book
+}
+
+func readarrTriggerSearchBook(r *http.Request) (int, interface{}) {
+	bookID, _ := strconv.ParseInt(mux.Vars(r)["bookid"], 10, 64)
+
+	output, err := getReadarr(r).SendCommand(&readarr.CommandRequest{
+		Name:    "BookSearch",
+		BookIDs: []int64{bookID},
+	})
+	if err != nil {
+		return http.StatusServiceUnavailable, fmt.Errorf("checking book: %w", err)
+	}
+
+	return http.StatusOK, output.Status
 }
 
 // Get the metadata profiles from readarr.

--- a/pkg/apps/readarr.go
+++ b/pkg/apps/readarr.go
@@ -93,7 +93,7 @@ func readarrCheckBook(r *http.Request) (int, interface{}) {
 	if err != nil {
 		return http.StatusServiceUnavailable, fmt.Errorf("checking book: %w", err)
 	} else if len(m) > 0 {
-		return http.StatusConflict, fmt.Errorf("%s: %w", grid, ErrExists)
+		return http.StatusConflict, fmt.Errorf("%d: %w", m[0].ID, ErrExists)
 	}
 
 	return http.StatusOK, http.StatusText(http.StatusNotFound)

--- a/pkg/apps/sonarr.go
+++ b/pkg/apps/sonarr.go
@@ -78,7 +78,7 @@ func sonarrCheckSeries(r *http.Request) (int, interface{}) {
 	if err != nil {
 		return http.StatusServiceUnavailable, fmt.Errorf("checking series: %w", err)
 	} else if len(m) > 0 {
-		return http.StatusConflict, fmt.Errorf("%s: %w", m[0].ID, ErrExists)
+		return http.StatusConflict, fmt.Errorf("%d: %w", m[0].ID, ErrExists)
 	}
 
 	return http.StatusOK, http.StatusText(http.StatusNotFound)

--- a/pkg/apps/sonarr.go
+++ b/pkg/apps/sonarr.go
@@ -78,7 +78,7 @@ func sonarrCheckSeries(r *http.Request) (int, interface{}) {
 	if err != nil {
 		return http.StatusServiceUnavailable, fmt.Errorf("checking series: %w", err)
 	} else if len(m) > 0 {
-		return http.StatusConflict, fmt.Errorf("%d: %w", tvdbid, ErrExists)
+		return http.StatusConflict, fmt.Errorf("%s: %w", m[0].ID, ErrExists)
 	}
 
 	return http.StatusOK, http.StatusText(http.StatusNotFound)

--- a/pkg/apps/sonarr.go
+++ b/pkg/apps/sonarr.go
@@ -27,6 +27,7 @@ func (a *Apps) sonarrHandlers() {
 	a.HandleAPIpath(Sonarr, "/tag/{tid:[0-9]+}/{label}", sonarrUpdateTag, "PUT")
 	a.HandleAPIpath(Sonarr, "/tag/{label}", sonarrSetTag, "PUT")
 	a.HandleAPIpath(Sonarr, "/update", sonarrUpdateSeries, "PUT")
+	a.HandleAPIpath(Sonarr, "/command/search/{seriesid:[0-9]+}", sonarrTriggerSearchSeries, "GET")
 }
 
 // SonarrConfig represents the input data for a Sonarr server.
@@ -60,7 +61,7 @@ func sonarrAddSeries(r *http.Request) (int, interface{}) {
 	if err != nil {
 		return http.StatusServiceUnavailable, fmt.Errorf("checking series: %w", err)
 	} else if len(m) > 0 {
-		return http.StatusConflict, m[0].ID
+		return http.StatusConflict, sonarrData(m[0])
 	}
 
 	series, err := app.AddSeries(&payload)
@@ -71,6 +72,19 @@ func sonarrAddSeries(r *http.Request) (int, interface{}) {
 	return http.StatusCreated, series
 }
 
+func sonarrData(series *sonarr.Series) map[string]interface{} {
+	hasFile := false
+	if series.Statistics != nil {
+		hasFile = series.Statistics.SizeOnDisk > 0
+	}
+
+	return map[string]interface{}{
+		"id":        series.ID,
+		"hasFile":   hasFile,
+		"monitored": series.Monitored,
+	}
+}
+
 func sonarrCheckSeries(r *http.Request) (int, interface{}) {
 	tvdbid, _ := strconv.ParseInt(mux.Vars(r)["tvdbid"], 10, 64)
 	// Check for existing series.
@@ -78,7 +92,7 @@ func sonarrCheckSeries(r *http.Request) (int, interface{}) {
 	if err != nil {
 		return http.StatusServiceUnavailable, fmt.Errorf("checking series: %w", err)
 	} else if len(m) > 0 {
-		return http.StatusConflict, m[0].ID
+		return http.StatusConflict, sonarrData(m[0])
 	}
 
 	return http.StatusOK, http.StatusText(http.StatusNotFound)
@@ -93,6 +107,20 @@ func sonarrGetSeries(r *http.Request) (int, interface{}) {
 	}
 
 	return http.StatusOK, series
+}
+
+func sonarrTriggerSearchSeries(r *http.Request) (int, interface{}) {
+	seriesID, _ := strconv.ParseInt(mux.Vars(r)["seriesid"], 10, 64)
+
+	output, err := getSonarr(r).SendCommand(&sonarr.CommandRequest{
+		Name:     "SeriesSearch",
+		SeriesID: seriesID,
+	})
+	if err != nil {
+		return http.StatusServiceUnavailable, fmt.Errorf("triggering series search: %w", err)
+	}
+
+	return http.StatusOK, output.Status
 }
 
 func sonarrLangProfiles(r *http.Request) (int, interface{}) {

--- a/pkg/apps/sonarr.go
+++ b/pkg/apps/sonarr.go
@@ -60,7 +60,7 @@ func sonarrAddSeries(r *http.Request) (int, interface{}) {
 	if err != nil {
 		return http.StatusServiceUnavailable, fmt.Errorf("checking series: %w", err)
 	} else if len(m) > 0 {
-		return http.StatusConflict, fmt.Errorf("%d: %w", payload.TvdbID, ErrExists)
+		return http.StatusConflict, m[0].ID
 	}
 
 	series, err := app.AddSeries(&payload)
@@ -78,7 +78,7 @@ func sonarrCheckSeries(r *http.Request) (int, interface{}) {
 	if err != nil {
 		return http.StatusServiceUnavailable, fmt.Errorf("checking series: %w", err)
 	} else if len(m) > 0 {
-		return http.StatusConflict, fmt.Errorf("%d: %w", m[0].ID, ErrExists)
+		return http.StatusConflict, m[0].ID
 	}
 
 	return http.StatusOK, http.StatusText(http.StatusNotFound)

--- a/pkg/client/handlers.go
+++ b/pkg/client/handlers.go
@@ -27,8 +27,9 @@ func (c *Client) internalHandlers() {
 	c.Config.HandleAPIpath("", "info/alert", c.updateInfoAlert, "PUT")
 
 	if c.Config.Plex != nil && c.Config.Plex.Token != "" && c.Config.Plex.URL != "" {
+		tokens := fmt.Sprintf("{token:%s|%s}", c.Config.Plex.Token, c.Config.Apps.APIKey)
 		c.Config.Router.Handle("/plex",
-			http.HandlerFunc(c.plexIncoming)).Methods("POST").Queries("token", c.Config.Plex.Token)
+			http.HandlerFunc(c.plexIncoming)).Methods("POST").Queries("token", tokens)
 	}
 
 	// Initialize internal-only paths.

--- a/pkg/client/plexsnaps.go
+++ b/pkg/client/plexsnaps.go
@@ -36,10 +36,10 @@ func (c *Client) plexIncoming(w http.ResponseWriter, r *http.Request) {
 	case (v.Event == "media.resume" || v.Event == "media.pause") && c.plex.Active(c.Config.Plex.Cooldown.Duration):
 		c.Printf("Plex Incoming Webhook IGNORED (cooldown): %s, %s '%s' => %s",
 			v.Server.Title, v.Account.Title, v.Event, v.Metadata.Title)
-		c.Config.Respond(w, http.StatusNoContent, "ignored, cooldown")
+		c.Config.Respond(w, http.StatusAlreadyReported, "ignored, cooldown")
 	default:
 		go c.collectSessions(&v)
-		c.Config.Respond(w, http.StatusAccepted, "processing")
+		c.Config.Respond(w, http.StatusAlreadyReported, "processing")
 	}
 }
 

--- a/pkg/client/plexsnaps.go
+++ b/pkg/client/plexsnaps.go
@@ -29,7 +29,7 @@ func (c *Client) plexIncoming(w http.ResponseWriter, r *http.Request) {
 	case !strings.HasPrefix(v.Event, "media"):
 		w.WriteHeader(http.StatusNoContent)
 		_, _ = w.Write([]byte("ignored, non-media\n"))
-	case c.plex.Active():
+	case (v.Event == "media.resume" || v.Event == "media.pause") && c.plex.Active():
 		c.Printf("Plex Incoming Webhook IGNORED (cooldown): %s, %s '%s' => %s",
 			v.Server.Title, v.Account.Title, v.Event, v.Metadata.Title)
 		w.WriteHeader(http.StatusNoContent)

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -70,7 +70,7 @@ type Client struct {
 	info   string
 	notify *notifiarr.Config
 	alert  *logs.Cooler
-	plex   *logs.Cooler
+	plex   *logs.Timer
 }
 
 // Errors returned by this package.
@@ -84,7 +84,7 @@ func NewDefaults() *Client {
 		sigkil: make(chan os.Signal, 1),
 		sighup: make(chan os.Signal, 1),
 		menu:   make(map[string]ui.MenuItem),
-		plex:   &logs.Cooler{},
+		plex:   &logs.Timer{},
 		alert:  &logs.Cooler{},
 		Logger: logs.New(),
 		Config: &Config{

--- a/pkg/client/webserver.go
+++ b/pkg/client/webserver.go
@@ -19,7 +19,7 @@ var ErrNoServer = fmt.Errorf("the web server is not running, cannot stop it")
 func (c *Client) StartWebServer() {
 	// Create an apache-style logger.
 	l, _ := apachelog.New(`%{X-Forwarded-For}i %l %u %t "%{X-Redacted-URI}i" %>s %b "%{Referer}i" ` +
-		`"%{User-agent}i" %{X-Request-Time}o %{ms}Tms`)
+		`"%{User-agent}i" %{X-Request-Time}i %{ms}Tms`)
 	// Create a request router.
 	c.Config.Apps.Router = mux.NewRouter()
 	c.Config.Apps.ErrorLog = c.Logger.ErrorLog

--- a/pkg/client/webserver.go
+++ b/pkg/client/webserver.go
@@ -18,14 +18,14 @@ var ErrNoServer = fmt.Errorf("the web server is not running, cannot stop it")
 // StartWebServer starts the web server.
 func (c *Client) StartWebServer() {
 	// Create an apache-style logger.
-	l, _ := apachelog.New(`%{X-Forwarded-For}i %l %u %t "%r" %>s %b "%{Referer}i" ` +
+	l, _ := apachelog.New(`%{X-Forwarded-For}i %l %u %t "%{X-Redacted-URI}i" %>s %b "%{Referer}i" ` +
 		`"%{User-agent}i" %{X-Request-Time}o %{ms}Tms`)
 	// Create a request router.
 	c.Config.Apps.Router = mux.NewRouter()
 	c.Config.Apps.ErrorLog = c.Logger.ErrorLog
 	// Create a server.
 	c.server = &http.Server{ // nolint: exhaustivestruct
-		Handler:           l.Wrap(c.fixForwardedFor(c.Config.Apps.Router), c.Logger.HTTPLog.Writer()),
+		Handler:           c.stripSecrets(l.Wrap(c.fixForwardedFor(c.Config.Apps.Router), c.Logger.HTTPLog.Writer())),
 		Addr:              c.Config.BindAddr,
 		IdleTimeout:       time.Minute,
 		WriteTimeout:      c.Config.Timeout.Duration,

--- a/pkg/logs/cooler.go
+++ b/pkg/logs/cooler.go
@@ -1,6 +1,9 @@
 package logs
 
-import "sync"
+import (
+	"sync"
+	"time"
+)
 
 /* This is a helper method used in a couple spots. Doesn't have anything to do with logs. */
 
@@ -30,4 +33,22 @@ func (c *Cooler) Done() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.active = false
+}
+
+type Timer struct {
+	lock  sync.Mutex
+	start time.Time
+}
+
+func (t *Timer) Active(d time.Duration) bool {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if time.Since(t.start) < d {
+		return true
+	}
+
+	t.start = time.Now()
+
+	return false
 }

--- a/pkg/notifiarr/plexcron.go
+++ b/pkg/notifiarr/plexcron.go
@@ -26,7 +26,7 @@ func (c *Config) startPlexCron() {
 		c.stopPlex = nil
 	}()
 
-	c.Printf("==> Plex Sessions Collection Started, URL: %s, interval: %v, timeout: %v, cooldown: %v",
+	c.Printf("==> Plex Sessions Collection Started, URL: %s, interval: %v, timeout: %v, webhook cooldown: %v",
 		c.Plex.URL, c.Plex.Interval, c.Plex.Timeout, c.Plex.Cooldown)
 
 	if c.Plex.MoviesPC != 0 || c.Plex.SeriesPC != 0 {

--- a/scripts/install-synology.sh
+++ b/scripts/install-synology.sh
@@ -87,7 +87,12 @@ chmod 0755 /usr/bin/notifiarr
 echo "${P} Ensuring config file: /etc/notifiarr/notifiarr.conf (File exists error after this is OK!)"
 mkdir /etc/notifiarr 2>/dev/null || \
   $CMD https://notifiarr.com/scripts/notifiarr-client.conf > /etc/notifiarr/notifiarr.conf
-[ ! -d /volume1/data ] || cp -n /etc/notifiarr/notifiarr.conf /volume1/data/notifiarr.conf
+
+CONFIGFILE=/etc/notifiarr/notifiarr.conf
+if [ -d /volume1/data ]; then
+  CONFIGFILE=/volume1/data/notifiarr.conf
+  [ -f /volume1/data/otifiarr.conf ] || cp /etc/notifiarr/notifiarr.conf ${CONFIGFILE}
+fi
 
 echo "${P} Adding sudoers entry to: /etc/sudoers"
 sed -i '/notifiarr/d' /etc/sudoers
@@ -112,7 +117,10 @@ if [ "$?" != "0" ]; then
   echo "${P} Adding notifiarr user: synouser --add notifiarr Notifiarr 0 support@notifiarr.com 0"
   pass="${RANDOM}${RANDOM}${RANDOM}${RANDOM}${RANDOM}${RANDOM}${RANDOM}${RANDOM}"
   synouser --add notifiarr "${pass}" Notifiarr 0 support@notifiarr.com 0
-  #        --add username  pwd       full-name expired{0|1} mail privilege(0=none)
+  if [ "${CONFIGFILE}" != "/etc/notifiarr/notifiarr.conf" ] then
+    echo "${P} Authorizing notifiarr user: synoacltool -add /volume1/data user:notifiarr:allow:r--------------:fd--"
+    synoacltool -add /volume1/data user:notifiarr:allow:r--------------:fd--
+  fi
 else
   echo "${P} User notifiarr already exists: ${ID}"
 fi
@@ -124,8 +132,7 @@ if [ "$?" = "0" ]; then
   start notifiarr
 fi
 
-echo "${P} Installed. Edit your config file: /etc/notifiarr/notifiarr.conf"
-echo "${P} The config may be symlinked at:   /volume1/data/notifiarr.conf"
+echo "${P} Installed. Edit your config file: ${CONFIGFILE}"
 echo "${P} start the service with:  start notifiarr"
 echo "${P} stop the service with:   stop notifiarr"
 echo "${P} to check service status: status notifiarr"


### PR DESCRIPTION
This contribution:
- Fixes config file access on a Synology.
- Removes the cool down from all media types except resume and pause. Closes #49.
- Allows the incoming pix web hook to use the API Key OR the Plex Token. Previously it only worked with the Plex Token, now you can use either string to authorize Plex to post to this app.
- Hides the Plex Token and Notifiarr API Key from logs.
- Adds search trigger ability for all four Starr apps.