### PR TITLE
Move flags to configfile, and add startup info post

### DIFF
--- a/pkg/client/handlers.go
+++ b/pkg/client/handlers.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path"
-	"runtime"
 	"strings"
 	"time"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/Notifiarr/notifiarr/pkg/plex"
 	"github.com/Notifiarr/notifiarr/pkg/ui"
 	"golift.io/starr"
-	"golift.io/version"
 )
 
 // internalHandlers initializes "special" internal API paths.
@@ -115,35 +113,10 @@ type conTest struct {
 	Status   interface{} `json:"systemStatus,omitempty"`
 }
 
-// getVersion returns application run and build time data.
-func (c *Client) getVersion() map[string]interface{} {
-	numPlex := 0 // maybe one day we'll support more than 1 plex.
-	if c.Config.Plex.Configured() {
-		numPlex = 1
-	}
-
-	return map[string]interface{}{
-		"version":        version.Version,
-		"os_arch":        runtime.GOOS + "." + runtime.GOARCH,
-		"uptime":         time.Since(version.Started).Round(time.Second).String(),
-		"uptime_seconds": time.Since(version.Started).Round(time.Second).Seconds(),
-		"build_date":     version.BuildDate,
-		"branch":         version.Branch,
-		"go_version":     version.GoVersion,
-		"revision":       version.Revision,
-		"gui":            ui.HasGUI(),
-		"num_lidarr":     len(c.Config.Apps.Lidarr),
-		"num_sonarr":     len(c.Config.Apps.Sonarr),
-		"num_radarr":     len(c.Config.Apps.Radarr),
-		"num_readarr":    len(c.Config.Apps.Readarr),
-		"num_plex":       numPlex,
-	}
-}
-
 // versionResponse returns application run and build time data and application statuses: /api/version.
 func (c *Client) versionResponse(r *http.Request) (int, interface{}) {
 	var (
-		output = c.getVersion()
+		output = c.notify.Info()
 		rad    = make([]*conTest, len(c.Config.Radarr))
 		read   = make([]*conTest, len(c.Config.Readarr))
 		son    = make([]*conTest, len(c.Config.Sonarr))

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -29,26 +29,10 @@ import (
 	"golift.io/version"
 )
 
-// Flags are our CLI input flags.
-type Flags struct {
-	*flag.FlagSet
-	verReq     bool
-	testSnaps  bool
-	sendSnaps  bool
-	restart    bool
-	updated    bool
-	cfsync     bool
-	pslist     bool
-	write      string
-	curl       string
-	ConfigFile string
-	EnvPrefix  string
-}
-
 // Client stores all the running data.
 type Client struct {
 	*logs.Logger
-	Flags  *Flags
+	Flags  *configfile.Flags
 	Config *configfile.Config
 	server *http.Server
 	sigkil chan os.Signal
@@ -92,32 +76,12 @@ func NewDefaults() *Client {
 				LogFileMb: mnd.DefaultLogFileMb,
 			},
 			Timeout: cnfg.Duration{Duration: mnd.DefaultTimeout},
-		}, Flags: &Flags{
+		}, Flags: &configfile.Flags{
 			FlagSet:    flag.NewFlagSet(mnd.DefaultName, flag.ExitOnError),
 			ConfigFile: os.Getenv(mnd.DefaultEnvPrefix + "_CONFIG_FILE"),
 			EnvPrefix:  mnd.DefaultEnvPrefix,
 		},
 	}
-}
-
-// ParseArgs stores the cli flag data into the Flags pointer.
-func (f *Flags) ParseArgs(args []string) {
-	f.StringVarP(&f.ConfigFile, "config", "c", os.Getenv(mnd.DefaultEnvPrefix+"_CONFIG_FILE"), f.Name()+" Config File.")
-	f.BoolVar(&f.testSnaps, "snaps", false, f.Name()+"Test Snapshots.")
-	f.BoolVar(&f.sendSnaps, "send", false, f.Name()+"Send Snapshots; must also pass --snaps for this to work.")
-	f.StringVarP(&f.EnvPrefix, "prefix", "p", mnd.DefaultEnvPrefix, "Environment Variable Prefix.")
-	f.BoolVarP(&f.verReq, "version", "v", false, "Print the version and exit.")
-	f.BoolVar(&f.cfsync, "cfsync", false, "Trigger Custom Format sync and exit.")
-	f.StringVar(&f.curl, "curl", "", "GET a URL and display headers and payload.")
-	f.BoolVar(&f.pslist, "ps", false, "Print the system process list; useful for 'process' service checks.")
-	f.StringVar(&f.write, "write", "", "Write new config file to provided path. Use - to overwrite '--config' file.")
-
-	if runtime.GOOS == mnd.Windows {
-		f.BoolVar(&f.restart, "restart", false, "This is used by auto-update, do not call it.")
-		f.BoolVar(&f.updated, "updated", false, "This flag causes the app to print an 'updated' message.")
-	}
-
-	f.Parse(args) // nolint: errcheck
 }
 
 // Start runs the app.
