### PR TITLE
New Stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 # Powered by Application Builder: https://github.com/golift/application-builder
 jobs:
   include:
-  - os: osx
+  - if: tag IS present
+    os: osx
     osx_image: xcode12
     language: go
     go: 1.16.x

--- a/examples/MANUAL.md
+++ b/examples/MANUAL.md
@@ -14,7 +14,7 @@ system snapshot and Plex session data to Notifiarr for Discord notifications.
 OPTIONS
 ---
 
-`notifiarr [-c <file>] [-m <mode>] [--snaps] [--ps] [--cfsync] [--curl <url>] [-h] [-v]`
+`notifiarr [-c <file>] [--snaps] [--ps] [--cfsync] [--curl <url>] [-h] [-v]`
 
     -c, --config <config file>
         Provide a configuration file (instead of the default).
@@ -23,10 +23,6 @@ OPTIONS
     -p, --prefix
         The default environment variable configuration prefix is `DN`.
         Use this tunable to change it.
-
-    -m, --mode <prod|test|dev>
-        There are three modes.
-        This setting selects which notifiarr server receives payloads.
 
     --snaps
         This flag makes the application output a system snapshot and exit.

--- a/examples/MANUAL.md
+++ b/examples/MANUAL.md
@@ -14,7 +14,7 @@ system snapshot and Plex session data to Notifiarr for Discord notifications.
 OPTIONS
 ---
 
-`notifiarr [-c <file>] [--snaps] [--ps] [--cfsync] [--curl <url>] [-h] [-v]`
+`notifiarr [-c <file>] [--write <file>] [--snaps] [--ps] [--cfsync] [--curl <url>] [-h] [-v]`
 
     -c, --config <config file>
         Provide a configuration file (instead of the default).
@@ -35,6 +35,10 @@ OPTIONS
     --cfsync
         This flag makes the application send a Custom Format request to
         Notifiarr.com. Then it exits.
