### PR TITLE
Update template.go and fix some bugs.

### DIFF
--- a/examples/notifiarr.conf.example
+++ b/examples/notifiarr.conf.example
@@ -1,15 +1,14 @@
 ###############################################
 # Notifiarr Client Example Configuration File #
-# Created by Notifiarr v0.1.10  @ 210307T0534 #
+# Created by Notifiarr v0.1.11  @ 211207T0621 #
 ###############################################
 
 # This API key must be copied from your notifiarr.com account.
 api_key = "api-key-from-notifiarr.com"
 
-## The ip:port or port to listen on for incoming web requests.
-## You can use 127.0.0.1:5454 to listen only on localhost.
-## This will be used in Plex for example to send webhooks, Example: http://localhost:5454
-## This will be used in Media Requests for example to send payloads, Example: http://your-domain.com:5454
+## The ip:port to listen on for incoming HTTP requests. 0.0.0.0 means all/any IP and is recommended!
+## You may use "127.0.0.1:5454" to listen only on localhost; good if using a local proxy.
+## This is used to receive Plex webhooks and Media Request commands.
 ##
 bind_addr = "0.0.0.0:5454"
 

--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -80,7 +80,7 @@ func (a *Apps) HandleAPIpath(app App, uri string, api APIHandler, method ...stri
 		id = ""
 	}
 
-	uri = path.Join("/", a.URLBase, "api", string(app), id, uri)
+	uri = path.Join(a.URLBase, "api", string(app), id, uri)
 
 	return a.Router.Handle(uri, a.CheckAPIKey(a.handleAPI(app, api))).Methods(method...)
 }

