### PR TITLE
Add incoming API triggers, channelize calls

### DIFF
--- a/pkg/client/handlers.go
+++ b/pkg/client/handlers.go
@@ -26,7 +26,6 @@ func (c *Client) internalHandlers() {
 	c.Config.HandleAPIpath("", "version", c.versionResponse, "GET", "HEAD")
 	c.Config.HandleAPIpath("", "info", c.updateInfo, "PUT")
 	c.Config.HandleAPIpath("", "info/alert", c.updateInfoAlert, "PUT")
-	c.Config.HandleAPIpath("", "cfsync", c.handleCFSyncReq, "GET") // deprecated
 	c.Config.HandleAPIpath("", "trigger/{trigger:[0-9a-z-]+}", c.handleTrigger, "GET")
 
 	if c.Config.Plex.Configured() {
@@ -299,9 +298,4 @@ func (c *Client) handleTrigger(r *http.Request) (int, interface{}) {
 	}
 
 	return http.StatusOK, trigger + " initiated"
-}
-
-func (c *Client) handleCFSyncReq(r *http.Request) (int, interface{}) {
-	c.notify.SyncCF(false)
-	return http.StatusOK, "sync initiated (deprecated)"
 }

--- a/pkg/client/tray.go
+++ b/pkg/client/tray.go
@@ -241,7 +241,7 @@ func (c *Client) watchNotifiarrMenu() { //nolint:cyclop
 			c.Config.Services.RunChecks(true)
 
 			data, _ := json.MarshalIndent(&services.Results{
-				What:     "user",
+				What:     "log",
 				Svcs:     c.Config.Services.GetResults(),
 				Type:     services.NotifiarrEventType,
 				Interval: c.Config.Services.Interval.Seconds(),

--- a/pkg/notifiarr/notifiarr.go
+++ b/pkg/notifiarr/notifiarr.go
@@ -87,6 +87,10 @@ type Config struct {
 	radarrCF     map[int]*cfMapIDpayload
 	sonarrRP     map[int]*cfMapIDpayload
 	syncCFnow    chan chan struct{}
+	stuckNow     chan string
+	plexNow      chan string
+	stateNow     chan struct{}
+	snapNow      chan string
 }
 
 // ClientInfo is the reply from the ClienRoute endpoint.
@@ -126,6 +130,10 @@ func (c *Config) Start(mode string) {
 	c.radarrCF = make(map[int]*cfMapIDpayload)
 	c.sonarrRP = make(map[int]*cfMapIDpayload)
 	c.syncCFnow = make(chan chan struct{})
+	c.stuckNow = make(chan string)
+	c.plexNow = make(chan string)
+	c.stateNow = make(chan struct{})
+	c.snapNow = make(chan string)
 
 	c.startTimers()
 }
@@ -134,6 +142,11 @@ func (c *Config) Start(mode string) {
 func (c *Config) Stop() {
 	if c != nil && c.stopTimers != nil {
 		c.stopTimers <- struct{}{}
+		close(c.syncCFnow)
+		close(c.stuckNow)
+		close(c.plexNow)
+		close(c.stateNow)
+		close(c.snapNow)
 	}
 }
 

--- a/pkg/notifiarr/plexcron.go
+++ b/pkg/notifiarr/plexcron.go
@@ -22,10 +22,15 @@ const (
 	episode = "episode"
 )
 
+// SendPlexSessions sends plex sessions in a go routine through a channel.
+func (c *Config) SendPlexSessions(source string) {
+	c.plexNow <- source
+}
+
 // sendPlexSessions is fired by a timer if plex monitoring is enabled.
-func (c *Config) sendPlexSessions() {
-	if body, err := c.SendMeta(PlexCron, c.URL, nil, 0); err != nil {
-		c.Errorf("Sending Plex Session to %s: %v", c.URL, err)
+func (c *Config) sendPlexSessions(source string) {
+	if body, err := c.SendMeta(source, c.URL, nil, 0); err != nil {
+		c.Errorf("Sending Plex Sessions to %s: %v", c.URL, err)
 	} else if fields := strings.Split(string(body), `"`); len(fields) > 3 { //nolint:gomnd
 		c.Printf("Plex Sessions sent to %s, sending again in %s, reply: %s", c.URL, c.Plex.Interval, fields[3])
 	} else {

--- a/pkg/notifiarr/snapcron.go
+++ b/pkg/notifiarr/snapcron.go
@@ -32,7 +32,11 @@ func (c *Config) logSnapshotStartup() {
 		c.Snap.Interval, c.Snap.Timeout, ex)
 }
 
-func (c *Config) sendSnapshot() {
+func (c *Config) SendSnapshot(source string) {
+	c.snapNow <- source
+}
+
+func (c *Config) sendSnapshot(source string) {
 	snapshot, errs, debug := c.Snap.GetSnapshot()
 	for _, err := range errs {
 		if err != nil {
@@ -47,7 +51,7 @@ func (c *Config) sendSnapshot() {
 		}
 	}
 
-	if _, body, err := c.SendData(c.URL, &Payload{Type: SnapCron, Snap: snapshot}, true); err != nil {
+	if _, body, err := c.SendData(c.URL, &Payload{Type: source, Snap: snapshot}, true); err != nil {
 		c.Errorf("Sending snapshot to %s: %v", c.URL, err)
 	} else if fields := strings.Split(string(body), `"`); len(fields) > 3 { //nolint:gomnd
 		c.Printf("Systems Snapshot sent to %s, sending again in %s, reply: %s", c.URL, c.Snap.Interval, fields[3])

--- a/pkg/notifiarr/state.go
+++ b/pkg/notifiarr/state.go
@@ -81,6 +81,10 @@ type States struct {
 }
 
 func (c *Config) GetState() {
+	c.stateNow <- struct{}{}
+}
+
+func (c *Config) getState() {
 	start := time.Now()
 	states := c.getStates()
 	apps := time.Since(start).Round(time.Millisecond)

--- a/pkg/notifiarr/stuckitems.go
+++ b/pkg/notifiarr/stuckitems.go
@@ -49,6 +49,10 @@ func (i ItemList) Empty() bool {
 }
 
 func (c *Config) SendFinishedQueueItems(url string) {
+	c.stuckNow <- url
+}
+
+func (c *Config) sendFinishedQueueItems(url string) {
 	start := time.Now()
 	q := c.getQueues()
 	apps := time.Since(start).Round(time.Millisecond)


### PR DESCRIPTION
This adds incoming triggers for:
- services
- dashboard
- snapshot
- sessions
- stuck items

Moves several of these external requests into the native go routine for the ticker running each item. This is accomplished by adding a new channel to send the request to. Closes #103.