+
+    --write <file>
+        This flag allows you to read in a config file and re-write it to another file.
+        Use - as a shortcut argument to over write the file provided by --config.
 
     --curl <url>
         This flags allows you to make the application GET a URL and print

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,8 +3,10 @@ To make a new default template, run this:
 ```
 # Build the binary.
 make
+
 # Re-write Template
 ./notifiarr -c examples/notifiarr.conf.example --write example
+
 # Check it out
 git diff examples
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,10 @@
+To make a new default template, run this:
+
+```
+# Build the binary.
+make
+# Re-write Template
+./notifiarr -c examples/notifiarr.conf.example --write example
+# Check it out
+git diff examples
+```

--- a/examples/notifiarr.conf.example
+++ b/examples/notifiarr.conf.example
@@ -1,6 +1,6 @@
 ###############################################
 # Notifiarr Client Example Configuration File #
-# Created by Notifiarr v0.1.7   @ 212606T0237 #
+# Created by Notifiarr v0.1.10  @ 210307T0521 #
 ###############################################
 
 # This API key must be copied from your notifiarr.com account.
@@ -70,24 +70,30 @@ timeout = "1m0s"
 ##
 ## Examples follow. UNCOMMENT (REMOVE #), AT MINIMUM: [[header]], url, api_key
 #[[lidarr]]
-#name    = "" # set a name to enable checks of your service.
-#url     = "http://lidarr:8989/"
-#api_key = ""
+#name        = "" # Set a name to enable checks of your service.
+#url         = "http://lidarr:8989/"
+#api_key     = ""
+#check_q     = 0 # Check for items stuck in queue. 0 = no repeat, 1 to repeat every hour, 2 for every 2 hours, etc.
 
 #[[radarr]]
-#name    = "" # set a name to enable checks of your service.
-#url     = "http://127.0.0.1:7878/radarr"
-#api_key = ""
+#name        = "" # Set a name to enable checks of your service.
+#url         = "http://127.0.0.1:7878/radarr"
+#api_key     = ""
+#disable_cf  = true  # Disable custom format sync.
+#check_q     = 0 # Check for items stuck in queue. 0 = no repeat, 1 to repeat every hour, 2 for every 2 hours, etc.
 
 #[[readarr]]
-#name    = "" # set a name to enable checks of your service.
-#url     = "http://127.0.0.1:8787/readarr"
-#api_key = ""
+#name        = "" # Set a name to enable checks of your service.
+#url         = "http://127.0.0.1:8787/readarr"
+#api_key     = ""
+#check_q     = 0 # Check for items stuck in queue. 0 = no repeat, 1 to repeat every hour, 2 for every 2 hours, etc.
 
 #[[sonarr]]
-#name    = "" # set a name to enable checks of your service.
-#url     = "http://sonarr:8989/"
-#api_key = ""
+#name        = ""  # Set a name to enable checks of your service.
+#url         = "http://sonarr:8989/"
+#api_key     = ""
+#disable_cf  = true # Disable release profile sync.
+#check_q     = 0    # Check for items stuck in queue. 0 = no repeat, 1 to repeat every hour, 2 for every 2 hours, etc.
 
 
 #################
@@ -98,10 +104,10 @@ timeout = "1m0s"
 ##
 [plex]
   url         = "http://localhost:32400" # Your plex URL
-  token       = ""     # your plex token; get this from a web inspector
-  interval    = "30m0s"  # how often to send session data, 0 = off
-  cooldown    = "15s"  # how often plex webhooks may trigger session hooks
-  account_map = ""     # map an email to a name, ex: "som@ema.il,Name|some@ther.mail,name"
+  token       = ""            # your plex token; get this from a web inspector
+  interval    = "30m0s"       # how often to send session data, 0 = off
+  cooldown    = "15s"         # how often plex webhooks may trigger session hooks
+  account_map = ""            # shared plex servers: map an email to a name, ex: "som@ema.il,Name|some@ther.mail,name"
   movies_percent_complete = 0 # 0, 70-99, send notifications when a movie session is this % complete.
   series_percent_complete = 0 # 0, 70-99, send notifications when an episode session is this % complete.
 
@@ -113,12 +119,13 @@ timeout = "1m0s"
 ## Install package(s)
 ##  - Windows:  smartmontools - https://sourceforge.net/projects/smartmontools/
 ##  - Linux:    apt install smartmontools || yum install smartmontools
+##  - Docker:   Already Included. Run in --privileged mode.
 ##  - Synology: opkg install smartmontools
 ##  - Entware:  https://github.com/Entware/Entware-ng/wiki/Install-on-Synology-NAS
 ##  - Entware Package List:  https://github.com/Entware/Entware-ng/wiki/Install-on-Synology-NAS
 ##
 [snapshot]
-  interval          = "30m0s"  # how often to send a snapshot, 0 = off, 30m - 2h recommended
+  interval          = "30m0s" # how often to send a snapshot, 0 = off, 30m - 2h recommended
   timeout           = "30s" # how long a snapshot may take
   monitor_raid      = false # mdadm / megacli
   monitor_drives    = false # smartctl: age, temp, health

--- a/examples/notifiarr.conf.example
+++ b/examples/notifiarr.conf.example
@@ -1,6 +1,6 @@
 ###############################################
 # Notifiarr Client Example Configuration File #
-# Created by Notifiarr v0.1.10  @ 210307T0521 #
+# Created by Notifiarr v0.1.10  @ 210307T0534 #
 ###############################################
 
 # This API key must be copied from your notifiarr.com account.

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22
 	golift.io/cnfg v0.0.8-0.20201101095209-9c9085f1bf93
 	golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9
-	golift.io/starr v0.10.3
+	golift.io/starr v0.10.4-0.20210703014015-e3a11890a8a9
 	golift.io/version v0.0.2
 	gopkg.in/toast.v1 v1.0.0-20180812000517-0a84660828b2
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/go.sum
+++ b/go.sum
@@ -377,6 +377,8 @@ golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9 h1:j/WeLF6Ew1lc/m8/bh5qleZ
 golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9/go.mod h1:EZevRvIGRh8jDMwuYL0/tlPns0KynquPZzb0SerIC1s=
 golift.io/starr v0.10.3 h1:uIncKFTa7SHXmRmrizNAHZ5pD+2xJc/s4E0dj9q6clg=
 golift.io/starr v0.10.3/go.mod h1:2ZSbBMYCBGkgA18ihFRL6R4DelptIkAJrtW8wyxU9ew=
+golift.io/starr v0.10.4-0.20210703014015-e3a11890a8a9 h1:98dD/2cIiseFSkJUioibGCCacNlTSedVWte4IMJlPB4=
+golift.io/starr v0.10.4-0.20210703014015-e3a11890a8a9/go.mod h1:2ZSbBMYCBGkgA18ihFRL6R4DelptIkAJrtW8wyxU9ew=
 golift.io/version v0.0.2 h1:i0gXRuSDHKs4O0sVDUg4+vNIuOxYoXhaxspftu2FRTE=
 golift.io/version v0.0.2/go.mod h1:76aHNz8/Pm7CbuxIsDi97jABL5Zui3f2uZxDm4vB6hU=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/pkg/apps/lidarr.go
+++ b/pkg/apps/lidarr.go
@@ -46,6 +46,7 @@ type LidarrConfig struct {
 	Name      string        `toml:"name"`
 	Interval  cnfg.Duration `toml:"interval"`
 	StuckItem bool          `toml:"stuck_items"`
+	CheckQ    *uint         `toml:"check_q"`
 	*starr.Config
 	*lidarr.Lidarr
 }
@@ -54,6 +55,12 @@ func (r *LidarrConfig) setup(timeout time.Duration) {
 	r.Lidarr = lidarr.New(r.Config)
 	if r.Timeout.Duration == 0 {
 		r.Timeout.Duration = timeout
+	}
+
+	// These things are not used in this package but this package configures them.
+	if r.StuckItem && r.CheckQ == nil {
+		i := uint(0)
+		r.CheckQ = &i
 	}
 }
 

--- a/pkg/apps/radarr.go
+++ b/pkg/apps/radarr.go
@@ -46,6 +46,7 @@ type RadarrConfig struct {
 	Interval  cnfg.Duration `toml:"interval"`
 	DisableCF bool          `toml:"disable_cf"`
 	StuckItem bool          `toml:"stuck_items"`
+	CheckQ    *uint         `toml:"check_q"`
 	*starr.Config
 	*radarr.Radarr
 }
@@ -54,6 +55,14 @@ func (r *RadarrConfig) setup(timeout time.Duration) {
 	r.Radarr = radarr.New(r.Config)
 	if r.Timeout.Duration == 0 {
 		r.Timeout.Duration = timeout
+	}
+
+	// These things are not used in this package but this package configures them.
+	if r.StuckItem && r.CheckQ == nil {
+		i := uint(0)
+		r.CheckQ = &i
+	} else if r.CheckQ != nil {
+		r.StuckItem = true
 	}
 }
 

--- a/pkg/apps/readarr.go
+++ b/pkg/apps/readarr.go
@@ -41,6 +41,7 @@ type ReadarrConfig struct {
 	Name      string        `toml:"name"`
 	Interval  cnfg.Duration `toml:"interval"`
 	StuckItem bool          `toml:"stuck_items"`
+	CheckQ    *uint         `toml:"check_q"`
 	*starr.Config
 	*readarr.Readarr
 }
@@ -49,6 +50,14 @@ func (r *ReadarrConfig) setup(timeout time.Duration) {
 	r.Readarr = readarr.New(r.Config)
 	if r.Timeout.Duration == 0 {
 		r.Timeout.Duration = timeout
+	}
+
+	// These things are not used in this package but this package configures them.
+	if r.StuckItem && r.CheckQ == nil {
+		i := uint(0)
+		r.CheckQ = &i
+	} else if r.CheckQ != nil {
+		r.StuckItem = true
 	}
 }
 

--- a/pkg/apps/sonarr.go
+++ b/pkg/apps/sonarr.go
@@ -45,6 +45,7 @@ type SonarrConfig struct {
 	Interval  cnfg.Duration `toml:"interval"`
 	DisableCF bool          `toml:"disable_cf"`
 	StuckItem bool          `toml:"stuck_items"`
+	CheckQ    *uint         `toml:"check_q"`
 	*starr.Config
 	*sonarr.Sonarr
 }
@@ -53,6 +54,14 @@ func (r *SonarrConfig) setup(timeout time.Duration) {
 	r.Sonarr = sonarr.New(r.Config)
 	if r.Timeout.Duration == 0 {
 		r.Timeout.Duration = timeout
+	}
+
+	// These things are not used in this package but this package configures them.
+	if r.StuckItem && r.CheckQ == nil {
+		i := uint(0)
+		r.CheckQ = &i
+	} else if r.CheckQ != nil {
+		r.StuckItem = true
 	}
 }
 

--- a/pkg/client/init.go
+++ b/pkg/client/init.go
@@ -10,11 +10,14 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/Notifiarr/notifiarr/pkg/ui"
 )
+
+const disabled = "disabled"
 
 // PrintStartupInfo prints info about our startup config.
 // This runs once on startup, and again during reloads.
@@ -155,60 +158,116 @@ func (c *Client) printPlex() {
 
 // printLidarr is called on startup to print info about each configured server.
 func (c *Client) printLidarr() {
-	if count := len(c.Config.Lidarr); count == 1 {
-		c.Printf(" => Lidarr Config: 1 server: %s, apikey:%v, timeout:%v, verify ssl:%v",
-			c.Config.Lidarr[0].URL, c.Config.Lidarr[0].APIKey != "", c.Config.Lidarr[0].Timeout, c.Config.Lidarr[0].ValidSSL)
-	} else {
-		c.Print(" => Lidarr Config:", count, "servers")
+	if len(c.Config.Lidarr) == 1 {
+		f := c.Config.Lidarr[0]
 
-		for _, f := range c.Config.Lidarr {
-			c.Printf(" =>    Server: %s, apikey:%v, timeout:%v, verify ssl:%v",
-				f.URL, f.APIKey != "", f.Timeout, f.ValidSSL)
+		checkQ := disabled
+		if f.CheckQ != nil {
+			checkQ = strconv.Itoa(int(*f.CheckQ))
 		}
+
+		c.Printf(" => Lidarr Config: 1 server: %s, apikey:%v, timeout:%v, verify ssl:%v, check_q: %s",
+			f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, checkQ)
+
+		return
+	}
+
+	c.Print(" => Lidarr Config:", len(c.Config.Lidarr), "servers")
+
+	for _, f := range c.Config.Lidarr {
+		checkQ := disabled
+		if f.CheckQ != nil {
+			checkQ = strconv.Itoa(int(*f.CheckQ))
+		}
+
+		c.Printf(" =>    Server: %s, apikey:%v, timeout:%v, verify ssl:%v, check_q: %s",
+			f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, checkQ)
 	}
 }
 
 // printRadarr is called on startup to print info about each configured server.
 func (c *Client) printRadarr() {
-	if count := len(c.Config.Radarr); count == 1 {
-		c.Printf(" => Radarr Config: 1 server: %s, apikey:%v, timeout:%v, verify ssl:%v",
-			c.Config.Radarr[0].URL, c.Config.Radarr[0].APIKey != "", c.Config.Radarr[0].Timeout, c.Config.Radarr[0].ValidSSL)
-	} else {
-		c.Print(" => Radarr Config:", count, "servers")
+	if len(c.Config.Radarr) == 1 {
+		f := c.Config.Radarr[0]
 
-		for _, f := range c.Config.Radarr {
-			c.Printf(" =>    Server: %s, apikey:%v, timeout:%v, verify ssl:%v",
-				f.URL, f.APIKey != "", f.Timeout, f.ValidSSL)
+		checkQ := disabled
+		if f.CheckQ != nil {
+			checkQ = strconv.Itoa(int(*f.CheckQ))
 		}
+
+		c.Printf(" => Radarr Config: 1 server: %s, apikey:%v, timeout:%v, verify ssl:%v, check_q: %s",
+			f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, checkQ)
+
+		return
+	}
+
+	c.Print(" => Radarr Config:", len(c.Config.Lidarr), "servers")
+
+	for _, f := range c.Config.Radarr {
+		checkQ := disabled
+		if f.CheckQ != nil {
+			checkQ = strconv.Itoa(int(*f.CheckQ))
+		}
+
+		c.Printf(" =>    Server: %s, apikey:%v, timeout:%v, verify ssl:%v, check_q: %s",
+			f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, checkQ)
 	}
 }
 
 // printReadarr is called on startup to print info about each configured server.
 func (c *Client) printReadarr() {
-	if count := len(c.Config.Readarr); count == 1 {
-		c.Printf(" => Readarr Config: 1 server: %s, apikey:%v, timeout:%v, verify ssl:%v",
-			c.Config.Readarr[0].URL, c.Config.Readarr[0].APIKey != "", c.Config.Readarr[0].Timeout, c.Config.Readarr[0].ValidSSL)
-	} else {
-		c.Print(" => Readarr Config:", count, "servers")
+	if len(c.Config.Readarr) == 1 {
+		f := c.Config.Readarr[0]
 
-		for _, f := range c.Config.Readarr {
-			c.Printf(" =>    Server: %s, apikey:%v, timeout:%v, verify ssl:%v",
-				f.URL, f.APIKey != "", f.Timeout, f.ValidSSL)
+		checkQ := disabled
+		if f.CheckQ != nil {
+			checkQ = strconv.Itoa(int(*f.CheckQ))
 		}
+
+		c.Printf(" => Readarr Config: 1 server: %s, apikey:%v, timeout:%v, verify ssl:%v, check_q: %s",
+			f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, checkQ)
+
+		return
+	}
+
+	c.Print(" => Readarr Config:", len(c.Config.Lidarr), "servers")
+
+	for _, f := range c.Config.Readarr {
+		checkQ := disabled
+		if f.CheckQ != nil {
+			checkQ = strconv.Itoa(int(*f.CheckQ))
+		}
+
+		c.Printf(" =>    Server: %s, apikey:%v, timeout:%v, verify ssl:%v, check_q: %s",
+			f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, checkQ)
 	}
 }
 
 // printSonarr is called on startup to print info about each configured server.
 func (c *Client) printSonarr() {
-	if count := len(c.Config.Sonarr); count == 1 {
-		c.Printf(" => Sonarr Config: 1 server: %s, apikey:%v, timeout:%v, verify ssl:%v",
-			c.Config.Sonarr[0].URL, c.Config.Sonarr[0].APIKey != "", c.Config.Sonarr[0].Timeout, c.Config.Sonarr[0].ValidSSL)
-	} else {
-		c.Print(" => Sonarr Config:", count, "servers")
+	if len(c.Config.Sonarr) == 1 {
+		f := c.Config.Sonarr[0]
 
-		for _, f := range c.Config.Sonarr {
-			c.Printf(" =>    Server: %s, apikey:%v, timeout:%v, verify ssl:%v",
-				f.URL, f.APIKey != "", f.Timeout, f.ValidSSL)
+		checkQ := disabled
+		if f.CheckQ != nil {
+			checkQ = strconv.Itoa(int(*f.CheckQ))
 		}
+
+		c.Printf(" => Sonarr Config: 1 server: %s, apikey:%v, timeout:%v, verify ssl:%v, check_q: %s",
+			f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, checkQ)
+
+		return
+	}
+
+	c.Print(" => Sonarr Config:", len(c.Config.Lidarr), "servers")
+
+	for _, f := range c.Config.Sonarr {
+		checkQ := disabled
+		if f.CheckQ != nil {
+			checkQ = strconv.Itoa(int(*f.CheckQ))
+		}
+
+		c.Printf(" =>    Server: %s, apikey:%v, timeout:%v, verify ssl:%v, check_q: %s",
+			f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, checkQ)
 	}
 }

--- a/pkg/client/plexsnaps.go
+++ b/pkg/client/plexsnaps.go
@@ -101,3 +101,32 @@ func (c *Client) logSnaps() {
 	}, "", "  ")
 	c.Printf("[user requested] Snapshot Data:\n%s", string(b))
 }
+
+// sendSystemSnapshot is triggered from a menu-bar item.
+func (c *Client) sendSystemSnapshot(url string) string {
+	c.Printf("[user requested] Sending System Snapshot to %s", url)
+
+	snaps, errs, debug := c.Config.Snapshot.GetSnapshot()
+	for _, err := range errs {
+		if err != nil {
+			c.Errorf("[user requested] %v", err)
+		}
+	}
+
+	for _, err := range debug {
+		if err != nil {
+			c.Errorf("[user requested] %v", err)
+		}
+	}
+
+	b, _ := json.MarshalIndent(&notifiarr.Payload{Type: notifiarr.SnapCron, Snap: snaps}, "", "  ")
+	if _, body, err := c.notify.SendJSON(url, b); err != nil { //nolint:bodyclose // body already closed
+		c.Errorf("[user requested] Sending System Snapshot to %s: %v: %s", url, err, string(body))
+	} else if fields := strings.Split(string(body), `"`); len(fields) > 3 { //nolint:gomnd
+		c.Printf("[user requested] Sent System Snapshot to %s, reply: %s", url, fields[3])
+	} else {
+		c.Printf("[user requested] Sent System Snapshot to %s, reply: %s", url, string(body))
+	}
+
+	return string(b)
+}

