### PR TITLE
Add log file for services checks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ to the app log nor to console stdout.
 
 |Config Name|Variable Name|Note|
 |---|---|---|
-services.log_file|`DN_SERVICES_LOG_FILE`|If a file path is provided, service check logs write go there|
+services.log_file|`DN_SERVICES_LOG_FILE`|If a file path is provided, service check logs write there|
 services.interval|`DN_SERVICES_INTERVAL`|`10m`, How often to check service health; minimum: `5m`|
 services.parallel|`DN_SERVICES_PARALLE`|`1`, How many services can be checked at once; 1 is plenty|
 

--- a/README.md
+++ b/README.md
@@ -246,9 +246,12 @@ snapshot.use_sudo|`DN_SNAPSHOT_USE_SUDO`|Set `true` if `monitor_drives=true` or 
 
 The Notifiarr client can also check URLs for health. If you set names on your
 Starr apps they will be automatically checked and reports sent to Notifiarr.
+If you provide a log file for service checks, those logs will no longer write
+to the app log nor to console stdout.
 
 |Config Name|Variable Name|Note|
 |---|---|---|
+services.log_file|`DN_SERVICES_LOG_FILE`|If a file path is provided, service check logs write go there|
 services.interval|`DN_SERVICES_INTERVAL`|`10m`, How often to check service health; minimum: `5m`|
 services.parallel|`DN_SERVICES_PARALLE`|`1`, How many services can be checked at once; 1 is plenty|
 

--- a/pkg/bindata/generate.go
+++ b/pkg/bindata/generate.go
@@ -3,7 +3,7 @@
 // find the _things_ we compress into base64 inside the files/ directory, and you
 // will find the base64 files in the bindata.go file. The generate.go file contains
 // the command that creates the binary data. Requires installing go-bindata binary.
-// See: https://github.com/kevinburke/go-bindata
+// See: https://github.com/kevinburke/go-bindata or the README.md file.
 package bindata
 
 //go:generate go-bindata -pkg bindata -modtime 1587356420 -o bindata.go files/

--- a/pkg/configfile/template.go
+++ b/pkg/configfile/template.go
@@ -217,6 +217,7 @@ timeout = "{{.Timeout}}"
   disabled = {{.Services.Disabled}}   # Setting this to true disables all service checking routines.
   parallel = {{.Services.Parallel}}       # How many services to check concurrently. 1 should be enough.
   interval = "{{.Services.Interval}}" # How often to send service states to Notifiarr.com. Minimum = 5m.
+  log_file = '{{.Services.LogFile}}'      # Service Check logs go to the app log by default. Change that by setting a services.log file here.
 
 ## Uncomment the following section to create a service check on a URL or IP:port.
 ## You may include as many [[service]] sections as you have services to check.

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -41,6 +41,7 @@ type Config struct {
 	Interval     cnfg.Duration     `toml:"interval" xml:"interval"`
 	Parallel     uint              `toml:"parallel" xml:"parallel"`
 	Disabled     bool              `toml:"disabled" xml:"disabled"`
+	LogFile      string            `toml:"log_file" xml:"log_file"`
 	Apps         *apps.Apps        `toml:"-"`
 	Notify       *notifiarr.Config `toml:"-"`
 	*logs.Logger `json:"-"`        // log file writer
@@ -179,6 +180,10 @@ func (c *Config) setup(services []*Service, run bool) error {
 		c.checks = make(chan *Service, DefaultBuffer)
 		c.done = make(chan bool)
 		c.stopChan = make(chan struct{})
+	}
+
+	if c.LogFile != "" {
+		c.Logger = logs.CustomLog(c.LogFile, "Services")
 	}
 
 	for i := range services {

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -1,6 +1,6 @@
-// Package services provides services checks to the notifiarr client application.
-// This package spins up go routines to check http endpoints, running process, tcp
-// ports, etc. The configuration comes directly from the config file.
+// Package services provides service-checks to the notifiarr client application.
+// This package spins up go routines to check http endpoints, running processes,
+// tcp ports, etc. The configuration comes directly from the config file.
 package services
 
 import (


### PR DESCRIPTION
This contribution adds a log file for service checks. They're spammy and this allows getting them out of the app log. Closes #75.

Debug POST logs still hit the app log, but this is better than it was.