### PR TITLE
Make sonarr quality releases palpable.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/Notifiarr/notifiarr
 
 go 1.16
 
+
 require (
 	github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 // indirect
 	github.com/gen2brain/dlgs v0.0.0-20210609125024-bf6c92aaa984
@@ -29,7 +30,7 @@ require (
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22
 	golift.io/cnfg v0.0.8-0.20201101095209-9c9085f1bf93
 	golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9
-	golift.io/starr v0.10.1
+	golift.io/starr v0.10.2-0.20210625072432-040e53eb75d0
 	golift.io/version v0.0.2
 	gopkg.in/toast.v1 v1.0.0-20180812000517-0a84660828b2
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/pkg/client/init.go
+++ b/pkg/client/init.go
@@ -151,7 +151,7 @@ func (c *Client) printPlex() {
 		name = "<possible connection error>"
 	}
 
-	c.Printf(" => Plex Config: 1 server: %s @ %s (enables incoming plex APIs and webhook)", name, p.URL)
+	c.Printf(" => Plex Config: 1 server: %s @ %s (enables incoming APIs and webhook)", name, p.URL)
 }
 
 // printLidarr is called on startup to print info about each configured server.

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -221,7 +221,7 @@ func (c *Client) start() error {
 	if c.Flags.cfsync {
 		c.Printf("==> Flag Requested: Syncing Custom Formats (then exiting)")
 		c.notify.SyncRadarrCF()
-		c.notify.SyncSonarrCF()
+		c.notify.SyncSonarrQR()
 
 		return nil
 	}

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -219,9 +219,9 @@ func (c *Client) start() error {
 	c.configureServices(!c.Flags.cfsync) // do not collect plex info if cfsync is active.
 
 	if c.Flags.cfsync {
-		c.Printf("==> Flag Requested: Syncing Custom Formats (then exiting)")
+		c.Printf("==> Flag Requested: Syncing Custom Formats and Quality Profiles (then exiting)")
 		c.notify.SyncRadarrCF()
-		c.notify.SyncSonarrQR()
+		c.notify.SyncSonarrQP()
 
 		return nil
 	}

--- a/pkg/client/tray.go
+++ b/pkg/client/tray.go
@@ -106,15 +106,17 @@ func (c *Client) makeMoreChannels() {
 	c.menu["plex_dev"] = ui.WrapMenu(data.AddSubMenuItem("Dev Plex Sessions", "send plex sessions to notifiarr dev endpoint"))
 	c.menu["snap_dev"] = ui.WrapMenu(data.AddSubMenuItem("Dev System Snapshot", "send system snapshot to notifiarr dev endpoint"))
 
-	if c.Config.Debug {
-		debug := systray.AddMenuItem("Debug", "Debug Menu")
-		c.menu["debug"] = ui.WrapMenu(debug)
-		c.menu["debug_panic"] = ui.WrapMenu(debug.AddSubMenuItem("Panic", "cause an application panic"))
-		c.menu["debug_logs"] = ui.WrapMenu(debug.AddSubMenuItem("View Log", "view the Debug log"))
+	debug := systray.AddMenuItem("Debug", "Debug Menu")
+	c.menu["debug"] = ui.WrapMenu(debug)
+	c.menu["debug_panic"] = ui.WrapMenu(debug.AddSubMenuItem("Panic", "cause an application panic"))
+	c.menu["debug_logs"] = ui.WrapMenu(debug.AddSubMenuItem("View Log", "view the Debug log"))
 
-		if c.Config.DebugLog == "" {
-			c.menu["debug_logs"].Hide()
-		}
+	if !c.Config.Debug {
+		c.menu["debug"].Hide()
+	}
+
+	if c.Config.DebugLog == "" {
+		c.menu["debug_logs"].Hide()
 	}
 
 	// These start hidden.

--- a/pkg/client/tray.go
+++ b/pkg/client/tray.go
@@ -221,7 +221,7 @@ func (c *Client) watchNotifiarrMenu() { //nolint:cyclop
 		case <-c.menu["sync_cf"].Clicked():
 			c.Printf("[user requested] Triggering Custom Formats and Quality Profiles Sync for Radarr and Sonarr.")
 			c.notify.SyncRadarrCF()
-			c.notify.SyncSonarrCF()
+			c.notify.SyncSonarrQR()
 		case <-c.menu["snap_log"].Clicked():
 			c.logSnaps()
 		case <-c.menu["svcs_log"].Clicked():

--- a/pkg/client/tray.go
+++ b/pkg/client/tray.go
@@ -223,7 +223,7 @@ func (c *Client) watchNotifiarrMenu() { //nolint:cyclop
 		case <-c.menu["sync_cf"].Clicked():
 			c.Printf("[user requested] Triggering Custom Formats and Quality Profiles Sync for Radarr and Sonarr.")
 			c.notify.SyncRadarrCF()
-			c.notify.SyncSonarrQR()
+			c.notify.SyncSonarrQP()
 		case <-c.menu["snap_log"].Clicked():
 			c.logSnaps()
 		case <-c.menu["svcs_log"].Clicked():

--- a/pkg/notifiarr/cfsync.go
+++ b/pkg/notifiarr/cfsync.go
@@ -149,10 +149,10 @@ func (c *Config) updateRadarrCFs(instance int, r *apps.RadarrConfig, data []byte
 		}
 	}
 
-	return c.postbackRadarrCFs(instance, maps)
+	return c.postbackRadarrCFupdates(instance, maps)
 }
 
-func (c *Config) postbackRadarrCFs(instance int, maps *cfMapIDpayload) error {
+func (c *Config) postbackRadarrCFupdates(instance int, maps *cfMapIDpayload) error {
 	if len(maps.QP) > 0 || len(maps.CF) > 0 {
 		//nolint:bodyclose // already closed.
 		resp, _, body, err := c.SendData(c.BaseURL+CFSyncRoute+"?app=radarr&updateIDs=true", &RadarrCustomFormatPayload{
@@ -238,14 +238,14 @@ func (c *Config) syncSonarrQR(instance int, s *apps.SonarrConfig) (bool, error) 
 
 	if len(body) < 1 {
 		return false, nil
-	} else if err := c.updateSonarrCFs(instance, s, body); err != nil {
+	} else if err := c.updateSonarrQRs(instance, s, body); err != nil {
 		return false, fmt.Errorf("updating application: %w", err)
 	}
 
 	return true, nil
 }
 
-func (c *Config) updateSonarrCFs(instance int, s *apps.SonarrConfig, data []byte) error {
+func (c *Config) updateSonarrQRs(instance int, s *apps.SonarrConfig, data []byte) error {
 	payload := struct {
 		Response string `json:"response"`
 		Message  struct {
@@ -293,10 +293,10 @@ func (c *Config) updateSonarrCFs(instance int, s *apps.SonarrConfig, data []byte
 		}
 	}
 
-	return c.postbackSonarrCFs(instance, maps)
+	return c.postbackSonarrQPupdates(instance, maps)
 }
 
-func (c *Config) postbackSonarrCFs(instance int, maps *cfMapIDpayload) error {
+func (c *Config) postbackSonarrQPupdates(instance int, maps *cfMapIDpayload) error {
 	if len(maps.QP) > 0 || len(maps.RP) > 0 {
 		//nolint:bodyclose // already closed
 		resp, _, body, err := c.SendData(c.BaseURL+CFSyncRoute+"?app=sonarr&updateIDs=true", &SonarrCustomFormatPayload{
@@ -306,10 +306,10 @@ func (c *Config) postbackSonarrCFs(instance int, maps *cfMapIDpayload) error {
 
 		if err != nil {
 			c.sonarrQRs[instance] = maps
-			return fmt.Errorf("updating release profiles ID map: %w: %s", err, string(body))
+			return fmt.Errorf("updating quality release ID map: %w: %s", err, string(body))
 		} else if resp.StatusCode != http.StatusOK {
 			c.sonarrQRs[instance] = maps
-			return fmt.Errorf("updating custom format ID map: %w: %s: %s", ErrNon200, resp.Status, string(body))
+			return fmt.Errorf("updating quality release ID map: %w: %s: %s", ErrNon200, resp.Status, string(body))
 		}
 	}
 

--- a/pkg/notifiarr/cfsync.go
+++ b/pkg/notifiarr/cfsync.go
@@ -40,6 +40,8 @@ func (c *Config) SyncRadarrCF() {
 	if ci, err := c.GetClientInfo(); err != nil || !ci.IsASub() {
 		c.Debugf("Cannot sync Radarr Custom Formats. Not a subscriber, or error: %v", err)
 		return
+	} else if ci.Message.CFSync < 1 {
+		return
 	}
 
 	for i, r := range c.Apps.Radarr {
@@ -184,6 +186,8 @@ type SonarrCustomFormatPayload struct {
 func (c *Config) SyncSonarrCF() {
 	if ci, err := c.GetClientInfo(); err != nil || !ci.IsASub() {
 		c.Debugf("Cannot sync Sonarr Release Profiles. Not a subscriber, or error: %v", err)
+		return
+	} else if ci.Message.QRSync < 1 {
 		return
 	}
 

--- a/pkg/notifiarr/cfsync.go
+++ b/pkg/notifiarr/cfsync.go
@@ -182,8 +182,8 @@ type SonarrCustomFormatPayload struct {
 	NewMaps         *cfMapIDpayload          `json:"newMaps,omitempty"`
 }
 
-// SyncSonarrCF triggers a custom format sync for Sonarr.
-func (c *Config) SyncSonarrCF() {
+// SyncSonarrQR triggers a custom format sync for Sonarr.
+func (c *Config) SyncSonarrQR() {
 	if ci, err := c.GetClientInfo(); err != nil || !ci.IsASub() {
 		c.Debugf("Cannot sync Sonarr Release Profiles. Not a subscriber, or error: %v", err)
 		return
@@ -196,7 +196,7 @@ func (c *Config) SyncSonarrCF() {
 			continue
 		}
 
-		switch synced, err := c.syncSonarrCF(i+1, s); {
+		switch synced, err := c.syncSonarrQR(i+1, s); {
 		case err != nil:
 			c.Errorf("Sonarr Release Profiles sync for '%d:%s' failed: %v", i+1, s.URL, err)
 		case synced:
@@ -207,10 +207,10 @@ func (c *Config) SyncSonarrCF() {
 	}
 }
 
-func (c *Config) syncSonarrCF(instance int, s *apps.SonarrConfig) (bool, error) {
+func (c *Config) syncSonarrQR(instance int, s *apps.SonarrConfig) (bool, error) {
 	var (
 		err     error
-		payload = SonarrCustomFormatPayload{Instance: instance, NewMaps: c.sonarrCFs[instance]}
+		payload = SonarrCustomFormatPayload{Instance: instance, NewMaps: c.sonarrQRs[instance]}
 	)
 
 	payload.QualityProfiles, err = s.Sonarr.GetQualityProfiles()
@@ -234,7 +234,7 @@ func (c *Config) syncSonarrCF(instance int, s *apps.SonarrConfig) (bool, error) 
 		c.Debugf("Response Payload: %s: %s", resp.Status, string(body))
 	}
 
-	c.sonarrCFs[instance] = nil
+	c.sonarrQRs[instance] = nil
 
 	if len(body) < 1 {
 		return false, nil
@@ -305,10 +305,10 @@ func (c *Config) postbackSonarrCFs(instance int, maps *cfMapIDpayload) error {
 		})
 
 		if err != nil {
-			c.sonarrCFs[instance] = maps
+			c.sonarrQRs[instance] = maps
 			return fmt.Errorf("updating release profiles ID map: %w: %s", err, string(body))
 		} else if resp.StatusCode != http.StatusOK {
-			c.sonarrCFs[instance] = maps
+			c.sonarrQRs[instance] = maps
 			return fmt.Errorf("updating custom format ID map: %w: %s: %s", ErrNon200, resp.Status, string(body))
 		}
 	}

--- a/pkg/notifiarr/notifiarr.go
+++ b/pkg/notifiarr/notifiarr.go
@@ -211,6 +211,7 @@ type ClientInfo struct {
 		Text       string `json:"text"`
 		Subscriber bool   `json:"subscriber"`
 		CFSync     int64  `json:"cfSync"`
+		QRSync     int64  `json:"qrSync"`
 	} `json:"message"`
 }
 

--- a/pkg/notifiarr/notifiarr.go
+++ b/pkg/notifiarr/notifiarr.go
@@ -81,7 +81,7 @@ type Config struct {
 	stopTimers   chan struct{}
 	client       *httpClient
 	radarrCFs    map[int]*cfMapIDpayload
-	sonarrCFs    map[int]*cfMapIDpayload
+	sonarrQRs    map[int]*cfMapIDpayload
 }
 
 // Start (and log) snapshot and plex cron jobs if they're configured.
@@ -107,7 +107,7 @@ func (c *Config) Start(mode string) {
 	}
 
 	c.radarrCFs = make(map[int]*cfMapIDpayload)
-	c.sonarrCFs = make(map[int]*cfMapIDpayload)
+	c.sonarrQRs = make(map[int]*cfMapIDpayload)
 
 	c.startTimers()
 }

--- a/pkg/notifiarr/notifiarr.go
+++ b/pkg/notifiarr/notifiarr.go
@@ -80,8 +80,8 @@ type Config struct {
 	*logs.Logger // log file writer
 	stopTimers   chan struct{}
 	client       *httpClient
-	radarrCFs    map[int]*cfMapIDpayload
-	sonarrQRs    map[int]*cfMapIDpayload
+	radarrCF     map[int]*cfMapIDpayload
+	sonarrQP     map[int]*cfMapIDpayload
 }
 
 // Start (and log) snapshot and plex cron jobs if they're configured.
@@ -106,8 +106,8 @@ func (c *Config) Start(mode string) {
 		c.Retries = DefaultRetries
 	}
 
-	c.radarrCFs = make(map[int]*cfMapIDpayload)
-	c.sonarrQRs = make(map[int]*cfMapIDpayload)
+	c.radarrCF = make(map[int]*cfMapIDpayload)
+	c.sonarrQP = make(map[int]*cfMapIDpayload)
 
 	c.startTimers()
 }
@@ -211,7 +211,7 @@ type ClientInfo struct {
 		Text       string `json:"text"`
 		Subscriber bool   `json:"subscriber"`
 		CFSync     int64  `json:"cfSync"`
-		QRSync     int64  `json:"qrSync"`
+		QPSync     int64  `json:"qpSync"`
 	} `json:"message"`
 }
 

--- a/pkg/notifiarr/timers.go
+++ b/pkg/notifiarr/timers.go
@@ -78,7 +78,7 @@ func (c *Config) runTimerLoop(snapTimer, syncTimer, plexTimer1, plexTimer2 *time
 		select {
 		case <-syncTimer.C:
 			c.SyncRadarrCF()
-			c.SyncSonarrCF()
+			c.SyncSonarrQR()
 		case <-snapTimer.C:
 			c.sendSnapshot()
 		case <-plexTimer1.C:

--- a/pkg/notifiarr/timers.go
+++ b/pkg/notifiarr/timers.go
@@ -21,11 +21,12 @@ func (c *Config) startTimers() {
 
 func (c *Config) getSyncTimer() *time.Ticker {
 	ci, err := c.GetClientInfo()
-	if err != nil || !ci.IsASub() || ci.Message.CFSync < 1 {
+	if err != nil || !ci.IsASub() || (ci.Message.CFSync < 1 && ci.Message.QRSync < 1) {
 		return &time.Ticker{C: make(<-chan time.Time)}
 	}
 
-	c.Printf("==> Keeping %d Radarr Custom Formats and 0 Sonarr Release Profiles synced", ci.Message.CFSync)
+	c.Printf("==> Keeping %d Radarr Custom Formats and %d Sonarr Release Profiles synced",
+		ci.Message.CFSync, ci.Message.QRSync)
 
 	return time.NewTicker(cfSyncTimer)
 }
@@ -34,7 +35,6 @@ func (c *Config) getPlexTimers() (*time.Ticker, *time.Ticker) {
 	empty := &time.Ticker{C: make(<-chan time.Time)}
 
 	if !c.Plex.Configured() || c.Plex.Interval.Duration < 1 {
-		c.Print("foo")
 		return empty, empty
 	}
 
@@ -78,7 +78,7 @@ func (c *Config) runTimerLoop(snapTimer, syncTimer, plexTimer1, plexTimer2 *time
 		select {
 		case <-syncTimer.C:
 			c.SyncRadarrCF()
-			// c.SyncSonarrCF() // later...
+			c.SyncSonarrCF()
 		case <-snapTimer.C:
 			c.sendSnapshot()
 		case <-plexTimer1.C:

--- a/pkg/notifiarr/timers.go
+++ b/pkg/notifiarr/timers.go
@@ -21,12 +21,12 @@ func (c *Config) startTimers() {
 
 func (c *Config) getSyncTimer() *time.Ticker {
 	ci, err := c.GetClientInfo()
-	if err != nil || !ci.IsASub() || (ci.Message.CFSync < 1 && ci.Message.QRSync < 1) {
+	if err != nil || !ci.IsASub() || (ci.Message.CFSync < 1 && ci.Message.QPSync < 1) {
 		return &time.Ticker{C: make(<-chan time.Time)}
 	}
 
 	c.Printf("==> Keeping %d Radarr Custom Formats and %d Sonarr Release Profiles synced",
-		ci.Message.CFSync, ci.Message.QRSync)
+		ci.Message.CFSync, ci.Message.QPSync)
 
 	return time.NewTicker(cfSyncTimer)
 }
@@ -78,7 +78,7 @@ func (c *Config) runTimerLoop(snapTimer, syncTimer, plexTimer1, plexTimer2 *time
 		select {
 		case <-syncTimer.C:
 			c.SyncRadarrCF()
-			c.SyncSonarrQR()
+			c.SyncSonarrQP()
 		case <-snapTimer.C:
 			c.sendSnapshot()
 		case <-plexTimer1.C:

--- a/pkg/plex/sessions.go
+++ b/pkg/plex/sessions.go
@@ -25,9 +25,9 @@ func (s *Server) GetXMLSessions() (*Sessions, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), s.Timeout.Duration)
 	defer cancel()
 
-	xml, err := s.getPlexURL(ctx, s.URL+"/status/sessions", map[string]string{"Accept": "application/xml"})
+	body, err := s.getPlexURL(ctx, s.URL+"/status/sessions", map[string]string{"Accept": "application/xml"})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", err, string(body))
 	}
 
 	var v struct {
@@ -37,13 +37,13 @@ func (s *Server) GetXMLSessions() (*Sessions, error) {
 	}
 
 	if s.ReturnJSON {
-		data, err := s.getPlexURL(ctx, s.URL+"/status/sessions", nil)
+		body, err := s.getPlexURL(ctx, s.URL+"/status/sessions", nil)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: %s", err, string(body))
 		}
 
 		// log.Print("DEBUG PLEX PAYLOAD:\n", string(data))
-		if err = json.Unmarshal(data, &v); err != nil {
+		if err = json.Unmarshal(body, &v); err != nil {
 			return nil, fmt.Errorf("parsing plex sessions: %w", err)
 		}
 	}
@@ -51,7 +51,7 @@ func (s *Server) GetXMLSessions() (*Sessions, error) {
 	return &Sessions{
 		Name:       s.Name,
 		AccountMap: strings.Split(s.AccountMap, "|"),
-		XML:        string(xml),
+		XML:        string(body),
 		Sessions:   v.MediaContainer.Sessions,
 	}, nil
 }
@@ -72,13 +72,13 @@ func (s *Server) GetSessionsWithContext(ctx context.Context) ([]*Session, error)
 	ctx, cancel := context.WithTimeout(ctx, s.Timeout.Duration)
 	defer cancel()
 
-	data, err := s.getPlexURL(ctx, s.URL+"/status/sessions", nil)
+	body, err := s.getPlexURL(ctx, s.URL+"/status/sessions", nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", err, string(body))
 	}
 
 	// log.Print("DEBUG PLEX PAYLOAD:\n", string(data))
-	if err = json.Unmarshal(data, &v); err != nil {
+	if err = json.Unmarshal(body, &v); err != nil {
 		return nil, fmt.Errorf("parsing plex sessions: %w", err)
 	}
 


### PR DESCRIPTION
This enables Sonarr Quality Profiles sync. Require @austinwbest to make some changes on the website, and depends on  https://github.com/TRaSH-/Guides/pull/280.

- Also fixes a crashing bug with windows + no debug.
- And bubbles up the response body from Plex when a sessions GET returns a non-200.
- Fixes the ability to unmonitor a movie. https://github.com/golift/starr/commit/9d240026989c59a6b38d1a8d21edb97c892fd755