### PR TITLE
Make synology install script upgrade-aware

### DIFF
--- a/scripts/install-synology.sh
+++ b/scripts/install-synology.sh
@@ -165,7 +165,7 @@ if [ "$?" != "0" ]; then
   echo "${P} Adding notifiarr user: synouser --add notifiarr Notifiarr 0 support@notifiarr.com 0"
   pass="${RANDOM}${RANDOM}${RANDOM}${RANDOM}${RANDOM}${RANDOM}${RANDOM}${RANDOM}"
   synouser --add notifiarr "${pass}" Notifiarr 0 support@notifiarr.com 0
-  if [ "${CONFIGFILE}" != "/etc/notifiarr/notifiarr.conf" ] then
+  if [ "${CONFIGFILE}" != "/etc/notifiarr/notifiarr.conf" ]; then
     echo "${P} Authorizing notifiarr user: synoacltool -add /volume1/data user:notifiarr:allow:r--------------:fd--"
     synoacltool -add /volume1/data user:notifiarr:allow:r--------------:fd--
   fi

--- a/scripts/install-synology.sh
+++ b/scripts/install-synology.sh
@@ -2,11 +2,17 @@
 #
 # This is a quick and dirty script to install the latest notifiarr on Synology.
 #
-# Use it like this, pick curl or wget:  (sudo is optional)
+# Use it like this, pick curl or wget:  (sudo is not optional for Synology)
 # ----
-#   curl -sL https://raw.githubusercontent.com/Notifiarr/notifiarr/main/scripts/install-synology.sh | sudo bash
+#   curl -sSL https://raw.githubusercontent.com/Notifiarr/notifiarr/main/scripts/install-synology.sh | sudo bash
 #   wget -qO- https://raw.githubusercontent.com/Notifiarr/notifiarr/main/scripts/install-synology.sh | sudo bash
 # ----
+#
+# This file can be added to crontab. First, save it locally:
+#   sudo curl -sSLo /usr/bin/update-notifiarr.sh https://raw.githubusercontent.com/Notifiarr/notifiarr/main/scripts/install-synology.sh
+# Then install this crontab:
+#   echo "10 3 * * * root /bin/bash /usr/bin/update-notifiarr.sh 2>&1 > /volume1/data/notifiarr-updates.log" | sudo tee /etc/cron.d/update-notifiarr
+#
 
 # Set the repo name correctly.
 REPO=Notifiarr/notifiarr
@@ -56,8 +62,12 @@ if [ "$CMD" = "" ]; then
   exit 1
 fi
 
+INSTALLED=$(/usr/bin/notifiarr -v 2>/dev/null | head -n1 | cut -d' ' -f3)
+
 # Grab latest release file from github.
-URL=$($CMD ${LATEST} | egrep "browser_download_url.*(${ARCH})\.${FILE}\"" | cut -d\" -f 4)
+PAYLOAD=$($CMD ${LATEST})
+URL=$(echo "$PAYLOAD" | egrep "browser_download_url.*(${ARCH})\.${FILE}\"" | cut -d\" -f 4)
+TAG=$(echo "$PAYLOAD" | grep 'tag_name' | cut -d\" -f4 | tr -d v)
 
 if [ "$?" != "0" ] || [ "$URL" = "" ]; then
   echo "${P} [ERROR] Missing latest release for '${FILE}' file ($OS/${ARCH}) at ${LATEST}"
@@ -67,13 +77,51 @@ if [ "$?" != "0" ] || [ "$URL" = "" ]; then
   exit 1
 fi
 
+# https://stackoverflow.com/questions/4023830/how-to-compare-two-strings-in-dot-separated-version-format-in-bash
+vercomp () {
+  if [ "$1" = "" ]; then
+    return 3
+  elif [ "$1" = "$2" ]; then
+    return 0
+  fi
+
+  local IFS=.
+  local i ver1=($1) ver2=($2)
+  # fill empty fields in ver1 with zeros
+  for ((i=${#ver1[@]}; i<${#ver2[@]}; i++)); do
+    ver1[i]=0
+  done
+
+  for ((i=0; i<${#ver1[@]}; i++)); do
+    if [[ -z ${ver2[i]} ]]; then
+      # fill empty fields in ver2 with zeros
+      ver2[i]=0
+    elif ((10#${ver1[i]} > 10#${ver2[i]})); then
+      return 1
+    elif ((10#${ver1[i]} < 10#${ver2[i]})); then
+      return 2
+    fi
+  done
+  return 0
+}
+
+vercomp "$INSTALLED" "$TAG"
+case $? in
+  0) echo "${P} The installed version of ${PACKAGE} (${INSTALLED}) is current: ${TAG}" ; exit 0 ;;
+  1) echo "${P} The installed version of ${PACKAGE} (${INSTALLED}) is newer than the current release (${TAG})" ; exit 0 ;;
+  2) echo "${P} Upgrading ${PACKAGE} to ${TAG} from ${INSTALLED}." ;;
+  3) echo "${P} Installing ${PACKAGE} version ${TAG}." ;;
+esac
+
 FILE=$(basename ${URL})
 echo "${P} Downloading: ${URL}"
 echo "${P} To Location: /tmp/${FILE}"
 $CMD ${URL} > /tmp/${FILE}
 
 if [ "$(id -u)" != "0" ]; then
-  echo "${P} Downloaded. Install the package manually."
+  echo "${P} Downloaded, but no root access. Install the file manually to /usr/bin/notifiarr"
+  echo "${P} Recommend re-running this script as root instead!"
+  echo "${P} Doing so will install the upstart file, notifiarr user, and config file."
   exit 0
 fi
 

--- a/scripts/install-synology.sh
+++ b/scripts/install-synology.sh
@@ -180,8 +180,12 @@ if [ "$?" = "0" ]; then
   start notifiarr
 fi
 
-echo "${P} Installed. Edit your config file: ${CONFIGFILE}"
-echo "${P} start the service with:  start notifiarr"
-echo "${P} stop the service with:   stop notifiarr"
-echo "${P} to check service status: status notifiarr"
+if [ "${INSTALLED}" == "" ]; then
+  echo "${P} Installed. Edit your config file: ${CONFIGFILE}"
+  echo "${P} start the service with:  start notifiarr"
+  echo "${P} stop the service with:   stop notifiarr"
+  echo "${P} to check service status: status notifiarr"
+else
+  echo "${P} Upgraded and restarted."
+fi
 echo "<-------------------------------------------------->"

--- a/scripts/install-synology.sh
+++ b/scripts/install-synology.sh
@@ -180,7 +180,7 @@ if [ "$?" = "0" ]; then
   start notifiarr
 fi
 
-if [ "${INSTALLED}" == "" ]; then
+if [ "${INSTALLED}" = "" ]; then
   echo "${P} Installed. Edit your config file: ${CONFIGFILE}"
   echo "${P} start the service with:  start notifiarr"
   echo "${P} stop the service with:   stop notifiarr"


### PR DESCRIPTION
This adds code to the Synology install script so it can be run in crontab to keep notifiarr up to date. Closes #50.

Test like this (**as root**).

```
# First install an old binary.
curl -sSL https://github.com/Notifiarr/notifiarr/releases/download/v0.1.2/notifiarr.amd64.linux.gz | gunzip > /usr/bin/notifiarr
# Then test the script. Run it a couple times.
curl -sSL https://raw.githubusercontent.com/Notifiarr/notifiarr/dn2_syno_auto_update/scripts/install-synology.sh | bash
```

