### PR TITLE
Snapshot improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,14 +260,20 @@ tautulli.api_key|`DN_TAUTULLI_API_KEY`|No Default. Provide URL and API key if yo
 
 This application can also take a snapshot of your system at an interval and send
 you a notification. Snapshot means system health like cpu, memory, disk, raid, users, etc.
+Other data available in the snapshot: mysql health, `iotop`, `iostat` and `top` data.
+Some of this may only be available on Linux, but other platforms have similar abilities.
 
 If you monitor drive health you must have smartmontools (`smartctl`) installed.
 If you use smartctl on Linux, you must enable sudo. Add this sudoers entry to
 `/etc/sudoers` and fix the path to `smartctl` if yours differs. If you monitor
 raid and use MegaCli (LSI card), add the appropriate sudoers entry for that too.
 
+To monitor application disk I/O you may install `iotop` and add the sudoers entry
+for it, shown below. This feature is enabled on the website.
+
 ```
 notifiarr ALL=(root) NOPASSWD:/usr/sbin/smartctl *
+notifiarr ALL=(root) NOPASSWD:/usr/sbin/iotop *
 notifiarr ALL=(root) NOPASSWD:/usr/sbin/MegaCli64 -LDInfo -Lall -aALL
 ```
 
@@ -283,6 +289,27 @@ notifiarr ALL=(root) NOPASSWD:/usr/sbin/MegaCli64 -LDInfo -Lall -aALL
 #### Snapshot Configuration
 
 Snapshot configuration is now found on the [website](https://notifiarr.com). - 9/14/2021
+
+#### MySQL Snapshots
+
+You may add mysql credentials to your notifiarr configuration to snapshot mysql
+service health. This feature snapshots `SHOW PROCESSLIST` and `SHOW STATUS` data.
+
+Example Grant:
+
+```
+GRANT PROCESS ON *.* to 'notifiarr'@'localhost'
+```
+
+Access to a database is not required. `SELECT` may not be required.
+
+|Config Name|Variable Name|Note|
+|---|---|---|
+snapshot.mysql.name|`DN_SNAPSHOT_MYSQL_NAME`|Setting a name enables service checks of MySQL|
+snapshot.mysql.host|`DN_SNAPSHOT_MYSQL_HOST`|Something like: `localhost:3306`|
+snapshot.mysql.user|`DN_SNAPSHOT_MYSQL_USER`|Username in the GRANT statement|
+snapshot.mysql.pass|`DN_SNAPSHOT_MYSQL_PASS`|Password for the user in the GRANT statement|
+
 
 ### Service Checks
 

--- a/examples/notifiarr.conf.example
+++ b/examples/notifiarr.conf.example
@@ -1,6 +1,6 @@
 ###############################################
 # Notifiarr Client Example Configuration File #
-# Created by Notifiarr v0.2.1   @ 212610T0855 #
+# Created by Notifiarr v0.2.1   @ 212910T0624 #
 ###############################################
 
 # This API key must be copied from your notifiarr.com account.
@@ -143,7 +143,7 @@ timeout = "1m0s"
 # Enables MySQL process list in snapshot output.
 # Adding a name to a server enables TCP service checks.
 # Example Grant:
-# GRANT SELECT,PROCESS ON *.* to 'notifiarr'@'localhost'
+# GRANT PROCESS ON *.* to 'notifiarr'@'localhost'
 
 #[[snapshot.mysql]]
 #name = "" # only set a name to enable service checks.

--- a/examples/notifiarr.conf.example
+++ b/examples/notifiarr.conf.example
@@ -1,6 +1,6 @@
 ###############################################
 # Notifiarr Client Example Configuration File #
-# Created by Notifiarr v0.2.0   @ 212410T2154 #
+# Created by Notifiarr v0.2.1   @ 212610T0855 #
 ###############################################
 
 # This API key must be copied from your notifiarr.com account.
@@ -132,9 +132,24 @@ timeout = "1m0s"
 # Must uncomment [tautulli], 'api_key' and 'url' at a minimum.
 
 #[tautulli]
-#  name    = "" # only set a name if you want to enable service checks.
+#  name    = "" # only set a name to enable service checks.
 #  url     = "http://localhost:8181" # Your Tautulli URL
 #  api_key = "" # your tautulli api key; get this from settings
+
+##################
+# MySQL Snapshot #
+##################
+
+# Enables MySQL process list in snapshot output.
+# Adding a name to a server enables TCP service checks.
+# Example Grant:
+# GRANT SELECT,PROCESS ON *.* to 'notifiarr'@'localhost'
+
+#[[snapshot.mysql]]
+#name = "" # only set a name to enable service checks.
+#host = "localhost:3306"
+#user = "notifiarr"
+#pass = "password"
 
 ##################
 # Service Checks #

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 require (
 	github.com/BurntSushi/toml v0.4.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-sql-driver/mysql v1.6.0
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/google/cabbie v1.0.2 // indirect
 	github.com/google/glazier v0.0.0-20211020141234-79a2756d295f // indirect

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/google/cabbie v1.0.2 // indirect
-	github.com/google/glazier v0.0.0-20211007155120-e60a0495f2ea // indirect
+	github.com/google/glazier v0.0.0-20211020141234-79a2756d295f // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20210825203111-a709d8e111b3 // indirect
 	github.com/gopherjs/gopherwasm v1.1.0 // indirect
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNI
 github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/cabbie v1.0.2 h1:UtB+Nn6fPB43wGg5xs4tgU+P3hTZ6KsulgtaHtqZZfs=
 github.com/google/cabbie v1.0.2/go.mod h1:6MmHaUrgfabehCHAIaxdrbmvHSxUVXj3Abs08FMABSo=
 github.com/google/glazier v0.0.0-20210617205946-bf91b619f5d4/go.mod h1:g7oyIhindbeebnBh0hbFua5rv6XUt/nweDwIWdvxirg=
-github.com/google/glazier v0.0.0-20211007155120-e60a0495f2ea h1:BMyoCnGfkRNgcnoFUI0Qj996HN8kqWIv9eyytljlAyc=
-github.com/google/glazier v0.0.0-20211007155120-e60a0495f2ea/go.mod h1:h2R3DLUecGbLSyi6CcxBs5bdgtJhgK+lIffglvAcGKg=
+github.com/google/glazier v0.0.0-20211020141234-79a2756d295f h1:wgupLmMh1RfLc/M7pQfZf+2hdV9in66rDgl7MGq3a0M=
+github.com/google/glazier v0.0.0-20211020141234-79a2756d295f/go.mod h1:h2R3DLUecGbLSyi6CcxBs5bdgtJhgK+lIffglvAcGKg=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/pkg/client/cli.go
+++ b/pkg/client/cli.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"runtime"
 	"strings"
 	"time"
 
@@ -61,7 +60,7 @@ func printProcessList() error {
 	}
 
 	for _, p := range pslist {
-		if runtime.GOOS == "freebsd" {
+		if mnd.IsFreeBSD {
 			fmt.Printf("[%-5d] %s\n", p.PID, p.CmdLine)
 			continue
 		}

--- a/pkg/client/init.go
+++ b/pkg/client/init.go
@@ -35,6 +35,7 @@ func (c *Client) PrintStartupInfo() {
 	c.printSABnzbd()
 	c.printPlex()
 	c.printTautulli()
+	c.printMySQL()
 	c.Printf(" => Timeout: %v, Quiet: %v", c.Config.Timeout, c.Config.Quiet)
 	c.Printf(" => Trusted Upstream Networks: %v", c.Config.Allow)
 
@@ -278,5 +279,34 @@ func (c *Client) printTautulli() {
 			t.URL, t.Timeout, t.Interval, t.Name)
 	default:
 		c.Printf(" => Tautulli Config (enables name map): 1 server: %s, timeout: %v", t.URL, t.Timeout)
+	}
+}
+
+// printMySQL is called on startup to print info about each configured SQL server.
+func (c *Client) printMySQL() {
+	if c.Config.Snapshot.Plugins == nil { // unlikely.
+		return
+	}
+
+	if len(c.Config.Snapshot.MySQL) == 1 {
+		if m := c.Config.Snapshot.MySQL[0]; m.Name != "" {
+			c.Printf(" => MySQL Config: 1 server: %s, user: %v, timeout:%v, check interval: %v, name: %s",
+				m.Host, m.User, m.Timeout, m.Interval, m.Name)
+		} else {
+			c.Printf(" => MySQL Config: 1 server: %s, user: %v, timeout:%v", m.Host, m.User, m.Timeout)
+		}
+
+		return
+	}
+
+	c.Print(" => MySQL Config:", len(c.Config.Snapshot.MySQL), "servers")
+
+	for i, m := range c.Config.Snapshot.MySQL {
+		if m.Name != "" {
+			c.Printf(" =>    Server %d: %s, user: %v, timeout:%v, check interval: %v, name: %s",
+				i+1, m.Host, m.User, m.Timeout, m.Interval, m.Name)
+		} else {
+			c.Printf(" =>    Server %d: %s, user: %v, timeout:%v", i+1, m.Host, m.User, m.Timeout)
+		}
 	}
 }

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -7,7 +7,6 @@ package client
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -225,7 +224,7 @@ func (c *Client) configureServices(source notifiarr.EventType) {
 	c.Config.Snapshot.Validate()
 	c.PrintStartupInfo()
 	c.website.Start()
-	/**/ // debug stuff.
+	/* // debug stuff.
 	snap, err, _ := c.Config.Snapshot.GetSnapshot()
 	b, _ := json.MarshalIndent(snap, "", "   ")
 	c.Print(string(b), err)

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -7,6 +7,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -224,7 +225,7 @@ func (c *Client) configureServices(source notifiarr.EventType) {
 	c.Config.Snapshot.Validate()
 	c.PrintStartupInfo()
 	c.website.Start()
-	/* // debug stuff.
+	/**/ // debug stuff.
 	snap, err, _ := c.Config.Snapshot.GetSnapshot()
 	b, _ := json.MarshalIndent(snap, "", "   ")
 	c.Print(string(b), err)

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -153,6 +153,7 @@ func (c *Client) loadSiteConfig(source notifiarr.EventType) {
 	c.Printf("==> %s", ci)
 
 	if ci.Actions.Snapshot != nil {
+		ci.Actions.Snapshot.Plugins = c.Config.Snapshot.Plugins // use local data for plugins.
 		c.website.Snap, c.Config.Snapshot = ci.Actions.Snapshot, ci.Actions.Snapshot
 	}
 
@@ -223,6 +224,12 @@ func (c *Client) configureServices(source notifiarr.EventType) {
 	c.Config.Snapshot.Validate()
 	c.PrintStartupInfo()
 	c.website.Start()
+	/* // debug stuff.
+	snap, err, _ := c.Config.Snapshot.GetSnapshot()
+	b, _ := json.MarshalIndent(snap, "", "   ")
+	c.Print(string(b), err)
+	os.Exit(1)
+	/**/
 	c.Config.Services.Start()
 }
 

--- a/pkg/configfile/config.go
+++ b/pkg/configfile/config.go
@@ -68,6 +68,7 @@ func NewConfig(logger *logs.Logger) *Config {
 		BindAddr: mnd.DefaultBindAddr,
 		Snapshot: &snapshot.Config{
 			Timeout: cnfg.Duration{Duration: snapshot.DefaultTimeout},
+			Plugins: &snapshot.Plugins{},
 		},
 		LogConfig: &logs.LogConfig{
 			LogFiles:  mnd.DefaultLogFiles,
@@ -98,6 +99,7 @@ func (c *Config) Get(configFile, envPrefix string) (*notifiarr.Config, error) {
 	}
 
 	c.Services.Apps = c.Apps
+	c.Services.Plugins = c.Snapshot.Plugins
 
 	svcs, err := c.Services.Setup(c.Service)
 	if err != nil {

--- a/pkg/configfile/template.go
+++ b/pkg/configfile/template.go
@@ -251,7 +251,7 @@ timeout = "{{.Timeout}}"
 # Enables MySQL process list in snapshot output.
 # Adding a name to a server enables TCP service checks.
 # Example Grant:
-# GRANT SELECT,PROCESS ON *.* to 'notifiarr'@'localhost'
+# GRANT PROCESS ON *.* to 'notifiarr'@'localhost'
 {{if .Snapshot.MySQL}} {{range .Snapshot.MySQL}}
 [[snapshot.mysql]]
   name     = "{{.Name}}"

--- a/pkg/configfile/template.go
+++ b/pkg/configfile/template.go
@@ -258,8 +258,8 @@ timeout = "{{.Timeout}}"
   host     = "{{.Host}}"
 	user     = "{{.User}}"
 	pass     = "{{.Pass}}"
-  interval = "{{.Interval}}" # Service check duration (if name is not empty).
-  timeout  = "{{.Timeout}}"{{end}}
+{{if .Name}}interval = "{{.Interval}}" # Service check duration.
+  timeout  = "{{.Timeout}}" # Service check timeout.{{end}}{{end}}
 {{else}}
 #[[snapshot.mysql]]
 #name = "" # only set a name to enable service checks.

--- a/pkg/configfile/template.go
+++ b/pkg/configfile/template.go
@@ -232,17 +232,41 @@ timeout = "{{.Timeout}}"
 # Must uncomment [tautulli], 'api_key' and 'url' at a minimum.
 {{if and .Tautulli (not force)}}
 [tautulli]
-  name     = "{{.Tautulli.Name}}" # only set a name if you want to enable service checks.
+  name     = "{{.Tautulli.Name}}" # only set a name to enable service checks.
   url      = "{{.Tautulli.URL}}" # Your Tautulli URL
   api_key  = "{{.Tautulli.APIKey}}" # your plex token; get this from a web inspector
   timeout  = "{{.Tautulli.Timeout}}" # how long to wait for HTTP responses
   interval = "{{.Tautulli.Interval}}" # how often to send service checks
 {{- else}}
 #[tautulli]
-#  name    = "" # only set a name if you want to enable service checks.
+#  name    = "" # only set a name to enable service checks.
 #  url     = "http://localhost:8181" # Your Tautulli URL
 #  api_key = "" # your tautulli api key; get this from settings
 {{- end }}
+
+##################
+# MySQL Snapshot #
+##################
+
+# Enables MySQL process list in snapshot output.
+# Adding a name to a server enables TCP service checks.
+# Example Grant:
+# GRANT SELECT,PROCESS ON *.* to 'notifiarr'@'localhost'
+{{if .Snapshot.MySQL}} {{range .Snapshot.MySQL}}
+[[snapshot.mysql]]
+  name     = "{{.Name}}"
+  host     = "{{.Host}}"
+	user     = "{{.User}}"
+	pass     = "{{.Pass}}"
+  interval = "{{.Interval}}" # Service check duration (if name is not empty).
+  timeout  = "{{.Timeout}}"{{end}}
+{{else}}
+#[[snapshot.mysql]]
+#name = "" # only set a name to enable service checks.
+#host = "localhost:3306"
+#user = "notifiarr"
+#pass = "password"
+{{- end}}
 
 ##################
 # Service Checks #

--- a/pkg/mnd/constants.go
+++ b/pkg/mnd/constants.go
@@ -1,28 +1,34 @@
 // Package mnd provides re-usable constants for the Notifiarr application packages.
 package mnd
 
-import "time"
+import (
+	"runtime"
+	"time"
+)
 
 // Application Constants.
 const (
-	Mode0755 = 0o755
-	Mode0750 = 0o750
-	Mode0600 = 0o600
-	Kilobyte = 1024
-	Megabyte = Kilobyte * Kilobyte
-	KB100    = Kilobyte * 100
-	OneDay   = 24 * time.Hour
-	HalfHour = 30 * time.Minute
-	Base10   = 10
-	Base8    = 8
-	Bits64   = 64
-	Bits32   = 32
-	Windows  = "windows"
-	HelpLink = "GoLift Discord: https://golift.io/discord"
-	UserRepo = "Notifiarr/notifiarr"
-	BugIssue = "This is a bug please report it on github: https://github.com/" + UserRepo + "/issues/new"
-	DockerV  = "NOTIFIARR_IN_DOCKER"
-	Synology = "/etc/synoinfo.conf" // Synology is the path to the syno config file.
+	Mode0755  = 0o755
+	Mode0750  = 0o750
+	Mode0600  = 0o600
+	Kilobyte  = 1024
+	Megabyte  = Kilobyte * Kilobyte
+	KB100     = Kilobyte * 100
+	OneDay    = 24 * time.Hour
+	HalfHour  = 30 * time.Minute
+	Base10    = 10
+	Base8     = 8
+	Bits64    = 64
+	Bits32    = 32
+	Windows   = "windows"
+	HelpLink  = "GoLift Discord: https://golift.io/discord"
+	UserRepo  = "Notifiarr/notifiarr"
+	BugIssue  = "This is a bug please report it on github: https://github.com/" + UserRepo + "/issues/new"
+	DockerV   = "NOTIFIARR_IN_DOCKER"
+	Synology  = "/etc/synoinfo.conf" // Synology is the path to the syno config file.
+	IsLinux   = runtime.GOOS == "linux"
+	IsWindows = runtime.GOOS == Windows
+	IsFreeBSD = runtime.GOOS == "freebsd"
 )
 
 // Application Defaults.

--- a/pkg/notifiarr/snapcron.go
+++ b/pkg/notifiarr/snapcron.go
@@ -10,6 +10,7 @@ func (c *Config) logSnapshotStartup() {
 		"uptime":  c.Snap.Uptime,
 		"cpumem":  c.Snap.CPUMem,
 		"cputemp": c.Snap.CPUTemp,
+		"iotop":   c.Snap.IOTop > 0,
 		"zfs":     len(c.Snap.ZFSPools) > 0,
 		"sudo":    c.Snap.UseSudo && c.Snap.DriveData,
 	} {

--- a/pkg/notifiarr/snapcron.go
+++ b/pkg/notifiarr/snapcron.go
@@ -12,6 +12,7 @@ func (c *Config) logSnapshotStartup() {
 		"cputemp": c.Snap.CPUTemp,
 		"iotop":   c.Snap.IOTop > 0,
 		"pstop":   c.Snap.PSTop > 0,
+		"mysql":   c.Snap.Plugins != nil && len(c.Snap.MySQL) > 0,
 		"zfs":     len(c.Snap.ZFSPools) > 0,
 		"sudo":    c.Snap.UseSudo && c.Snap.DriveData,
 	} {

--- a/pkg/notifiarr/snapcron.go
+++ b/pkg/notifiarr/snapcron.go
@@ -11,6 +11,7 @@ func (c *Config) logSnapshotStartup() {
 		"cpumem":  c.Snap.CPUMem,
 		"cputemp": c.Snap.CPUTemp,
 		"iotop":   c.Snap.IOTop > 0,
+		"pstop":   c.Snap.PSTop > 0,
 		"zfs":     len(c.Snap.ZFSPools) > 0,
 		"sudo":    c.Snap.UseSudo && c.Snap.DriveData,
 	} {

--- a/pkg/services/apps.go
+++ b/pkg/services/apps.go
@@ -192,20 +192,26 @@ func (c *Config) collectMySQLApps(svcs []*Service) []*Service {
 			m.Interval.Duration = DefaultCheckInterval
 		}
 
+		if m.Timeout.Duration == 0 {
+			m.Timeout.Duration = DefaultTimeout
+		}
+
 		host := strings.TrimLeft(strings.TrimRight(m.Host, ")"), "@tcp(")
+		if m.Name == "" || host == "" || strings.HasPrefix(host, "@") {
+			continue
+		}
+
 		if !strings.Contains(host, ":") {
 			host += ":3306"
 		}
 
-		if m.Name != "" {
-			svcs = append(svcs, &Service{
-				Name:     m.Name,
-				Type:     CheckTCP,
-				Value:    host,
-				Timeout:  m.Timeout,
-				Interval: m.Interval,
-			})
-		}
+		svcs = append(svcs, &Service{
+			Name:     m.Name,
+			Type:     CheckTCP,
+			Value:    host,
+			Timeout:  m.Timeout,
+			Interval: m.Interval,
+		})
 	}
 
 	return svcs

--- a/pkg/services/check_proc.go
+++ b/pkg/services/check_proc.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"runtime"
 	"strings"
 	"time"
 
+	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/hako/durafmt"
 	"github.com/shirou/gopsutil/v3/process"
 )
@@ -192,7 +192,7 @@ func getProcInfo(ctx context.Context, p *process.Process) (*ProcInfo, []error) {
 	}
 
 	// FreeBSD doesn't have create time.
-	if runtime.GOOS != "freebsd" {
+	if !mnd.IsFreeBSD {
 		created, err := p.CreateTimeWithContext(ctx)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("CreateTimeWithContext: %w", err))

--- a/pkg/services/check_proc_pre.go
+++ b/pkg/services/check_proc_pre.go
@@ -3,9 +3,10 @@ package services
 import (
 	"fmt"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
+
+	"github.com/Notifiarr/notifiarr/pkg/mnd"
 )
 
 // Custom errors.
@@ -45,7 +46,7 @@ func (s *Service) fillExpect() (err error) {
 		case strings.EqualFold(str, "restart"):
 			s.proc.restarts = true
 
-			if runtime.GOOS == "freebsd" {
+			if mnd.IsFreeBSD {
 				return ErrBSDRestart
 			}
 		case strings.EqualFold(str, "running"):

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Notifiarr/notifiarr/pkg/apps"
 	"github.com/Notifiarr/notifiarr/pkg/logs"
 	"github.com/Notifiarr/notifiarr/pkg/notifiarr"
+	"github.com/Notifiarr/notifiarr/pkg/snapshot"
 	"golift.io/cnfg"
 )
 
@@ -38,6 +39,7 @@ type Config struct {
 	LogFile      string            `toml:"log_file" xml:"log_file"`
 	Apps         *apps.Apps        `toml:"-"`
 	Notifiarr    *notifiarr.Config `toml:"-"`
+	Plugins      *snapshot.Plugins `toml:"-"`
 	*logs.Logger `json:"-"`        // log file writer
 	services     map[string]*Service
 	checks       chan *Service

--- a/pkg/snapshot/diskio.go
+++ b/pkg/snapshot/diskio.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -164,7 +163,7 @@ func (s *Snapshot) scanIOTop(stdout *bufio.Scanner, wg *sync.WaitGroup, procs in
 }
 
 func (s *Snapshot) getIoStat(ctx context.Context, run bool) error {
-	if !run || mnd.IsDocker || runtime.GOOS != "linux" {
+	if !run || mnd.IsDocker || mnd.IsLinux {
 		return nil
 	}
 

--- a/pkg/snapshot/diskio.go
+++ b/pkg/snapshot/diskio.go
@@ -1,0 +1,226 @@
+package snapshot
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/Notifiarr/notifiarr/pkg/mnd"
+)
+
+/* This files has procedures to structure data from iotop and iostat. */
+
+// IOTopData is the data structure for iotop output.
+type IOTopData struct {
+	TotalRead  float64    `json:"totalRead"`
+	TotalWrite float64    `json:"totalWrite"`
+	CurrRead   float64    `json:"currentRead"`
+	CurrWrite  float64    `json:"currentWrite"`
+	Processes  IOTopProcs `json:"procs"`
+}
+
+// IOTopProcs is part of IOTopData.
+type IOTopProcs []*IOTopProc
+
+// IOTopProc is part of IOTopData.
+type IOTopProc struct {
+	Pid       int     `json:"pid"`
+	Priority  string  `json:"prio"`
+	User      string  `json:"user"`
+	DiskRead  float64 `json:"diskRead"`
+	DiskWrite float64 `json:"diskWrite"`
+	SwapIn    float64 `json:"swapIn"`
+	IO        float64 `json:"io"`
+	Command   string  `json:"command"`
+}
+
+// IoStatData is the data structure for iostat output.
+type IoStatData struct {
+	Sysstat struct {
+		Hosts []*IoStatHost `json:"hosts"`
+	} `json:"sysstat"`
+}
+
+// IoStatHost is part of IoStatData.
+type IoStatHost struct {
+	Nodename     string `json:"nodename"`
+	Sysname      string `json:"sysname"`
+	Release      string `json:"release"`
+	Machine      string `json:"machine"`
+	NumberOfCpus int    `json:"number-of-cpus"`
+	Date         string `json:"date"`
+	Statistics   []struct {
+		Disk IoStatDisks `json:"disk"`
+	} `json:"statistics"`
+}
+
+// IoStatDisks is part of IoStatData.
+type IoStatDisks []*IoStatDisk
+
+// IoStatDisk is part of IoStatData.
+type IoStatDisk struct {
+	DiskDevice string  `json:"disk_device"`
+	RS         float64 `json:"r/s"`
+	WS         float64 `json:"w/s"`
+	DS         float64 `json:"d/s"`
+	RkBS       float64 `json:"rkB/s"`
+	WkBS       float64 `json:"wkB/s"`
+	DkBS       float64 `json:"dkB/s"`
+	RrqmS      float64 `json:"rrqm/s"`
+	WrqmS      float64 `json:"wrqm/s"`
+	DrqmS      float64 `json:"drqm/s"`
+	Rrqm       float64 `json:"rrqm"`
+	Wrqm       float64 `json:"wrqm"`
+	Drqm       float64 `json:"drqm"`
+	RAwait     float64 `json:"r_await"`
+	WAwait     float64 `json:"w_await"`
+	DAwait     float64 `json:"d_await"`
+	RareqSz    float64 `json:"rareq-sz"`
+	WareqSz    float64 `json:"wareq-sz"`
+	DareqSz    float64 `json:"dareq-sz"`
+	AquSz      float64 `json:"aqu-sz"`
+	Util       float64 `json:"util"`
+}
+
+func (s *Snapshot) getIOTop(ctx context.Context, useSudo bool, procs int) error {
+	if procs < 1 {
+		return nil
+	}
+
+	args := []string{"--batch", "--only", "--iter=1", "--quiet", "--quiet", "--kilobytes", "--processes"}
+
+	cmd, stdout, wg, err := readyCommand(ctx, useSudo, "iotop", args...)
+	if err != nil {
+		return err
+	}
+
+	s.IOTop = &IOTopData{}
+
+	go s.scanIOTop(stdout, wg, procs)
+
+	return runCommand(cmd, wg)
+}
+
+// scanIOTop turns the iotop output into structured data using a Scanner.
+func (s *Snapshot) scanIOTop(stdout *bufio.Scanner, wg *sync.WaitGroup, procs int) {
+	defer wg.Done()
+
+	for stdout.Scan() {
+		text := stdout.Text()
+
+		switch fields := strings.Fields(text); {
+		case strings.Contains(text, "illegal option"):
+			return
+			// it's a bad command wrong OS.
+		case len(fields) < 10, fields[0] == "PID": //nolint:gomnd
+		// PID  PRIO  USER     DISK READ  DISK WRITE  SWAPIN      IO    COMMAND
+		// not enough fields, or header row.
+		case fields[0] == "Total":
+			//	Total DISK READ:         0.00 K/s | Total DISK WRITE:         0.00 K/s
+			s.IOTop.TotalRead, _ = strconv.ParseFloat(fields[3], mnd.Bits64)
+			s.IOTop.TotalWrite, _ = strconv.ParseFloat(fields[9], mnd.Bits64)
+			s.IOTop.TotalRead *= mnd.Kilobyte  // convert to bytes.
+			s.IOTop.TotalWrite *= mnd.Kilobyte // convert to bytes.
+		case fields[0] == "Current":
+			//	Current DISK READ:       0.00 K/s | Current DISK WRITE:       0.00 K/s
+			s.IOTop.CurrRead, _ = strconv.ParseFloat(fields[3], mnd.Bits64)
+			s.IOTop.CurrWrite, _ = strconv.ParseFloat(fields[9], mnd.Bits64)
+			s.IOTop.CurrRead *= mnd.Kilobyte  // convert to bytes.
+			s.IOTop.CurrWrite *= mnd.Kilobyte // convert to bytes.
+		case len(fields) < 12: //nolint:gomnd
+			// not enough fields to do anything else.
+		default:
+			// 780711 be/4 david       0.00 K/s    0.00 K/s  0.00 %  0.00 % pulseaudio --daemonize=no --log-target=journal
+			proc := &IOTopProc{
+				// Pid:   fields[0]
+				Priority: fields[1],
+				User:     fields[2],
+				// DiskRead:  fields[3],
+				// DiskWrite: fields[5],
+				// SwapIn:    fields[7],
+				// IO:        fields[9],
+				Command: strings.Join(fields[11:], " "),
+			}
+			proc.Pid, _ = strconv.Atoi(fields[0])
+			proc.DiskRead, _ = strconv.ParseFloat(fields[3], mnd.Bits64)
+			proc.DiskWrite, _ = strconv.ParseFloat(fields[5], mnd.Bits64)
+			proc.SwapIn, _ = strconv.ParseFloat(fields[7], mnd.Bits64)
+			proc.IO, _ = strconv.ParseFloat(fields[9], mnd.Bits64)
+			proc.DiskRead *= mnd.Kilobyte
+			proc.DiskWrite *= mnd.Kilobyte
+			s.IOTop.Processes = append(s.IOTop.Processes, proc)
+		}
+	}
+	sort.Sort(s.IOTop.Processes)
+	s.IOTop.Processes.Shrink(procs)
+}
+
+func (s *Snapshot) getIoStat(ctx context.Context, run bool) error {
+	if !run || mnd.IsDocker || runtime.GOOS != "linux" {
+		return nil
+	}
+
+	cmdPath, err := exec.LookPath("iostat")
+	if err != nil {
+		// do not throw an error if iostat is missing.
+		// return fmt.Errorf("iostat missing! %w", err)
+		return nil //nolint:nilerr
+	}
+
+	cmd := exec.CommandContext(ctx, cmdPath, "-x", "-d", "-o", "JSON")
+	sysCallSettings(cmd)
+
+	stderr := &bytes.Buffer{}
+	stdout := &bytes.Buffer{}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%v: %w: %s", cmd.Args, err, stderr)
+	}
+
+	var v IoStatData
+	if err = json.NewDecoder(stdout).Decode(&v); err != nil {
+		return fmt.Errorf("%v: output error: %w, %s", cmd.Args, err, stderr)
+	}
+
+	if len(v.Sysstat.Hosts) > 0 && len(v.Sysstat.Hosts[0].Statistics) > 0 {
+		s.IOStat = &v.Sysstat.Hosts[0].Statistics[0].Disk
+	}
+
+	return nil
+}
+
+// Len allows us to sort IOTopProcs.
+func (s IOTopProcs) Len() int {
+	return len(s)
+}
+
+// Swap allows us to sort IOTopProcs.
+func (s IOTopProcs) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Less allows us to sort IOTopProcs.
+func (s IOTopProcs) Less(i, j int) bool {
+	return s[i].DiskRead+s[i].DiskWrite < s[j].DiskRead+s[j].DiskWrite
+}
+
+// Shrink a process list.
+func (s *IOTopProcs) Shrink(size int) {
+	if s == nil {
+		return
+	}
+
+	if len(*s) > size {
+		*s = (*s)[:size]
+	}
+}

--- a/pkg/snapshot/diskusage.go
+++ b/pkg/snapshot/diskusage.go
@@ -25,7 +25,10 @@ func (s *Snapshot) getDisksUsage(ctx context.Context, run bool, allDrives bool) 
 
 	s.DiskUsage = make(map[string]*Partition)
 
-	var errs []error
+	var (
+		errs  []error
+		names = []string{}
+	)
 
 	for i := range partitions {
 		u, err := disk.UsageWithContext(ctx, partitions[i].Mountpoint)
@@ -33,6 +36,8 @@ func (s *Snapshot) getDisksUsage(ctx context.Context, run bool, allDrives bool) 
 			errs = append(errs, fmt.Errorf("unable to get partition usage: %s: %w", partitions[i].Mountpoint, err))
 			continue
 		}
+
+		names = append(names, partitions[i].Device, partitions[i].Mountpoint)
 
 		if u.Total == 0 ||
 			((runtime.GOOS == "darwin" || strings.HasSuffix(runtime.GOOS, "bsd")) &&

--- a/pkg/snapshot/diskusage.go
+++ b/pkg/snapshot/diskusage.go
@@ -25,10 +25,7 @@ func (s *Snapshot) getDisksUsage(ctx context.Context, run bool, allDrives bool) 
 
 	s.DiskUsage = make(map[string]*Partition)
 
-	var (
-		errs  []error
-		names = []string{}
-	)
+	var errs []error
 
 	for i := range partitions {
 		u, err := disk.UsageWithContext(ctx, partitions[i].Mountpoint)
@@ -36,8 +33,6 @@ func (s *Snapshot) getDisksUsage(ctx context.Context, run bool, allDrives bool) 
 			errs = append(errs, fmt.Errorf("unable to get partition usage: %s: %w", partitions[i].Mountpoint, err))
 			continue
 		}
-
-		names = append(names, partitions[i].Device, partitions[i].Mountpoint)
 
 		if u.Total == 0 ||
 			((runtime.GOOS == "darwin" || strings.HasSuffix(runtime.GOOS, "bsd")) &&

--- a/pkg/snapshot/mysql.go
+++ b/pkg/snapshot/mysql.go
@@ -18,8 +18,8 @@ type MySQLConfig struct {
 	Host     string        `toml:"host"`
 	User     string        `toml:"user"`
 	Pass     string        `toml:"pass"`
-	Timeout  cnfg.Duration `toml:"timeout"`
-	Interval cnfg.Duration `toml:"interval"` // only used by service checks.
+	Timeout  cnfg.Duration `toml:"timeout"`  // only used by service checks, snapshot timeout is used for mysql.
+	Interval cnfg.Duration `toml:"interval"` // only used by service checks, snapshot interval is used for mysql.
 }
 
 // MySQLProcesses allows us to manipulate our list with methods.

--- a/pkg/snapshot/mysql.go
+++ b/pkg/snapshot/mysql.go
@@ -1,0 +1,161 @@
+package snapshot
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+
+	// We use mysql driver, this is how it's loaded.
+	_ "github.com/go-sql-driver/mysql"
+	"golift.io/cnfg"
+)
+
+// MySQLConfig allows us to gather a process list for the snapshot.
+type MySQLConfig struct {
+	Name     string        `toml:"name"`
+	Host     string        `toml:"host"`
+	User     string        `toml:"user"`
+	Pass     string        `toml:"pass"`
+	Timeout  cnfg.Duration `toml:"timeout"`
+	Interval cnfg.Duration `toml:"interval"` // only used by service checks.
+}
+
+// MySQLProcesses allows us to manipulate our list with methods.
+type MySQLProcesses []*MySQLProcess
+
+// MySQLProcess represents the data returned from SHOW PROCESS LIST.
+type MySQLProcess struct {
+	ID    int64      `json:"id"`
+	User  string     `json:"user"`
+	Host  string     `json:"host"`
+	DB    NullString `json:"db"`
+	Cmd   string     `json:"command"`
+	Time  int64      `json:"time"`
+	State string     `json:"state"`
+	Info  NullString `json:"info"`
+}
+
+type NullString struct {
+	sql.NullString
+}
+
+// MarshalJSON makes the output from sql.NullString not suck.
+func (n NullString) MarshalJSON() ([]byte, error) {
+	if !n.Valid {
+		return []byte(`"NULL"`), nil
+	}
+
+	return []byte(`"` + n.String + `"`), nil
+}
+
+// GetMySQL grabs the process list from a bunch of servers.
+func (s *Snapshot) GetMySQL(ctx context.Context, servers []*MySQLConfig, limit int) (errs []error) {
+	s.MySQL = make(map[string]MySQLProcesses)
+
+	for _, server := range servers {
+		if server.Host == "" {
+			continue
+		}
+
+		data, err := getMySQL(ctx, server)
+		if err != nil {
+			errs = append(errs, err)
+		}
+
+		if server.Name != "" {
+			s.MySQL[server.Name] = data
+		} else {
+			s.MySQL[server.Host] = data
+		}
+	}
+
+	for _, v := range s.MySQL {
+		sort.Sort(v)
+		v.Shrink(limit)
+	}
+
+	return errs
+}
+
+func getMySQL(ctx context.Context, s *MySQLConfig) (MySQLProcesses, error) {
+	id := s.Host
+	if s.Name != "" {
+		id = s.Name
+	}
+
+	host := "@tcp(" + s.Host + ")"
+	if strings.HasPrefix(s.Host, "@") {
+		host = s.Host
+	}
+
+	db, err := sql.Open("mysql", s.User+":"+s.Pass+host+"/")
+	if err != nil {
+		return nil, fmt.Errorf("mysql server %s: connecting: %w", id, err)
+	}
+	defer db.Close()
+
+	list, err := scanMySQLProcessList(ctx, db)
+	if err != nil {
+		return list, fmt.Errorf("mysql server %s: %w", id, err)
+	}
+
+	return list, nil
+}
+
+func scanMySQLProcessList(ctx context.Context, db *sql.DB) (MySQLProcesses, error) {
+	rows, err := db.QueryContext(ctx, "SHOW PROCESSLIST")
+	if err != nil {
+		return nil, fmt.Errorf("getting processes: %w", err)
+	} else if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("getting processes rows: %w", err)
+	}
+	defer rows.Close()
+
+	var list MySQLProcesses
+
+	for rows.Next() {
+		var p MySQLProcess
+
+		// for each row, scan the result into our tag composite object
+		err := rows.Scan(&p.ID, &p.User, &p.Host, &p.DB, &p.Cmd, &p.Time, &p.State, &p.Info)
+		if err != nil {
+			return nil, fmt.Errorf("scanning rows: %w", err)
+		}
+
+		list = append(list, &p)
+	}
+
+	return list, nil
+}
+
+// Len allows us to sort MySQLProcesses.
+func (s MySQLProcesses) Len() int {
+	return len(s)
+}
+
+// Swap allows us to sort MySQLProcesses.
+func (s MySQLProcesses) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Less allows us to sort MySQLProcesses.
+func (s MySQLProcesses) Less(i, j int) bool {
+	return s[i].Time > s[j].Time
+}
+
+// Shrink a process list.
+func (s *MySQLProcesses) Shrink(size int) {
+	if size == 0 {
+		size = defaultMyLimit
+	}
+
+	if s == nil {
+		return
+	}
+
+	if len(*s) > size {
+		*s = (*s)[:size]
+	}
+}

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -92,7 +92,7 @@ type Snapshot struct {
 	IOStat2    map[string]disk.IOCountersStat `json:"ioStat2,omitempty"`
 	Processes  Processes                      `json:"processes,omitempty"`
 	ZFSPool    map[string]*Partition          `json:"zfsPools,omitempty"`
-	MySQL      map[string]MySQLProcesses      `json:"mysql,omitempty"`
+	MySQL      map[string]*MySQLServerData    `json:"mysql,omitempty"`
 }
 
 // RaidData contains raid information from mdstat and/or megacli.
@@ -131,14 +131,6 @@ func (c *Config) Validate() { //nolint:cyclop
 
 	if mnd.IsDocker || !mnd.IsLinux {
 		c.IOTop = 0
-	}
-
-	if c.Plugins != nil {
-		for _, mysql := range c.Plugins.MySQL {
-			if mysql.Timeout.Duration == 0 {
-				mysql.Timeout.Duration = DefaultTimeout
-			}
-		}
 	}
 }
 

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
-	"runtime"
 	"sync"
 	"time"
 
@@ -115,11 +114,11 @@ func (c *Config) Validate() {
 		c.Interval.Duration = minimumInterval
 	}
 
-	if mnd.IsDocker || runtime.GOOS == mnd.Windows {
+	if mnd.IsDocker || mnd.IsWindows {
 		c.UseSudo = false
 	}
 
-	if mnd.IsDocker || runtime.GOOS != "linux" {
+	if mnd.IsDocker || mnd.IsLinux {
 		c.IOTop = 0
 	}
 }
@@ -139,7 +138,7 @@ func (c *Config) GetSnapshot() (*Snapshot, []error, []error) {
 }
 
 func (c *Config) getSnapshot(ctx context.Context, s *Snapshot) ([]error, []error) {
-	errs := s.GetProcesses(ctx, 10)
+	errs := s.GetProcesses(ctx, c.PSTop)
 	errs = append(errs, s.GetCPUSample(ctx, c.CPUMem))
 
 	if err := s.GetLocalData(ctx, c.Uptime); len(err) != 0 {

--- a/pkg/snapshot/system.go
+++ b/pkg/snapshot/system.go
@@ -2,7 +2,9 @@ package snapshot
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"os/user"
 	"sort"
 	"time"
@@ -121,11 +123,11 @@ func (s *Snapshot) GetProcesses(ctx context.Context, count int) (errs []error) {
 	time.Sleep(4 * time.Second) // nolint:gomnd
 
 	for i, p := range procs {
-		if s.Processes[i].CPUPercent, err = p.PercentWithContext(ctx, 0); err != nil {
+		if s.Processes[i].CPUPercent, err = p.PercentWithContext(ctx, 0); err != nil && !errors.Is(err, os.ErrNotExist) {
 			errs = append(errs, fmt.Errorf("pid %d, cpu percent: %w", p.Pid, err))
 		}
 
-		if s.Processes[i].MemPercent, err = p.MemoryPercentWithContext(ctx); err != nil {
+		if s.Processes[i].MemPercent, err = p.MemoryPercentWithContext(ctx); err != nil && !errors.Is(err, os.ErrNotExist) {
 			errs = append(errs, fmt.Errorf("pid %d, mem percent: %w", p.Pid, err))
 		}
 	}

--- a/pkg/snapshot/system.go
+++ b/pkg/snapshot/system.go
@@ -4,13 +4,26 @@ import (
 	"context"
 	"fmt"
 	"os/user"
+	"sort"
 	"time"
 
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/host"
 	"github.com/shirou/gopsutil/v3/load"
 	"github.com/shirou/gopsutil/v3/mem"
+	"github.com/shirou/gopsutil/v3/process"
 )
+
+// Processes allows us to sort a process list.
+type Processes []*Process
+
+// Process is a PID's basic info.
+type Process struct {
+	Name       string  `json:"name"`
+	Pid        int32   `json:"pid"`
+	MemPercent float32 `json:"memPercent"`
+	CPUPercent float64 `json:"cpuPercent"`
+}
 
 // GetCPUSample gets a CPU percentage sample, CPU Times and Load Average.
 func (s *Snapshot) GetCPUSample(ctx context.Context, run bool) error {
@@ -78,4 +91,73 @@ func (s *Snapshot) GetLocalData(ctx context.Context, run bool) (errs []error) {
 	}
 
 	return errs
+}
+
+// GetProcesses collects 'count' processes by CPU usage.
+func (s *Snapshot) GetProcesses(ctx context.Context, count int) (errs []error) {
+	if count < 1 {
+		return nil
+	}
+
+	procs, err := process.ProcessesWithContext(ctx)
+	if err != nil {
+		return []error{fmt.Errorf("process list: %w", err)}
+	}
+
+	s.Processes = make(Processes, len(procs))
+
+	for i, p := range procs {
+		s.Processes[i] = &Process{Pid: p.Pid}
+
+		if s.Processes[i].Name, err = p.NameWithContext(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("pid %d, no name: %w", p.Pid, err))
+		}
+
+		// This for loop primes the second run of PercentWithContext.
+		// Then sleep a moment, and gather the cpu samples for all PIDs across that moment.
+		_, _ = p.PercentWithContext(ctx, 0)
+	}
+
+	time.Sleep(4 * time.Second) // nolint:gomnd
+
+	for i, p := range procs {
+		if s.Processes[i].CPUPercent, err = p.PercentWithContext(ctx, 0); err != nil {
+			errs = append(errs, fmt.Errorf("pid %d, cpu percent: %w", p.Pid, err))
+		}
+
+		if s.Processes[i].MemPercent, err = p.MemoryPercentWithContext(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("pid %d, mem percent: %w", p.Pid, err))
+		}
+	}
+
+	sort.Sort(s.Processes)
+	s.Processes.Shrink(count)
+
+	return errs
+}
+
+// Len allows us to sort Processes.
+func (s Processes) Len() int {
+	return len(s)
+}
+
+// Swap allows us to sort Processes.
+func (s Processes) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Less allows us to sort Processes.
+func (s Processes) Less(i, j int) bool {
+	return s[i].CPUPercent > s[j].CPUPercent
+}
+
+// Shrink a process list.
+func (s *Processes) Shrink(size int) {
+	if s == nil {
+		return
+	}
+
+	if len(*s) > size {
+		*s = (*s)[:size]
+	}
 }

--- a/pkg/update/check.go
+++ b/pkg/update/check.go
@@ -95,7 +95,7 @@ func FillUpdate(release *GitHubReleasesLatest, version string) (*Update, error) 
 	}
 
 	suffix := OSsuffixMap[runtime.GOOS]
-	if runtime.GOOS == "freebsd" || runtime.GOOS == "linux" {
+	if mnd.IsFreeBSD || mnd.IsLinux {
 		suffix = arch + suffix
 	}
 


### PR DESCRIPTION
So far this adds `iostat` and `iotop` data collection to snapshots for Linux (non-Docker). Also adds "top" (top cpu-using processes), and  includes CPU times for most platforms.  This explains the CPU times data: https://github.com/shirou/gopsutil/blob/fb65e185a90cc6aff00678664869701d491d9a43/v3/cpu/cpu.go#L16-L30

snapshot config payload has two new items: `psTop` and `ioTop`, both integers representing how many processes to return.

`iotop` requires `sudo`. example, make sure to get the path correct:
```
notifiarr ALL=(root) NOPASSWD:/usr/sbin/iotop *
```

Also added mysql "top process list" to snapshots.