--- a/pkg/client/plexsnaps.go
+++ b/pkg/client/plexsnaps.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/Notifiarr/notifiarr/pkg/notifiarr"
 	"github.com/Notifiarr/notifiarr/pkg/plex"
 )
@@ -14,7 +15,7 @@ import (
 func (c *Client) plexIncoming(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 
-	if err := r.ParseMultipartForm(1000 * 100); err != nil { // nolint:gomnd // 100kbyte memory usage
+	if err := r.ParseMultipartForm(mnd.KB100); err != nil {
 		c.Errorf("Parsing Multipart Form (plex): %v", err)
 		c.Config.Respond(w, http.StatusBadRequest, "form parse error")
 
@@ -102,7 +103,7 @@ func (c *Client) logSnaps() {
 	c.Printf("[user requested] Snapshot Data:\n%s", string(b))
 }
 
-// sendSystemSnapshot is triggered from a menu-bar item.
+// sendSystemSnapshot is triggered from a menu-bar item, and from --send cli arg.
 func (c *Client) sendSystemSnapshot(url string) string {
 	c.Printf("[user requested] Sending System Snapshot to %s", url)
 

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -62,7 +62,7 @@ type Client struct {
 
 // Errors returned by this package.
 var (
-	ErrNilAPIKey = fmt.Errorf("API key may not be empty: set a key in config file or with environment variable")
+	ErrNilAPIKey = fmt.Errorf("API key may not be empty: set a key in config file, OR with environment variable")
 )
 
 // NewDefaults returns a new Client pointer with default settings.
@@ -189,7 +189,7 @@ func (c *Client) config() error {
 func (c *Client) forceWriteWithExit(f, msg string) error {
 	if f == "-" {
 		f = c.Flags.ConfigFile
-	} else if f == "example" || f == "--" {
+	} else if f == "example" || f == "---" {
 		// Bubilding a default template.
 		f = c.Flags.ConfigFile
 		c.Config.LogFile = ""

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -41,7 +41,6 @@ type Flags struct {
 	curl       string
 	ConfigFile string
 	EnvPrefix  string
-	Mode       string
 }
 
 // Client stores all the running data.
@@ -103,7 +102,6 @@ func NewDefaults() *Client {
 func (f *Flags) ParseArgs(args []string) {
 	f.StringVarP(&f.ConfigFile, "config", "c", os.Getenv(mnd.DefaultEnvPrefix+"_CONFIG_FILE"), f.Name()+" Config File")
 	f.BoolVar(&f.testSnaps, "snaps", false, f.Name()+"Test Snapshots")
-	f.StringVarP(&f.Mode, "mode", "m", "prod", "Selects Notifiarr URL: test, dev, prod")
 	f.StringVarP(&f.EnvPrefix, "prefix", "p", mnd.DefaultEnvPrefix, "Environment Variable Prefix")
 	f.BoolVarP(&f.verReq, "version", "v", false, "Print the version and exit.")
 	f.BoolVar(&f.cfsync, "cfsync", false, "Trigger Custom Format sync and exit.")
@@ -275,7 +273,7 @@ func (c *Client) configureServices(getPlexInfo bool) {
 
 	c.Config.Snapshot.Validate()
 	c.PrintStartupInfo()
-	c.notify.Start(c.Flags.Mode)
+	c.notify.Start(c.Config.Mode)
 
 	c.Config.Services.Logger = c.Logger
 	c.Config.Services.Apps = c.Config.Apps

--- a/pkg/client/tray_commands.go
+++ b/pkg/client/tray_commands.go
@@ -200,19 +200,21 @@ func (c *Client) sendSystemSnapshot(url string) {
 }
 
 func (c *Client) writeConfigFile() {
-	if c.Flags.ConfigFile == "" {
+	val, _, _ := ui.Entry(mnd.Title, "Enter path to write config file:", c.Flags.ConfigFile)
+
+	if val == "" {
 		_, _ = ui.Error(mnd.Title+" Error", "No Config File Provided")
 		return
 	}
 
-	c.Print("[user requested] Writing Config File:", c.Flags.ConfigFile)
+	c.Print("[user requested] Writing Config File:", val)
 
-	if _, err := c.Config.Write(c.Flags.ConfigFile); err != nil {
+	if _, err := c.Config.Write(val); err != nil {
 		c.Errorf("Writing Config File: %v", err)
 		_, _ = ui.Error(mnd.Title+" Error", "Writing Config File: "+err.Error())
 
 		return
 	}
 
-	_, _ = ui.Info(mnd.Title, "Wrote Config File: "+c.Flags.ConfigFile)
+	_, _ = ui.Info(mnd.Title, "Wrote Config File: "+val)
 }

--- a/pkg/client/tray_commands.go
+++ b/pkg/client/tray_commands.go
@@ -3,7 +3,6 @@
 package client
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"path"
@@ -169,33 +168,6 @@ func (c *Client) sendPlexSessions(url string) {
 		c.Printf("[user requested] Sent Plex Sessions to %s, reply: %s", url, fields[3])
 	} else {
 		c.Printf("[user requested] Sent Plex Sessions to %s, reply: %s", url, string(body))
-	}
-}
-
-// sendSystemSnapshot is triggered from a menu-bar item.
-func (c *Client) sendSystemSnapshot(url string) {
-	c.Printf("[user requested] Sending System Snapshot to %s", url)
-
-	snaps, errs, debug := c.Config.Snapshot.GetSnapshot()
-	for _, err := range errs {
-		if err != nil {
-			c.Errorf("[user requested] %v", err)
-		}
-	}
-
-	for _, err := range debug {
-		if err != nil {
-			c.Errorf("[user requested] %v", err)
-		}
-	}
-
-	b, _ := json.MarshalIndent(&notifiarr.Payload{Type: notifiarr.SnapCron, Snap: snaps}, "", "  ")
-	if _, body, err := c.notify.SendJSON(url, b); err != nil {
-		c.Errorf("[user requested] Sending System Snapshot to %s: %v: %s", url, err, string(body))
-	} else if fields := strings.Split(string(body), `"`); len(fields) > 3 { //nolint:gomnd
-		c.Printf("[user requested] Sent System Snapshot to %s, reply: %s", url, fields[3])
-	} else {
-		c.Printf("[user requested] Sent System Snapshot to %s, reply: %s", url, string(body))
 	}
 }
 

--- a/pkg/client/webserver.go
+++ b/pkg/client/webserver.go
@@ -18,7 +18,7 @@ var ErrNoServer = fmt.Errorf("the web server is not running, cannot stop it")
 // StartWebServer starts the web server.
 func (c *Client) StartWebServer() {
 	// Create an apache-style logger.
-	l, _ := apachelog.New(`%{X-Forwarded-For}i %l %u %t "%{X-Redacted-URI}i" %>s %b "%{Referer}i" ` +
+	l, _ := apachelog.New(`%{X-Forwarded-For}i %l %u %t "%m %{X-Redacted-URI}i %H" %>s %b "%{Referer}i" ` +
 		`"%{User-agent}i" %{X-Request-Time}i %{ms}Tms`)
 	// Create a request router.
 	c.Config.Apps.Router = mux.NewRouter()

--- a/pkg/configfile/config.go
+++ b/pkg/configfile/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	SSLCrtFile string              `json:"ssl_cert_file" toml:"ssl_cert_file" xml:"ssl_cert_file" yaml:"ssl_cert_file"`
 	SSLKeyFile string              `json:"ssl_key_file" toml:"ssl_key_file" xml:"ssl_key_file" yaml:"ssl_key_file"`
 	AutoUpdate string              `json:"auto_update" toml:"auto_update" xml:"auto_update" yaml:"auto_update"`
+	Mode       string              `json:"mode" toml:"mode" xml:"mode" yaml:"mode"`
 	Upstreams  []string            `json:"upstreams" toml:"upstreams" xml:"upstreams" yaml:"upstreams"`
 	Timeout    cnfg.Duration       `json:"timeout" toml:"timeout" xml:"timeout" yaml:"timeout"`
 	Plex       *plex.Server        `json:"plex" toml:"plex" xml:"plex" yaml:"plex"`

--- a/pkg/configfile/template.go
+++ b/pkg/configfile/template.go
@@ -9,6 +9,9 @@ import (
 	"golift.io/version"
 )
 
+// ForceAllTmpl allows you to force some specific settings. Used to build a default template.
+var ForceAllTmpl = false // nolint:gochecknoglobals
+
 // Template is the config file template.
 //nolint: gochecknoglobals
 var Template = template.Must(template.New("config").Funcs(Funcs()).Parse(tmpl))
@@ -16,7 +19,8 @@ var Template = template.Must(template.New("config").Funcs(Funcs()).Parse(tmpl))
 // Funcs returns our template functions.
 func Funcs() template.FuncMap {
 	return map[string]interface{}{
-		"os": func() string { return runtime.GOOS },
+		"os":    func() string { return runtime.GOOS },
+		"force": func() bool { return ForceAllTmpl },
 		"version": func() string {
 			return fmt.Sprintf("v%-7s @ %s", version.Version, time.Now().UTC().Format("060201T1504"))
 		},
@@ -38,12 +42,12 @@ const tmpl = `###############################################
 ## This will be used in Media Requests for example to send payloads, Example: http://your-domain.com:5454
 ##
 bind_addr = "{{.BindAddr}}"
-{{if eq os "windows"}}
+{{if or (eq os "windows") (force)}}
 ## This application can update itself on Windows systems.
 ## Set this to "daily" to check GitHub every day for updates.
 ## You may also set it to a Go duration like "12h" or "72h".
 ## THIS ONLY WORKS ON WINDOWS
-{{if .AutoUpdate}}auto_update = "{{.AutoUpdate}}"{{else}}auto_update="off"{{end}}
+{{if .AutoUpdate}}auto_update = "{{.AutoUpdate}}"{{else}}auto_update = "off"{{end}}
 {{end}}
 ## Quiet makes the app not log anything to output.
 ## Recommend setting log files if you make the app quiet.
@@ -51,6 +55,8 @@ bind_addr = "{{.BindAddr}}"
 ## Log files are automatically written on those platforms.
 ##
 quiet = {{.Quiet}}{{if .Debug}}
+
+## Debug prints more data and json payloads. Recommend setting debug_log if enabled.
 debug = true{{end}}{{if .Mode}}
 
 ## Mode may be "prod" or "dev" or "test". Default, invalid, or unknown uses "prod".
@@ -106,63 +112,67 @@ timeout = "{{.Timeout}}"
 ## Examples follow. UNCOMMENT (REMOVE #), AT MINIMUM: [[header]], url, api_key
 {{if .Lidarr}}{{range .Lidarr}}
 [[lidarr]]
-  name     = "{{.Name}}"
-  url      = "{{.URL}}"
-  api_key  = "{{.APIKey}}"
-  interval = "{{.Interval}}" # service check duration (if name is not empty)
-  timeout  = "{{.Timeout}}"
-	stuck_items = {{.StuckItem}}{{end -}}
+  name        = "{{.Name}}"
+  url         = "{{.URL}}"
+  api_key     = "{{.APIKey}}"
+  interval    = "{{.Interval}}" # Service check duration (if name is not empty).
+  timeout     = "{{.Timeout}}"{{if .CheckQ}}
+  check_q = {{.CheckQ}} # 0 = no repeat, 1 = every hour, 2 = every 2 hours, etc.{{else}}
+  #check_q = 0 # Check for items stuck in queue. 0 = no repeat, 1 to repeat every hour, 2 for every 2 hours, etc.{{end}}{{end -}}
 {{else}}#[[lidarr]]
-#name    = "" # set a name to enable checks of your service.
-#url     = "http://lidarr:8989/"
-#api_key = ""
-#stuck_items = false{{end}}
+#name        = "" # Set a name to enable checks of your service.
+#url         = "http://lidarr:8989/"
+#api_key     = ""
+#check_q     = 0 # Check for items stuck in queue. 0 = no repeat, 1 to repeat every hour, 2 for every 2 hours, etc.{{end}}
 
 {{if .Radarr}}{{range .Radarr}}
 [[radarr]]
-  name     = "{{.Name}}"
-  url      = "{{.URL}}"
-  api_key  = "{{.APIKey}}"
-  {{if .DisableCF}}disable_cf = true
-  {{end -}}
-  interval = "{{.Interval}}" # service check duration (if name is not empty)
-	timeout  = "{{.Timeout}}"
-	stuck_items = {{.StuckItem}}{{end -}}
+  name        = "{{.Name}}"
+  url         = "{{.URL}}"
+  api_key     = "{{.APIKey}}"
+  disable_cf  = {{.DisableCF}} # Disable custom format sync.
+  interval    = "{{.Interval}}" # Service check duration (if name is not empty).
+  timeout     = "{{.Timeout}}"{{if .CheckQ}}
+  check_q = {{.CheckQ}} # 0 = no repeat, 1 = every hour, 2 = every 2 hours, etc.{{else}}
+  #check_q = 0 # Check for items stuck in queue. 0 = no repeat, 1 to repeat every hour, 2 for every 2 hours, etc.{{end}}{{end -}}
 {{else}}#[[radarr]]
-#name    = "" # set a name to enable checks of your service.
-#url     = "http://127.0.0.1:7878/radarr"
-#api_key = ""
-#stuck_items = false{{end}}
+#name        = "" # Set a name to enable checks of your service.
+#url         = "http://127.0.0.1:7878/radarr"
+#api_key     = ""
+#disable_cf  = true  # Disable custom format sync.
+#check_q     = 0 # Check for items stuck in queue. 0 = no repeat, 1 to repeat every hour, 2 for every 2 hours, etc.{{end}}
 
 {{if .Readarr}}{{range .Readarr}}
 [[readarr]]
-  name     = "{{.Name}}"
-  url      = "{{.URL}}"
-  api_key  = "{{.APIKey}}"
-  interval = "{{.Interval}}" # service check duration (if name is not empty)
-  timeout  = "{{.Timeout}}"
-	stuck_items = {{.StuckItem}}{{end -}}
+  name        = "{{.Name}}"
+  url         = "{{.URL}}"
+  api_key     = "{{.APIKey}}"
+  interval    = "{{.Interval}}" # Service check duration (if name is not empty).
+  timeout     = "{{.Timeout}}"{{if .CheckQ}}
+  check_q = {{.CheckQ}} # 0 = no repeat, 1 = every hour, 2 = every 2 hours, etc.{{else}}
+  #check_q = 0 # Check for items stuck in queue. 0 = no repeat, 1 to repeat every hour, 2 for every 2 hours, etc.{{end}}{{end -}}
 {{else}}#[[readarr]]
-#name    = "" # set a name to enable checks of your service.
-#url     = "http://127.0.0.1:8787/readarr"
-#api_key = ""
-#stuck_items = false{{end}}
+#name        = "" # Set a name to enable checks of your service.
+#url         = "http://127.0.0.1:8787/readarr"
+#api_key     = ""
+#check_q     = 0 # Check for items stuck in queue. 0 = no repeat, 1 to repeat every hour, 2 for every 2 hours, etc.{{end}}
 
 {{if .Sonarr}}{{range .Sonarr}}
 [[sonarr]]
-  name     = "{{.Name}}"
-  url      = "{{.URL}}"
-  api_key  = "{{.APIKey}}"
-  {{if .DisableCF}}disable_cf = true
-  {{end -}}
-  interval = "{{.Interval}}" # service check duration (if name is not empty)
-  timeout  = "{{.Timeout}}"
-	stuck_items = {{.StuckItem}}{{end -}}
+  name        = "{{.Name}}"
+  url         = "{{.URL}}"
+  api_key     = "{{.APIKey}}"
+  disable_cf  = {{.DisableCF}}  # Disable release profile sync.
+  interval    = "{{.Interval}}" # Service check duration (if name is not empty).
+  timeout     = "{{.Timeout}}"{{if .CheckQ}}
+  check_q = {{.CheckQ}} # 0 = no repeat, 1 = every hour, 2 = every 2 hours, etc.{{else}}
+  #check_q = 0 # Check for items stuck in queue. 0 = no repeat, 1 to repeat every hour, 2 for every 2 hours, etc.{{end}}{{end -}}
 {{else}}#[[sonarr]]
-#name    = "" # set a name to enable checks of your service.
-#url     = "http://sonarr:8989/"
-#api_key = ""
-#stuck_items = false{{end}}
+#name        = ""  # Set a name to enable checks of your service.
+#url         = "http://sonarr:8989/"
+#api_key     = ""
+#disable_cf  = true # Disable release profile sync.
+#check_q     = 0    # Check for items stuck in queue. 0 = no repeat, 1 to repeat every hour, 2 for every 2 hours, etc.{{end}}
 
 
 #################
@@ -171,20 +181,20 @@ timeout = "{{.Timeout}}"
 
 ## Find your token: https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/
 ##
-[plex]{{if .Plex}}
-  url         = "{{.Plex.URL}}" # Your plex URL
-  token       = "{{.Plex.Token}}"     # your plex token; get this from a web inspector
+[plex]{{if and .Plex (not force)}}
+  url         = "{{.Plex.URL}}"  # Your plex URL
+  token       = "{{.Plex.Token}}"  # your plex token; get this from a web inspector
   interval    = "{{.Plex.Interval}}"  # how often to send session data, 0 = off
   cooldown    = "{{.Plex.Cooldown}}"  # how often plex webhooks may trigger session hooks
-  account_map = "{{.Plex.AccountMap}}"     # map an email to a name, ex: "som@ema.il,Name|some@ther.mail,name"
-  movies_percent_complete = {{.Plex.MoviesPC}} # 0, 70-99, send notifications when a movie session is this % complete.
-  series_percent_complete = {{.Plex.SeriesPC}} # 0, 70-99, send notifications when an episode session is this % complete.
+  account_map = "{{.Plex.AccountMap}}"  # map an email to a name, ex: "som@ema.il,Name|some@ther.mail,name"
+  movies_percent_complete = {{.Plex.MoviesPC}}  # 0, 70-99, send notifications when a movie session is this % complete.
+  series_percent_complete = {{.Plex.SeriesPC}}  # 0, 70-99, send notifications when an episode session is this % complete.
 {{- else}}
   url         = "http://localhost:32400" # Your plex URL
-  token       = ""     # your plex token; get this from a web inspector
-  interval    = "30m"  # how often to send session data, 0 = off
-  cooldown    = "15s"  # how often plex webhooks may trigger session hooks
-  account_map = ""     # shared plex servers: map an email to a name, ex: "som@ema.il,Name|some@ther.mail,name"
+  token       = ""            # your plex token; get this from a web inspector
+  interval    = "30m0s"       # how often to send session data, 0 = off
+  cooldown    = "15s"         # how often plex webhooks may trigger session hooks
+  account_map = ""            # shared plex servers: map an email to a name, ex: "som@ema.il,Name|some@ther.mail,name"
   movies_percent_complete = 0 # 0, 70-99, send notifications when a movie session is this % complete.
   series_percent_complete = 0 # 0, 70-99, send notifications when an episode session is this % complete.
 {{- end }}
@@ -197,12 +207,13 @@ timeout = "{{.Timeout}}"
 ## Install package(s)
 ##  - Windows:  smartmontools - https://sourceforge.net/projects/smartmontools/
 ##  - Linux:    apt install smartmontools || yum install smartmontools
+##  - Docker:   Already Included. Run in --privileged mode.
 ##  - Synology: opkg install smartmontools
 ##  - Entware:  https://github.com/Entware/Entware-ng/wiki/Install-on-Synology-NAS
 ##  - Entware Package List:  https://github.com/Entware/Entware-ng/wiki/Install-on-Synology-NAS
 ##
 [snapshot]
-  interval          = "{{.Snapshot.Interval}}"  # how often to send a snapshot, 0 = off, 30m - 2h recommended
+  interval          = "{{.Snapshot.Interval}}" # how often to send a snapshot, 0 = off, 30m - 2h recommended
   timeout           = "{{.Snapshot.Timeout}}" # how long a snapshot may take
   monitor_raid      = {{.Snapshot.Raid}} # mdadm / megacli
   monitor_drives    = {{.Snapshot.DriveData}} # smartctl: age, temp, health

--- a/pkg/configfile/template.go
+++ b/pkg/configfile/template.go
@@ -51,7 +51,10 @@ bind_addr = "{{.BindAddr}}"
 ## Log files are automatically written on those platforms.
 ##
 quiet = {{.Quiet}}{{if .Debug}}
-debug = true{{end}}
+debug = true{{end}}{{if .Mode}}
+
+## Mode may be "prod" or "dev" or "test". Default, invalid, or unknown uses "prod".
+mode  = "{{.Mode}}"{{end}}
 
 ## All API paths start with /api. This does not affect incoming /plex webhooks.
 ## Change it to /somethingelse/api by setting urlbase to "/somethingelse"

--- a/pkg/mnd/constants.go
+++ b/pkg/mnd/constants.go
@@ -10,6 +10,7 @@ const (
 	Mode0600 = 0600
 	Megabyte = 1024 * 1024
 	OneDay   = 24 * time.Hour
+	HalfHour = 30 * time.Minute
 	Base10   = 10
 	Base8    = 8
 	Bits64   = 64

--- a/pkg/mnd/constants.go
+++ b/pkg/mnd/constants.go
@@ -9,6 +9,7 @@ const (
 	Mode0750 = 0750
 	Mode0600 = 0600
 	Megabyte = 1024 * 1024
+	KB100    = 1024 * 100
 	OneDay   = 24 * time.Hour
 	HalfHour = 30 * time.Minute
 	Base10   = 10

--- a/pkg/notifiarr/notifiarr.go
+++ b/pkg/notifiarr/notifiarr.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -97,7 +98,7 @@ type ClientInfo struct {
 
 // Start (and log) snapshot and plex cron jobs if they're configured.
 func (c *Config) Start(mode string) {
-	switch mode {
+	switch strings.ToLower(mode) {
 	default:
 		fallthrough
 	case "prod", "production":
@@ -106,7 +107,7 @@ func (c *Config) Start(mode string) {
 	case "test", "testing":
 		c.URL = TestURL
 		c.BaseURL = BaseURL
-	case "dev", "development":
+	case "dev", "devel", "development":
 		c.URL = DevURL
 		c.BaseURL = DevBaseURL
 	}

--- a/pkg/notifiarr/stuckitems.go
+++ b/pkg/notifiarr/stuckitems.go
@@ -2,6 +2,8 @@ package notifiarr
 
 import (
 	"strings"
+
+	"golift.io/starr/sonarr"
 )
 
 /* This file contains the procedures to send stuck download queue items to notifiarr. */
@@ -153,10 +155,18 @@ func (c *Config) getFinishedItemsSonarr() ItemList {
 			continue
 		}
 
+		// repeatStomper is used to collapse duplicate download IDs.
+		repeatStomper := make(map[string]*sonarr.QueueRecord)
+
 		for _, item := range queue.Records {
 			if strings.EqualFold(item.Status, "completed") || len(item.StatusMessages) > 0 {
+				if repeatStomper[item.DownloadID] != nil {
+					continue
+				}
+
 				item.Quality = nil
 				item.Language = nil
+				repeatStomper[item.DownloadID] = item
 				stuck[i+1] = append(stuck[i+1], item)
 			}
 		}

--- a/pkg/notifiarr/stuckitems.go
+++ b/pkg/notifiarr/stuckitems.go
@@ -15,7 +15,12 @@ const (
 	completed = "completed"
 )
 
-type ItemList map[int][]interface{}
+type custom struct {
+	Repeat uint          `json:"repeat"`
+	Queue  []interface{} `json:"queue"`
+}
+
+type ItemList map[int]custom
 
 type QueuePayload struct {
 	Type    string   `json:"type"`
@@ -29,7 +34,7 @@ const getItemsMax = 100
 
 func (i ItemList) Len() (count int) {
 	for _, v := range i {
-		count += len(v)
+		count += len(v.Queue)
 	}
 
 	return count
@@ -66,7 +71,7 @@ func (c *Config) getFinishedItemsLidarr() ItemList {
 	stuck := make(ItemList)
 
 	for i, l := range c.Apps.Lidarr {
-		if !l.StuckItem {
+		if l.CheckQ == nil {
 			continue
 		}
 
@@ -83,11 +88,14 @@ func (c *Config) getFinishedItemsLidarr() ItemList {
 			}
 
 			item.Quality = nil
-			stuck[i+1] = append(stuck[i+1], item)
+			instance := stuck[i+1]
+			instance.Repeat = *l.CheckQ
+			instance.Queue = append(instance.Queue, item)
+			stuck[i+1] = instance
 		}
 
 		c.Debugf("Checking Lidarr (%d) Queue for Stuck Items, queue size: %d, stuck: %d",
-			i+1, len(queue.Records), len(stuck[i+1]))
+			i+1, len(queue.Records), len(stuck[i+1].Queue))
 	}
 
 	return stuck
@@ -97,7 +105,7 @@ func (c *Config) getFinishedItemsRadarr() ItemList {
 	stuck := make(ItemList)
 
 	for i, l := range c.Apps.Radarr {
-		if !l.StuckItem {
+		if l.CheckQ == nil {
 			continue
 		}
 
@@ -116,11 +124,14 @@ func (c *Config) getFinishedItemsRadarr() ItemList {
 			item.Quality = nil
 			item.CustomFormats = nil
 			item.Languages = nil
-			stuck[i+1] = append(stuck[i+1], item)
+			instance := stuck[i+1]
+			instance.Repeat = *l.CheckQ
+			instance.Queue = append(instance.Queue, item)
+			stuck[i+1] = instance
 		}
 
 		c.Debugf("Checking Radarr (%d) Queue for Stuck Items, queue size: %d, stuck: %d",
-			i+1, len(queue.Records), len(stuck[i+1]))
+			i+1, len(queue.Records), len(stuck[i+1].Queue))
 	}
 
 	return stuck
@@ -130,7 +141,7 @@ func (c *Config) getFinishedItemsReadarr() ItemList {
 	stuck := make(ItemList)
 
 	for i, l := range c.Apps.Readarr {
-		if !l.StuckItem {
+		if l.CheckQ == nil {
 			continue
 		}
 
@@ -147,11 +158,14 @@ func (c *Config) getFinishedItemsReadarr() ItemList {
 			}
 
 			item.Quality = nil
-			stuck[i+1] = append(stuck[i+1], item)
+			instance := stuck[i+1]
+			instance.Repeat = *l.CheckQ
+			instance.Queue = append(instance.Queue, item)
+			stuck[i+1] = instance
 		}
 
 		c.Debugf("Checking Readarr (%d) Queue for Stuck Items, queue size: %d, stuck: %d",
-			i+1, len(queue.Records), len(stuck[i+1]))
+			i+1, len(queue.Records), len(stuck[i+1].Queue))
 	}
 
 	return stuck
@@ -161,7 +175,7 @@ func (c *Config) getFinishedItemsSonarr() ItemList {
 	stuck := make(ItemList)
 
 	for i, l := range c.Apps.Sonarr {
-		if !l.StuckItem {
+		if l.CheckQ == nil {
 			continue
 		}
 
@@ -185,11 +199,14 @@ func (c *Config) getFinishedItemsSonarr() ItemList {
 			item.Quality = nil
 			item.Language = nil
 			repeatStomper[item.DownloadID] = item
-			stuck[i+1] = append(stuck[i+1], item)
+			instance := stuck[i+1]
+			instance.Repeat = *l.CheckQ
+			instance.Queue = append(instance.Queue, item)
+			stuck[i+1] = instance
 		}
 
 		c.Debugf("Checking Sonarr (%d) Queue for Stuck Items, queue size: %d, stuck: %d",
-			i+1, len(queue.Records), len(stuck[i+1]))
+			i+1, len(queue.Records), len(stuck[i+1].Queue))
 	}
 
 	return stuck


### PR DESCRIPTION
- Add missing method to HTTP log entries.
- Combine stuck Sonarr queue items. Closes #82.
- Change stuck items catcher logic to catch a few more things.
- Deprecate `stuck_items` in favor of `check_q` in config file.
  - This new item allows you to pick how often to repeat a notification for an app instance.
  - Omit  `check_q` from config file  to disable Queue checker.
  - `stuck_items=true` sets `check_q` to `0` if it's not set.
- Add `--send` CLI arg to compliment `--snaps`.
- Add `--write <file>` CLI arg to write a new, or rewrite config file.
- Allow choosing file location when writing config file from menu item.