### PR TITLE
Add stuck queue items check for all Starr apps.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/Notifiarr/notifiarr
 
 go 1.16
 
-
 require (
 	github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 // indirect
 	github.com/gen2brain/dlgs v0.0.0-20210609125024-bf6c92aaa984

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22
 	golift.io/cnfg v0.0.8-0.20201101095209-9c9085f1bf93
 	golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9
-	golift.io/starr v0.10.2
+	golift.io/starr v0.10.3
 	golift.io/version v0.0.2
 	gopkg.in/toast.v1 v1.0.0-20180812000517-0a84660828b2
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/go.sum
+++ b/go.sum
@@ -375,8 +375,8 @@ golift.io/cnfg v0.0.8-0.20201101095209-9c9085f1bf93 h1:6zgmt5vpnqltfJ7Wfj16NT+rg
 golift.io/cnfg v0.0.8-0.20201101095209-9c9085f1bf93/go.mod h1:AsB0DJe7nv0bizKaoy3e3MjjOF7upTpMOMvsfv4CNNk=
 golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9 h1:j/WeLF6Ew1lc/m8/bh5qleZ66aSeJ72B1fUWigF69OE=
 golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9/go.mod h1:EZevRvIGRh8jDMwuYL0/tlPns0KynquPZzb0SerIC1s=
-golift.io/starr v0.10.1 h1:3CDs552OLQ6b+9iLNVRwReKpTnHFKJ660wrHV6PvRlQ=
-golift.io/starr v0.10.1/go.mod h1:2ZSbBMYCBGkgA18ihFRL6R4DelptIkAJrtW8wyxU9ew=
+golift.io/starr v0.10.2-0.20210625072432-040e53eb75d0 h1:eq2BL1+PN21ZUN1Riin6ojVXmoaVke6/0QsetFD4j0U=
+golift.io/starr v0.10.2-0.20210625072432-040e53eb75d0/go.mod h1:2ZSbBMYCBGkgA18ihFRL6R4DelptIkAJrtW8wyxU9ew=
 golift.io/version v0.0.2 h1:i0gXRuSDHKs4O0sVDUg4+vNIuOxYoXhaxspftu2FRTE=
 golift.io/version v0.0.2/go.mod h1:76aHNz8/Pm7CbuxIsDi97jABL5Zui3f2uZxDm4vB6hU=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/go.sum
+++ b/go.sum
@@ -375,10 +375,8 @@ golift.io/cnfg v0.0.8-0.20201101095209-9c9085f1bf93 h1:6zgmt5vpnqltfJ7Wfj16NT+rg
 golift.io/cnfg v0.0.8-0.20201101095209-9c9085f1bf93/go.mod h1:AsB0DJe7nv0bizKaoy3e3MjjOF7upTpMOMvsfv4CNNk=
 golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9 h1:j/WeLF6Ew1lc/m8/bh5qleZ66aSeJ72B1fUWigF69OE=
 golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9/go.mod h1:EZevRvIGRh8jDMwuYL0/tlPns0KynquPZzb0SerIC1s=
-golift.io/starr v0.10.2-0.20210625072432-040e53eb75d0 h1:eq2BL1+PN21ZUN1Riin6ojVXmoaVke6/0QsetFD4j0U=
-golift.io/starr v0.10.2-0.20210625072432-040e53eb75d0/go.mod h1:2ZSbBMYCBGkgA18ihFRL6R4DelptIkAJrtW8wyxU9ew=
-golift.io/starr v0.10.2 h1:hJYD9scKrs5hUEdSJ39llbKDGPs9lvSHDK3VJ7RKq5M=
-golift.io/starr v0.10.2/go.mod h1:2ZSbBMYCBGkgA18ihFRL6R4DelptIkAJrtW8wyxU9ew=
+golift.io/starr v0.10.3 h1:uIncKFTa7SHXmRmrizNAHZ5pD+2xJc/s4E0dj9q6clg=
+golift.io/starr v0.10.3/go.mod h1:2ZSbBMYCBGkgA18ihFRL6R4DelptIkAJrtW8wyxU9ew=
 golift.io/version v0.0.2 h1:i0gXRuSDHKs4O0sVDUg4+vNIuOxYoXhaxspftu2FRTE=
 golift.io/version v0.0.2/go.mod h1:76aHNz8/Pm7CbuxIsDi97jABL5Zui3f2uZxDm4vB6hU=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/pkg/apps/lidarr.go
+++ b/pkg/apps/lidarr.go
@@ -42,8 +42,9 @@ func (a *Apps) lidarrHandlers() {
 
 // LidarrConfig represents the input data for a Lidarr server.
 type LidarrConfig struct {
-	Name     string
-	Interval cnfg.Duration
+	Name      string        `toml:"name"`
+	Interval  cnfg.Duration `toml:"interval"`
+	StuckItem bool          `toml:"stuck_items"`
 	*starr.Config
 	*lidarr.Lidarr
 }

--- a/pkg/apps/radarr.go
+++ b/pkg/apps/radarr.go
@@ -44,6 +44,7 @@ type RadarrConfig struct {
 	Name      string        `toml:"name"`
 	Interval  cnfg.Duration `toml:"interval"`
 	DisableCF bool          `toml:"disable_cf"`
+	StuckItem bool          `toml:"stuck_items"`
 	*starr.Config
 	*radarr.Radarr
 }

--- a/pkg/apps/readarr.go
+++ b/pkg/apps/readarr.go
@@ -37,8 +37,9 @@ func (a *Apps) readarrHandlers() {
 
 // ReadarrConfig represents the input data for a Readarr server.
 type ReadarrConfig struct {
-	Name     string
-	Interval cnfg.Duration
+	Name      string        `toml:"name"`
+	Interval  cnfg.Duration `toml:"interval"`
+	StuckItem bool          `toml:"stuck_items"`
 	*starr.Config
 	*readarr.Readarr
 }

--- a/pkg/apps/sonarr.go
+++ b/pkg/apps/sonarr.go
@@ -41,6 +41,7 @@ type SonarrConfig struct {
 	Name      string        `toml:"name"`
 	Interval  cnfg.Duration `toml:"interval"`
 	DisableCF bool          `toml:"disable_cf"`
+	StuckItem bool          `toml:"stuck_items"`
 	*starr.Config
 	*sonarr.Sonarr
 }

--- a/pkg/client/tray.go
+++ b/pkg/client/tray.go
@@ -105,6 +105,8 @@ func (c *Client) makeMoreChannels() {
 	c.menu["snap_test"] = ui.WrapMenu(data.AddSubMenuItem("Test System Snapshot", "send system snapshot to notifiarr test endpoint"))
 	c.menu["plex_dev"] = ui.WrapMenu(data.AddSubMenuItem("Dev Plex Sessions", "send plex sessions to notifiarr dev endpoint"))
 	c.menu["snap_dev"] = ui.WrapMenu(data.AddSubMenuItem("Dev System Snapshot", "send system snapshot to notifiarr dev endpoint"))
+	c.menu["app_ques"] = ui.WrapMenu(data.AddSubMenuItem("Stuck Items Check", "check app queues for stuck items and send to notifiarr"))
+	c.menu["app_ques_dev"] = ui.WrapMenu(data.AddSubMenuItem("Stuck Items Check (Dev)", "check app queues for stuck items and send to notifiarr dev"))
 
 	debug := systray.AddMenuItem("Debug", "Debug Menu")
 	c.menu["debug"] = ui.WrapMenu(debug)
@@ -113,6 +115,12 @@ func (c *Client) makeMoreChannels() {
 
 	if !c.Config.Debug {
 		c.menu["debug"].Hide()
+		c.menu["svcs_test"].Hide()
+		c.menu["plex_test"].Hide()
+		c.menu["snap_test"].Hide()
+		c.menu["plex_dev"].Hide()
+		c.menu["snap_dev"].Hide()
+		c.menu["app_ques_dev"].Hide()
 	}
 
 	if c.Config.DebugLog == "" {
@@ -259,6 +267,10 @@ func (c *Client) watchNotifiarrMenu() { //nolint:cyclop
 			c.sendPlexSessions(notifiarr.DevURL)
 		case <-c.menu["snap_dev"].Clicked():
 			c.sendSystemSnapshot(notifiarr.DevURL)
+		case <-c.menu["app_ques"].Clicked():
+			c.notify.SendFinishedQueueItems(notifiarr.BaseURL)
+		case <-c.menu["app_ques_dev"].Clicked():
+			c.notify.SendFinishedQueueItems(notifiarr.DevBaseURL)
 		case <-c.menu["plex_prod"].Clicked():
 			c.sendPlexSessions(notifiarr.ProdURL)
 		case <-c.menu["snap_prod"].Clicked():

--- a/pkg/configfile/template.go
+++ b/pkg/configfile/template.go
@@ -109,11 +109,13 @@ timeout = "{{.Timeout}}"
   {{if .DisableCF}}disable_cf = true
   {{end -}}
   interval = "{{.Interval}}" # service check duration (if name is not empty)
-  timeout  = "{{.Timeout}}"{{end -}}
+	timeout  = "{{.Timeout}}"
+	stuck_items = {{.StuckItem}}{{end -}}
 {{else}}#[[radarr]]
 #name    = "" # set a name to enable checks of your service.
 #url     = "http://127.0.0.1:7878/radarr"
-#api_key = ""{{end}}
+#api_key = ""
+#stuck_items = false{{end}}
 
 {{if .Readarr}}{{range .Readarr}}
 [[readarr]]
@@ -121,11 +123,13 @@ timeout = "{{.Timeout}}"
   url      = "{{.URL}}"
   api_key  = "{{.APIKey}}"
   interval = "{{.Interval}}" # service check duration (if name is not empty)
-  timeout  = "{{.Timeout}}"{{end -}}
+  timeout  = "{{.Timeout}}"
+	stuck_items = {{.StuckItem}}{{end -}}
 {{else}}#[[readarr]]
 #name    = "" # set a name to enable checks of your service.
 #url     = "http://127.0.0.1:8787/readarr"
-#api_key = ""{{end}}
+#api_key = ""
+#stuck_items = false{{end}}
 
 {{if .Sonarr}}{{range .Sonarr}}
 [[sonarr]]
@@ -135,11 +139,13 @@ timeout = "{{.Timeout}}"
   {{if .DisableCF}}disable_cf = true
   {{end -}}
   interval = "{{.Interval}}" # service check duration (if name is not empty)
-  timeout  = "{{.Timeout}}"{{end -}}
+  timeout  = "{{.Timeout}}"
+	stuck_items = {{.StuckItem}}{{end -}}
 {{else}}#[[sonarr]]
 #name    = "" # set a name to enable checks of your service.
 #url     = "http://sonarr:8989/"
-#api_key = ""{{end}}
+#api_key = ""
+#stuck_items = false{{end}}
 
 {{if .Lidarr}}{{range .Lidarr}}
 [[lidarr]]
@@ -147,11 +153,13 @@ timeout = "{{.Timeout}}"
   url      = "{{.URL}}"
   api_key  = "{{.APIKey}}"
   interval = "{{.Interval}}" # service check duration (if name is not empty)
-  timeout  = "{{.Timeout}}"{{end -}}
+  timeout  = "{{.Timeout}}"
+	stuck_items = {{.StuckItem}}{{end -}}
 {{else}}#[[lidarr]]
 #name    = "" # set a name to enable checks of your service.
 #url     = "http://lidarr:8989/"
-#api_key = ""{{end}}
+#api_key = ""
+#stuck_items = false{{end}}
 
 
 #################

--- a/pkg/notifiarr/stuckitems.go
+++ b/pkg/notifiarr/stuckitems.go
@@ -1,0 +1,162 @@
+package notifiarr
+
+import (
+	"strings"
+)
+
+/* This file contains the procedures to send stuck download queue items to notifiarr. */
+
+type ItemList map[int][]interface{}
+
+type QueuePayload struct {
+	Type    string   `json:"type"`
+	Lidarr  ItemList `json:"lidarr,omitempty"`
+	Radarr  ItemList `json:"radarr,omitempty"`
+	Readarr ItemList `json:"readarr,omitempty"`
+	Sonarr  ItemList `json:"sonarr,omitempty"`
+}
+
+const getItemsMax = 100
+
+func (i ItemList) Len() (count int) {
+	for _, v := range i {
+		count += len(v)
+	}
+
+	return count
+}
+
+func (i ItemList) Empty() bool {
+	return i.Len() < 1
+}
+
+func (c *Config) SendFinishedQueueItems(url string) {
+	q := &QueuePayload{
+		Type:    "queue",
+		Lidarr:  c.getFinishedItemsLidarr(),
+		Radarr:  c.getFinishedItemsRadarr(),
+		Readarr: c.getFinishedItemsReadarr(),
+		Sonarr:  c.getFinishedItemsSonarr(),
+	}
+
+	if q.Lidarr.Empty() && q.Radarr.Empty() && q.Readarr.Empty() && q.Sonarr.Empty() {
+		return
+	}
+
+	_, _, body, err := c.SendData(url+"/api/v1/user/client", q)
+	if err != nil {
+		c.Errorf("Sending Stuck Queue Items: %v: %v", err, string(body))
+		return
+	}
+
+	c.Printf("Sent Stuck Items: Lidarr: %d, Radarr: %d, Readarr: %d, Sonarr: %d",
+		q.Lidarr.Len(), q.Radarr.Len(), q.Readarr.Len(), q.Sonarr.Len())
+}
+
+func (c *Config) getFinishedItemsLidarr() ItemList {
+	stuck := make(ItemList)
+
+	for i, l := range c.Apps.Lidarr {
+		if !l.StuckItem {
+			continue
+		}
+
+		queue, err := l.GetQueue(getItemsMax)
+		if err != nil {
+			c.Errorf("Getting Lidarr Queue (%d): %v", i, err)
+			continue
+		}
+
+		for _, item := range queue.Records {
+			if strings.EqualFold(item.Status, "completed") || len(item.StatusMessages) > 0 {
+				stuck[i+1] = append(stuck[i+1], item)
+			}
+		}
+
+		c.Debugf("Checking Lidarr (%d) Queue for Stuck Items, queue size: %d, stuck: %d",
+			i+1, len(queue.Records), len(stuck[i+1]))
+	}
+
+	return stuck
+}
+
+func (c *Config) getFinishedItemsRadarr() ItemList {
+	stuck := make(ItemList)
+
+	for i, l := range c.Apps.Radarr {
+		if !l.StuckItem {
+			continue
+		}
+
+		queue, err := l.GetQueue(getItemsMax, 1)
+		if err != nil {
+			c.Errorf("Getting Radarr Queue (%d): %v", i, err)
+			continue
+		}
+
+		for _, item := range queue.Records {
+			if strings.EqualFold(item.Status, "completed") || len(item.StatusMessages) > 0 {
+				stuck[i+1] = append(stuck[i+1], item)
+			}
+		}
+
+		c.Debugf("Checking Radarr (%d) Queue for Stuck Items, queue size: %d, stuck: %d",
+			i+1, len(queue.Records), len(stuck[i+1]))
+	}
+
+	return stuck
+}
+
+func (c *Config) getFinishedItemsReadarr() ItemList {
+	stuck := make(ItemList)
+
+	for i, l := range c.Apps.Readarr {
+		if !l.StuckItem {
+			continue
+		}
+
+		queue, err := l.GetQueue(getItemsMax)
+		if err != nil {
+			c.Errorf("Getting Readarr Queue (%d): %v", i, err)
+			continue
+		}
+
+		for j, item := range queue.Records {
+			if strings.EqualFold(item.Status, "completed") || len(item.StatusMessages) > 0 {
+				stuck[i+1] = append(stuck[i+1], &queue.Records[j])
+			}
+		}
+
+		c.Debugf("Checking Readarr (%d) Queue for Stuck Items, queue size: %d, stuck: %d",
+			i+1, len(queue.Records), len(stuck[i+1]))
+	}
+
+	return stuck
+}
+
+func (c *Config) getFinishedItemsSonarr() ItemList {
+	stuck := make(ItemList)
+
+	for i, l := range c.Apps.Sonarr {
+		if !l.StuckItem {
+			continue
+		}
+
+		queue, err := l.GetQueue(getItemsMax, 1)
+		if err != nil {
+			c.Errorf("Getting Sonarr Queue (%d): %v", i, err)
+			continue
+		}
+
+		for _, item := range queue.Records {
+			if strings.EqualFold(item.Status, "completed") || len(item.StatusMessages) > 0 {
+				stuck[i+1] = append(stuck[i+1], item)
+			}
+		}
+
+		c.Debugf("Checking Sonarr (%d) Queue for Stuck Items, queue size: %d, stuck: %d",
+			i+1, len(queue.Records), len(stuck[i+1]))
+	}
+
+	return stuck
+}


### PR DESCRIPTION
Closes #86. Adds a five minute ticker to check the queue on every app. Looks for completed items, or items with an error message. Sends them all in one POST to notifiarr.com. The content is the entire queue item record. I can trim it down, but this was quick and easy. Adds a couple new menu items, and a config item for each app to enable the new notification feature. I also disabled the dev and test endpoints when debug is false (menu cleanup/shrinkage).
 TODO: readme update

```
[DEBUG] 2021/06/25 03:34:22 Checking Lidarr (1) Queue for Stuck Items, queue size: 1, stuck: 1
[DEBUG] 2021/06/25 03:34:22 Checking Radarr (1) Queue for Stuck Items, queue size: 3, stuck: 3
[DEBUG] 2021/06/25 03:34:22 Checking Readarr (1) Queue for Stuck Items, queue size: 0, stuck: 0
[DEBUG] 2021/06/25 03:34:22 Checking Sonarr (1) Queue for Stuck Items, queue size: 100, stuck: 0
[DEBUG] 2021/06/25 03:34:22 Sending JSON Payload to http://dev.notifiarr.com/api/v1/user/client:
 "type": "queue",
 "lidarr": {
  "1": [
   {
    "artistId": 285,
    "albumId": 2312,
  <snip> ...
[INFO] 2021/06/25 03:34:23 Sent Stuck Items: Lidarr: 1, Radarr: 3, Readarr: 0, Sonarr: 0
```