@@ -126,15 +90,15 @@ func Start() error {
 	c.Flags.ParseArgs(os.Args[1:])
 
 	switch {
-	case c.Flags.verReq:
+	case c.Flags.VerReq:
 		fmt.Println(version.Print(c.Flags.Name()))
 		return nil // print version and exit.
-	case c.Flags.pslist:
+	case c.Flags.PSlist:
 		return printProcessList()
-	case c.Flags.curl != "":
-		resp, body, err := curl.Get(c.Flags.curl) //nolint:bodyclose // it's already closed.
+	case c.Flags.Curl != "":
+		resp, body, err := curl.Get(c.Flags.Curl) //nolint:bodyclose // it's already closed.
 		if err != nil {
-			return fmt.Errorf("getting URL '%s': %w", c.Flags.curl, err)
+			return fmt.Errorf("getting URL '%s': %w", c.Flags.Curl, err)
 		}
 
 		curl.Print(resp, body)
@@ -145,7 +109,7 @@ func Start() error {
 	if err := c.config(); err != nil {
 		_, _ = ui.Error(mnd.Title, err.Error())
 		return err
-	} else if c.Flags.restart || c.Flags.write != "" {
+	} else if c.Flags.Restart || c.Flags.Write != "" {
 		return nil
 	}
 
@@ -163,10 +127,10 @@ func (c *Client) config() error {
 	// Find or write a config file. This does not parse it.
 	// A config file is only written when none is found on Windows, macOS (GUI App only), or Docker.
 	// And in the case of Docker, only if `/config` is a mounted volume.
-	write := (!c.Flags.restart && ui.HasGUI()) || os.Getenv("NOTIFIARR_IN_DOCKER") == "true"
+	write := (!c.Flags.Restart && ui.HasGUI()) || os.Getenv("NOTIFIARR_IN_DOCKER") == "true"
 	c.Flags.ConfigFile, c.newCon, msg = c.Config.FindAndReturn(c.Flags.ConfigFile, write)
 
-	if c.Flags.restart {
+	if c.Flags.Restart {
 		return update.Restart(&update.Command{ //nolint:wrapcheck
 			Path: os.Args[0],
 			Args: []string{"--updated", "--config", c.Flags.ConfigFile},
@@ -179,8 +143,8 @@ func (c *Client) config() error {
 	}
 
 	// If c.Flags.write is set it will force-write the read-config to the provided file path.
-	if c.Flags.write != "" {
-		return c.forceWriteWithExit(c.Flags.write, msg)
+	if c.Flags.Write != "" {
+		return c.forceWriteWithExit(c.Flags.Write, msg)
 	}
 
 	c.startupMessage([]string{msg})
@@ -230,15 +194,15 @@ func (c *Client) startupMessage(msg []string) {
 }
 
 func (c *Client) start() error {
-	if c.Flags.updated {
+	if c.Flags.Updated {
 		c.printUpdateMessage()
 	}
 
-	if c.Flags.testSnaps {
+	if c.Flags.TestSnaps {
 		c.checkPlex()
 		c.Config.Snapshot.Validate()
 
-		if c.Flags.sendSnaps {
+		if c.Flags.SendSnaps {
 			c.configureNotifiarr()
 			c.notify.Start(c.Config.Mode)
 			c.Printf("[user requested] Snapshot Data:\n%s", c.sendSystemSnapshot(c.notify.URL))
@@ -253,9 +217,9 @@ func (c *Client) start() error {
 		return fmt.Errorf("%w %s_API_KEY", ErrNilAPIKey, c.Flags.EnvPrefix)
 	}
 
-	c.configureServices(!c.Flags.cfsync) // do not collect plex info if cfsync is active.
+	c.configureServices(!c.Flags.CFsync) // do not collect plex info if cfsync is active.
 
-	if c.Flags.cfsync {
+	if c.Flags.CFsync {
 		c.Printf("==> Flag Requested: Syncing Custom Formats and Release Profiles (then exiting)")
 		// c.notify.SendFinishedQueueItems(c.notify.BaseURL)
 		c.notify.SyncCF(true)

--- a/pkg/configfile/flags.go
+++ b/pkg/configfile/flags.go
@@ -1,0 +1,47 @@
+package configfile
+
+import (
+	"os"
+	"runtime"
+
+	"github.com/Notifiarr/notifiarr/pkg/mnd"
+	flag "github.com/spf13/pflag"
+)
+
+/* This file handles application cli flags. */
+
+// Flags are our CLI input flags.
+type Flags struct {
+	*flag.FlagSet
+	VerReq     bool
+	TestSnaps  bool
+	SendSnaps  bool
+	Restart    bool
+	Updated    bool
+	CFsync     bool
+	PSlist     bool
+	Write      string
+	Curl       string
+	ConfigFile string
+	EnvPrefix  string
+}
+
+// ParseArgs stores the cli flag data into the Flags pointer.
+func (f *Flags) ParseArgs(args []string) {
+	f.StringVarP(&f.ConfigFile, "config", "c", os.Getenv(mnd.DefaultEnvPrefix+"_CONFIG_FILE"), f.Name()+" Config File.")
+	f.BoolVar(&f.TestSnaps, "snaps", false, f.Name()+"Test Snapshots.")
+	f.BoolVar(&f.SendSnaps, "send", false, f.Name()+"Send Snapshots; must also pass --snaps for this to work.")
+	f.StringVarP(&f.EnvPrefix, "prefix", "p", mnd.DefaultEnvPrefix, "Environment Variable Prefix.")
+	f.BoolVarP(&f.VerReq, "version", "v", false, "Print the version and exit.")
+	f.BoolVar(&f.CFsync, "cfsync", false, "Trigger Custom Format sync and exit.")
+	f.StringVar(&f.Curl, "curl", "", "GET a URL and display headers and payload.")
+	f.BoolVar(&f.PSlist, "ps", false, "Print the system process list; useful for 'process' service checks.")
+	f.StringVar(&f.Write, "write", "", "Write new config file to provided path. Use - to overwrite '--config' file.")
+
+	if runtime.GOOS == mnd.Windows {
+		f.BoolVar(&f.Restart, "restart", false, "This is used by auto-update, do not call it.")
+		f.BoolVar(&f.Updated, "updated", false, "This flag causes the app to print an 'updated' message.")
+	}
+
+	f.Parse(args) // nolint: errcheck
+}

--- a/pkg/notifiarr/clientinfo.go
+++ b/pkg/notifiarr/clientinfo.go
@@ -1,6 +1,7 @@
 package notifiarr
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Notifiarr/notifiarr/pkg/ui"
+	"github.com/shirou/gopsutil/v3/host"
 	"golift.io/version"
 )
 
@@ -76,6 +78,14 @@ func (c *Config) Info() map[string]interface{} {
 		numPlex = 1
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	hostInfo, _ := host.InfoWithContext(ctx)
+	if hostInfo != nil {
+		hostInfo.Hostname = "" // we do not need this.
+	}
+
 	return map[string]interface{}{
 		"arch":        runtime.GOARCH,
 		"build_date":  version.BuildDate,
@@ -84,6 +94,7 @@ func (c *Config) Info() map[string]interface{} {
 		"docker":      os.Getenv("NOTIFIARR_IN_DOCKER") == "true",
 		"go_version":  version.GoVersion,
 		"gui":         ui.HasGUI(),
+		"host":        hostInfo,
 		"num_deluge":  len(c.Apps.Deluge),
 		"num_lidarr":  len(c.Apps.Lidarr),
 		"num_plex":    numPlex,

--- a/pkg/notifiarr/clientinfo.go
+++ b/pkg/notifiarr/clientinfo.go
@@ -1,0 +1,104 @@
+package notifiarr
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/Notifiarr/notifiarr/pkg/ui"
+	"golift.io/version"
+)
+
+// ClientInfo is the reply from the ClienRoute endpoint.
+type ClientInfo struct {
+	Status  string `json:"status"`
+	Message struct {
+		Text       string `json:"text"`
+		Subscriber bool   `json:"subscriber"`
+		Patron     bool   `json:"patron"`
+		CFSync     int64  `json:"cfSync"`
+		RPSync     int64  `json:"rpSync"`
+	} `json:"message"`
+}
+
+// String returns the message text for a client info response.
+func (c *ClientInfo) String() string {
+	if c == nil {
+		return ""
+	}
+
+	return c.Message.Text
+}
+
+// IsSub returns true if the client is a subscriber. False otherwise.
+func (c *ClientInfo) IsSub() bool {
+	return c != nil && c.Message.Subscriber
+}
+
+// IsPatron returns true if the client is a patron. False otherwise.
+func (c *ClientInfo) IsPatron() bool {
+	return c != nil && c.Message.Patron
+}
+
+// GetClientInfo returns an error if the API key is wrong. Returns client info otherwise.
+func (c *Config) GetClientInfo() (*ClientInfo, error) {
+	if c.ClientInfo != nil {
+		return c.ClientInfo, nil
+	}
+
+	resp, body, err := c.SendData(c.BaseURL+ClientRoute, c.Info(), true) //nolint:bodyclose // already closed.
+	if err != nil {
+		return nil, fmt.Errorf("POSTing client info: %w", err)
+	}
+
+	v := ClientInfo{}
+	if err = json.Unmarshal(body, &v); err != nil {
+		return &v, fmt.Errorf("parsing response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return &v, ErrNon200
+	}
+
+	// Only set this if there was no error.
+	c.ClientInfo = &v
+
+	return c.ClientInfo, nil
+}
+
+// Info is used for JSON input for our outgoing client info.
+func (c *Config) Info() map[string]interface{} {
+	numPlex := 0 // maybe one day we'll support more than 1 plex.
+	if c.Plex.Configured() {
+		numPlex = 1
+	}
+
+	return map[string]interface{}{
+		"arch":        runtime.GOARCH,
+		"build_date":  version.BuildDate,
+		"cfsync_dur":  cfSyncTimer.Seconds(),
+		"dash_dur":    c.DashDur.Seconds(),
+		"docker":      os.Getenv("NOTIFIARR_IN_DOCKER") == "true",
+		"go_version":  version.GoVersion,
+		"gui":         ui.HasGUI(),
+		"num_deluge":  len(c.Apps.Deluge),
+		"num_lidarr":  len(c.Apps.Lidarr),
+		"num_plex":    numPlex,
+		"num_qbit":    len(c.Apps.Qbit),
+		"num_radarr":  len(c.Apps.Radarr),
+		"num_readarr": len(c.Apps.Readarr),
+		"num_sonarr":  len(c.Apps.Sonarr),
+		"os":          runtime.GOOS,
+		"retries":     c.Retries,
+		"revision":    version.Revision,
+		"snap_dur":    c.Snap.Interval.Seconds(),
+		"snap_tout":   c.Snap.Timeout.Seconds(),
+		"stuck_dur":   stuckTimer.Seconds(),
+		"timeout":     c.Timeout.Seconds(),
+		"uptime_dur":  time.Since(version.Started).Round(time.Second).Seconds(),
+		"version":     version.Version,
+	}
+}

--- a/pkg/notifiarr/notifiarr.go
+++ b/pkg/notifiarr/notifiarr.go
@@ -89,18 +89,6 @@ type Config struct {
 	syncCFnow    chan chan struct{}
 }
 
-// ClientInfo is the reply from the ClienRoute endpoint.
-type ClientInfo struct {
-	Status  string `json:"status"`
-	Message struct {
-		Text       string `json:"text"`
-		Subscriber bool   `json:"subscriber"`
-		Patron     bool   `json:"patron"`
-		CFSync     int64  `json:"cfSync"`
-		RPSync     int64  `json:"rpSync"`
-	} `json:"message"`
-}
-
 // Start (and log) snapshot and plex cron jobs if they're configured.
 func (c *Config) Start(mode string) {
 	switch strings.ToLower(mode) {
@@ -220,67 +208,6 @@ func (c *Config) GetMetaSnap(ctx context.Context) *snapshot.Snapshot {
 	wg.Wait()
 
 	return snap
-}
-
-// String returns the message text for a client info response.
-func (c *ClientInfo) String() string {
-	if c == nil {
-		return ""
-	}
-
-	return c.Message.Text
-}
-
-// IsSub returns true if the client is a subscriber. False otherwise.
-func (c *ClientInfo) IsSub() bool {
-	return c != nil && c.Message.Subscriber
-}
-
-// IsPatron returns true if the client is a patron. False otherwise.
-func (c *ClientInfo) IsPatron() bool {
-	return c != nil && c.Message.Patron
-}
-
-// GetClientInfo returns an error if the API key is wrong. Returns client info otherwise.
-func (c *Config) GetClientInfo() (*ClientInfo, error) {
-	if c.ClientInfo != nil {
-		return c.ClientInfo, nil
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+ClientRoute, nil)
-	if err != nil {
-		return nil, fmt.Errorf("creating http request: %w", err)
-	}
-
-	req.Header.Set("X-API-Key", c.Apps.APIKey)
-
-	resp, err := c.getClient().Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("making http request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	v := ClientInfo{}
-	if err = json.Unmarshal(body, &v); err != nil {
-		return &v, fmt.Errorf("parsing response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return &v, ErrNon200
-	}
-
-	// Only set this if there was no error.
-	c.ClientInfo = &v
-
-	return c.ClientInfo, nil
 }
 
 // SendJSON posts a JSON payload to a URL. Returns the response body or an error.


### PR DESCRIPTION
This adds some startup data so we can track usage (version) statistics; closes #105. Re-used the `version` API endpoint code and made both implementations use the same data. Moved the ClientInfo code for incoming and outgoing info into one file. Also moved Flags into the `configfile` package.