--- a/pkg/client/handlers.go
+++ b/pkg/client/handlers.go
@@ -155,6 +155,10 @@ func (c *Client) versionResponse(r *http.Request) (int, interface{}) {
 
 	if c.Config.Plex.Configured() {
 		stat, err := c.Config.Plex.GetInfo()
+		if stat == nil {
+			stat = &plex.PMSInfo{}
+		}
+
 		status.Plex = []*conTest{{
 			Instance: 1,
 			Up:       err == nil,

--- a/pkg/client/handlers.go
+++ b/pkg/client/handlers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"path"
 	"runtime"
 	"strings"
 	"time"
@@ -32,11 +33,26 @@ func (c *Client) internalHandlers() {
 		tokens := fmt.Sprintf("{token:%s|%s}", c.Config.Plex.Token, c.Config.Apps.APIKey)
 		c.Config.Router.Handle("/plex",
 			http.HandlerFunc(c.plexIncoming)).Methods("POST").Queries("token", tokens)
+
+		if c.Config.URLBase != "/" {
+			// Allow plex to use the base url too.
+			// If this causes a panic, they probably set urlbase to "//" or something.
+			c.Config.Router.Handle(path.Join(c.Config.URLBase, "plex"),
+				http.HandlerFunc(c.plexIncoming)).Methods("POST").Queries("token", tokens)
+		}
 	}
 
 	// Initialize internal-only paths.
-	c.Config.Router.Handle("/favicon.ico", http.HandlerFunc(c.favIcon))   // built-in icon.
-	c.Config.Router.Handle("/", http.HandlerFunc(c.slash))                // "hi" page on /
+	c.Config.Router.Handle("/favicon.ico", http.HandlerFunc(c.favIcon)) // built-in icon.
+	c.Config.Router.Handle("/", http.HandlerFunc(c.slash))              // "hi" page on /
+
+	if base := c.Config.URLBase; !strings.EqualFold(base, "/") {
+		// Handle the same URLs on the different base URL too.
+		c.Config.Router.Handle(path.Join(base, "favicon.ico"), http.HandlerFunc(c.favIcon))
+		c.Config.Router.Handle(base, http.HandlerFunc(c.slash))     // "hi" page on /urlbase
+		c.Config.Router.Handle(base+"/", http.HandlerFunc(c.slash)) // "hi" page on /urlbase/
+	}
+
 	c.Config.Router.PathPrefix("/").Handler(http.HandlerFunc(c.notFound)) // 404 everything
 }
 

--- a/pkg/client/tray.go
+++ b/pkg/client/tray.go
@@ -111,21 +111,23 @@ func (c *Client) makeMoreChannels() {
 
 	debug := systray.AddMenuItem("Debug", "Debug Menu")
 	c.menu["debug"] = ui.WrapMenu(debug)
-	c.menu["debug_panic"] = ui.WrapMenu(debug.AddSubMenuItem("Panic", "cause an application panic"))
 	c.menu["debug_logs"] = ui.WrapMenu(debug.AddSubMenuItem("View Log", "view the Debug log"))
+	// debug.AddSeparator() // not exist: https://github.com/getlantern/systray/issues/170
+	ui.WrapMenu(debug.AddSubMenuItem("__________", "")).Disable() // fake separator.
+	c.menu["debug_panic"] = ui.WrapMenu(debug.AddSubMenuItem("Panic", "cause an application panic"))
+
+	if c.Config.DebugLog == "" {
+		c.menu["debug_logs"].Hide()
+	}
 
 	if !c.Config.Debug {
-		c.menu["debug"].Hide()
 		c.menu["svcs_test"].Hide()
 		c.menu["plex_test"].Hide()
 		c.menu["snap_test"].Hide()
 		c.menu["plex_dev"].Hide()
 		c.menu["snap_dev"].Hide()
 		c.menu["app_ques_dev"].Hide()
-	}
-
-	if c.Config.DebugLog == "" {
-		c.menu["debug_logs"].Hide()
+		c.menu["debug"].Hide()
 	}
 
 	// These start hidden.
@@ -154,8 +156,7 @@ func (c *Client) watchKillerChannels() {
 			// turn on and off debug?
 			// u.menu["debug"].Check()
 		case <-c.menu["debug_panic"].Clicked():
-			c.Printf("User Requested Application Panic, good bye.")
-			panic("user requested panic")
+			c.menuPanic()
 		case <-c.menu["debug_logs"].Clicked():
 			c.Print("User Viewing Debug File:", c.Config.DebugLog)
 			_ = ui.OpenLog(c.Config.DebugLog)

--- a/pkg/client/tray_commands.go
+++ b/pkg/client/tray_commands.go
@@ -190,3 +190,13 @@ func (c *Client) writeConfigFile() {
 
 	_, _ = ui.Info(mnd.Title, "Wrote Config File: "+val)
 }
+
+func (c *Client) menuPanic() {
+	yes, err := ui.Question(mnd.Title, "You really want to panic?", true)
+	if !yes || err != nil {
+		return
+	}
+
+	defer c.Printf("User Requested Application Panic, good bye.")
+	panic("user requested panic")
+}

--- a/pkg/client/tray_commands.go
+++ b/pkg/client/tray_commands.go
@@ -5,7 +5,6 @@ package client
 import (
 	"errors"
 	"fmt"
-	"path"
 	"runtime"
 	"strings"
 	"time"
@@ -100,11 +99,11 @@ func (c *Client) displayConfig() (s string) { //nolint: funlen,cyclop
 	s += fmt.Sprintf("\nUpstreams: %v", c.Config.Allow)
 
 	if c.Config.SSLCrtFile != "" && c.Config.SSLKeyFile != "" {
-		s += fmt.Sprintf("\nHTTPS: https://%s%s", c.Config.BindAddr, path.Join("/", c.Config.URLBase))
+		s += fmt.Sprintf("\nHTTPS: https://%s%s", c.Config.BindAddr, c.Config.URLBase)
 		s += fmt.Sprintf("\nCert File: %v", c.Config.SSLCrtFile)
 		s += fmt.Sprintf("\nCert Key: %v", c.Config.SSLKeyFile)
 	} else {
-		s += fmt.Sprintf("\nHTTP: http://%s%s", c.Config.BindAddr, path.Join("/", c.Config.URLBase))
+		s += fmt.Sprintf("\nHTTP: http://%s%s", c.Config.BindAddr, c.Config.URLBase)
 	}
 
 	if c.Config.LogFiles > 0 {

--- a/pkg/client/webserver.go
+++ b/pkg/client/webserver.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -23,10 +24,12 @@ func (c *Client) StartWebServer() {
 	// Create a request router.
 	c.Config.Apps.Router = mux.NewRouter()
 	c.Config.Apps.ErrorLog = c.Logger.ErrorLog
+	// Cleanup user input.
+	bindAddr := strings.TrimPrefix(strings.TrimPrefix(strings.TrimRight(c.Config.BindAddr, "/"), "http://"), "https://")
 	// Create a server.
 	c.server = &http.Server{ // nolint: exhaustivestruct
 		Handler:           c.stripSecrets(l.Wrap(c.fixForwardedFor(c.Config.Apps.Router), c.Logger.HTTPLog.Writer())),
-		Addr:              c.Config.BindAddr,
+		Addr:              bindAddr,
 		IdleTimeout:       time.Minute,
 		WriteTimeout:      c.Config.Timeout.Duration,
 		ReadTimeout:       c.Config.Timeout.Duration,

--- a/pkg/configfile/config.go
+++ b/pkg/configfile/config.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -86,6 +87,8 @@ func (c *Config) setup() {
 	} else if !strings.Contains(c.BindAddr, ":") {
 		c.BindAddr = "0.0.0.0:" + c.BindAddr
 	}
+
+	c.URLBase = path.Join("/", c.URLBase)
 
 	for _, ip := range c.Upstreams {
 		if !strings.Contains(ip, "/") {

--- a/pkg/configfile/template.go
+++ b/pkg/configfile/template.go
@@ -36,10 +36,9 @@ const tmpl = `###############################################
 # This API key must be copied from your notifiarr.com account.
 {{if .APIKey}}api_key = "{{.APIKey}}"{{else}}api_key = "api-key-from-notifiarr.com"{{end}}
 
-## The ip:port or port to listen on for incoming web requests.
-## You can use 127.0.0.1:5454 to listen only on localhost.
-## This will be used in Plex for example to send webhooks, Example: http://localhost:5454
-## This will be used in Media Requests for example to send payloads, Example: http://your-domain.com:5454
+## The port to listen on for incoming web requests.
+## You can use "127.0.0.1:5454" to listen only on localhost.
+## This is used to Plex receive webhooks, and to receive Media Request commands.
 ##
 bind_addr = "{{.BindAddr}}"
 {{if or (eq os "windows") (force)}}

--- a/pkg/configfile/template.go
+++ b/pkg/configfile/template.go
@@ -36,9 +36,9 @@ const tmpl = `###############################################
 # This API key must be copied from your notifiarr.com account.
 {{if .APIKey}}api_key = "{{.APIKey}}"{{else}}api_key = "api-key-from-notifiarr.com"{{end}}
 
-## The port to listen on for incoming web requests.
-## You can use "127.0.0.1:5454" to listen only on localhost.
-## This is used to Plex receive webhooks, and to receive Media Request commands.
+## The ip:port to listen on for incoming HTTP requests. 0.0.0.0 means all/any IP and is recommended!
+## You may use "127.0.0.1:5454" to listen only on localhost; good if using a local proxy.
+## This is used to receive Plex webhooks and Media Request commands.
 ##
 bind_addr = "{{.BindAddr}}"
 {{if or (eq os "windows") (force)}}

--- a/pkg/logs/logs_linux.go
+++ b/pkg/logs/logs_linux.go
@@ -7,7 +7,9 @@ import (
 	"syscall"
 )
 
+var stderr = os.Stderr.Fd() // nolint:gochecknoglobals
+
 func redirectStderr(file *os.File) {
 	os.Stderr = file
-	_ = syscall.Dup3(int(file.Fd()), syscall.Stderr, 0)
+	_ = syscall.Dup3(int(file.Fd()), int(stderr), 0)
 }

--- a/pkg/logs/logs_others.go
+++ b/pkg/logs/logs_others.go
@@ -9,8 +9,11 @@ import (
 	"syscall"
 )
 
+// nolint:gochecknoglobals
+var stderr = os.Stderr.Fd()
+
 func redirectStderr(file *os.File) {
-	os.Stderr = file
 	// This works on darwin and freebsd, maybe others.
-	_ = syscall.Dup2(int(file.Fd()), syscall.Stderr)
+	_ = syscall.Dup2(int(file.Fd()), int(stderr))
+	os.Stderr = file
 }

--- a/pkg/logs/logs_windows.go
+++ b/pkg/logs/logs_windows.go
@@ -11,12 +11,12 @@ import (
 var (
 	kernel    = syscall.MustLoadDLL("kernel32.dll")
 	setHandle = kernel.MustFindProc("SetStdHandle")
+	stderr    = syscall.STD_ERROR_HANDLE
 )
 
 //nolint:errcheck
 func redirectStderr(file *os.File) {
 	os.Stderr = file
-	stderr := syscall.STD_ERROR_HANDLE
 
 	const noIdeaWhatThisIs = 2
 


### PR DESCRIPTION
Updates the bind_addr description in the config file. Closes #95. 
Fixes a crashing bug on windows. Closes #94. 
Fixes a crashing bug when Plex is down/unreachable. Closes #98.
Make the `urlbase` (setting) path return a 200 instead of 404. Repotted by @RumlePot

Changes error/panic logging a bit more.