### PR TITLE
Fix sonarr commands, other minor fixes.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2021 Go Lift - Building Strong Go Tools
+Copyright (c) 2020-2022 Go Lift - Building Strong Go Tools
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -159,6 +159,70 @@ Debug-log payload sizes from each app can be controlled individually.
 
 _Note: You may disable the GUI (menu item) on Windows by setting the env variable `USEGUI` to `false`._
 
+### System Snapshot
+
+This application can take a snapshot of your system at an interval and send
+you a notification. Snapshot means system health like cpu, memory, disk, raid, users, etc.
+Other data available in the snapshot: mysql health, `iotop`, `iostat` and `top` data.
+Some of this may only be available on Linux, but other platforms have similar abilities.
+
+If you monitor drive health you must have smartmontools (`smartctl`) installed.
+If you use smartctl on Linux, you must enable sudo. Add the sudoers entry below to
+`/etc/sudoers` and fix the path to `smartctl` if yours differs. If you monitor
+raid and use MegaCli (LSI card), add the appropriate sudoers entry for that too.
+
+To monitor application disk I/O you may install `iotop` and add the sudoers entry
+for it, shown below. This feature is enabled on the website.
+
+#### Snapshot Sudoers
+
+The following sudoers entries are used by various snapshot features. Add them if you use the respective feature.
+You can usually just put the following content into `/etc/sudoers` or `/etc/sudoers.d/00-notifiarr`.
+
+```
+# Allows drive health monitoring on macOS, Linux/Docker and FreeBSD.
+notifiarr ALL=(root) NOPASSWD:/usr/sbin/smartctl *
+
+# Allows disk utilization monitoring on Linux (non-Docker).
+notifiarr ALL=(root) NOPASSWD:/usr/sbin/iotop *
+
+# Allows monitoring megaraid volumes on macOS, Linux/Docker and FreeBSD.
+# Rarely needed, and you'll know if you need this.
+notifiarr ALL=(root) NOPASSWD:/usr/sbin/MegaCli64 -LDInfo -Lall -aALL
+```
+
+#### Snapshot Packages
+
+  - **Windows**:  `smartmontools` - get it here https://sourceforge.net/projects/smartmontools/
+  - **Linux**:    Debian/Ubuntu: `apt install smartmontools`, RedHat/CentOS: `yum install smartmontools`
+  - **Docker**:    It's already in the container. Lucky you! Just run it in `--privileged` mode.
+  - **Synology**: `opkg install smartmontools`, but first get Entware:
+    - Entware (synology):  https://github.com/Entware/Entware-ng/wiki/Install-on-Synology-NAS
+    - Entware Package List:  https://github.com/Entware/Entware-ng/wiki/Install-on-Synology-NAS
+
+#### Snapshot Configuration
+
+There is no client configuration for snapshots (except MySQL, below).
+Snapshot configuration is found on the [website](https://notifiarr.com).
+
+#### MySQL Snapshots
+
+You may add mysql credentials to your notifiarr configuration to snapshot mysql
+service health. This feature snapshots `SHOW PROCESSLIST` and `SHOW STATUS` data.
+
+Access to a database is not required. Example Grant:
+
+```
+GRANT PROCESS ON *.* to 'notifiarr'@'localhost'
+```
+
+|Config Name|Variable Name|Note|
+|---|---|---|
+snapshot.mysql.name|`DN_SNAPSHOT_MYSQL_NAME`|Setting a name enables service checks of MySQL|
+snapshot.mysql.host|`DN_SNAPSHOT_MYSQL_HOST`|Something like: `localhost:3306`|
+snapshot.mysql.user|`DN_SNAPSHOT_MYSQL_USER`|Username in the GRANT statement|
+snapshot.mysql.pass|`DN_SNAPSHOT_MYSQL_PASS`|Password for the user in the GRANT statement|
+
 ### Lidarr
 
 |Config Name|Variable Name|Note|
@@ -256,61 +320,6 @@ tautulli.name|`DN_TAUTULLI_NAME`|No Default. Setting a name enables service chec
 tautulli.url|`DN_TAUTULLI_URL`|No Default. Something like: `http://localhost:8181`|
 tautulli.api_key|`DN_TAUTULLI_API_KEY`|No Default. Provide URL and API key if you want name maps from Tautulli|
 
-### System Snapshot
-
-This application can also take a snapshot of your system at an interval and send
-you a notification. Snapshot means system health like cpu, memory, disk, raid, users, etc.
-Other data available in the snapshot: mysql health, `iotop`, `iostat` and `top` data.
-Some of this may only be available on Linux, but other platforms have similar abilities.
-
-If you monitor drive health you must have smartmontools (`smartctl`) installed.
-If you use smartctl on Linux, you must enable sudo. Add this sudoers entry to
-`/etc/sudoers` and fix the path to `smartctl` if yours differs. If you monitor
-raid and use MegaCli (LSI card), add the appropriate sudoers entry for that too.
-
-To monitor application disk I/O you may install `iotop` and add the sudoers entry
-for it, shown below. This feature is enabled on the website.
-
-```
-notifiarr ALL=(root) NOPASSWD:/usr/sbin/smartctl *
-notifiarr ALL=(root) NOPASSWD:/usr/sbin/iotop *
-notifiarr ALL=(root) NOPASSWD:/usr/sbin/MegaCli64 -LDInfo -Lall -aALL
-```
-
-#### Snapshot Packages
-
-  - **Windows**:  `smartmontools` - get it here https://sourceforge.net/projects/smartmontools/
-  - **Linux**:    Debian/Ubuntu: `apt install smartmontools`, RedHat/CentOS: `yum install smartmontools`
-  - **Docker**:    It's already in the container. Lucky you! Just run it in `--privileged` mode.
-  - **Synology**: `opkg install smartmontools`, but first get Entware:
-    - Entware (synology):  https://github.com/Entware/Entware-ng/wiki/Install-on-Synology-NAS
-    - Entware Package List:  https://github.com/Entware/Entware-ng/wiki/Install-on-Synology-NAS
-
-#### Snapshot Configuration
-
-Snapshot configuration is now found on the [website](https://notifiarr.com). - 9/14/2021
-
-#### MySQL Snapshots
-
-You may add mysql credentials to your notifiarr configuration to snapshot mysql
-service health. This feature snapshots `SHOW PROCESSLIST` and `SHOW STATUS` data.
-
-Example Grant:
-
-```
-GRANT PROCESS ON *.* to 'notifiarr'@'localhost'
-```
-
-Access to a database is not required. `SELECT` may not be required.
-
-|Config Name|Variable Name|Note|
-|---|---|---|
-snapshot.mysql.name|`DN_SNAPSHOT_MYSQL_NAME`|Setting a name enables service checks of MySQL|
-snapshot.mysql.host|`DN_SNAPSHOT_MYSQL_HOST`|Something like: `localhost:3306`|
-snapshot.mysql.user|`DN_SNAPSHOT_MYSQL_USER`|Username in the GRANT statement|
-snapshot.mysql.pass|`DN_SNAPSHOT_MYSQL_PASS`|Password for the user in the GRANT statement|
-
-
 ### Service Checks
 
 The Notifiarr client can also check URLs for health. If you set names on your
@@ -404,4 +413,4 @@ Yes, please.
 
 ## License
 
-[MIT](https://github.com/Notifiarr/notifiarr/blob/main/LICENSE) - Copyright (c) 2020-2021 Go Lift
+[MIT](https://github.com/Notifiarr/notifiarr/blob/main/LICENSE) - Copyright (c) 2020-2022 Go Lift

--- a/examples/MANUAL.md
+++ b/examples/MANUAL.md
@@ -14,7 +14,7 @@ system snapshot and Plex session data to Notifiarr for Discord notifications.
 OPTIONS
 ---
 
-`notifiarr [-c <file>] [-w <file>] [--snaps] [--ps] [--cfsync] [--curl <url>] [-h] [-v]`
+`notifiarr [-c <file>] [-w <file>] [--ps] [--curl <url> [--header <header>]] [-h] [-v]`
 
     -c, --config <config file>
         Provide a configuration file (instead of the default).
@@ -24,17 +24,9 @@ OPTIONS
         The default environment variable configuration prefix is `DN`.
         Use this tunable to change it.
 
-    --snaps
-        This flag makes the application output a system snapshot and exit.
-        Useful for debugging and testing.
-
     --ps
         This flags makes the application output the system process list and exit.
         Useful for debugging and testing 'process' service checks.
-
-    --cfsync
-        This flag makes the application send a Custom Format request to
-        Notifiarr.com. Then it exits.
 
     -w, --write <file>
         This flag allows you to read in a config file and re-write it to another file.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	golift.io/deluge v0.9.2
 	golift.io/qbit v0.0.0-20210717220751-d545c7a8f721
 	golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9
-	golift.io/starr v0.11.11
+	golift.io/starr v0.11.12
 	golift.io/version v0.0.2
 )
 
@@ -26,7 +26,7 @@ require (
 	github.com/getlantern/systray v1.1.0
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-toast/toast v0.0.0-20190211030409-01e6764cf0a4 // indirect
-	github.com/godbus/dbus/v5 v5.0.5 // indirect
+	github.com/godbus/dbus/v5 v5.0.6 // indirect
 	github.com/gonutz/w32 v1.0.0
 	github.com/iamacarpet/go-win64api v0.0.0-20210719094426-0fa5b6bd91f5
 	github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af // indirect
@@ -38,7 +38,7 @@ require (
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/google/cabbie v1.0.2 // indirect
-	github.com/google/glazier v0.0.0-20211020141234-79a2756d295f // indirect
+	github.com/google/glazier v0.0.0-20211029225403-9f766cca891d // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20210825203111-a709d8e111b3 // indirect
 	github.com/gopherjs/gopherwasm v1.1.0 // indirect
 	github.com/gorilla/mux v1.8.0
@@ -53,14 +53,16 @@ require (
 	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/scjalliance/comshim v0.0.0-20190308082608-cf06d2532c4e // indirect
-	github.com/shirou/gopsutil/v3 v3.21.9
+	github.com/shirou/gopsutil/v3 v3.21.10
 	github.com/spf13/pflag v1.0.6-0.20201009195203-85dd5c8bc61c
 	github.com/tklauser/go-sysconf v0.3.9 // indirect
 	github.com/tklauser/numcpus v0.3.0 // indirect
 	golang.org/x/mod v0.5.0
 	golang.org/x/net v0.0.0-20210825183410-e898025ed96a // indirect
-	golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e
+	golang.org/x/sys v0.0.0-20211013075003-97ac67df715c
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	howett.net/plist v0.0.0-20201203080718-1454fab16a06 // indirect
 )
+
+require github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZ
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.5 h1:9Eg0XUhQxtkV8ykTMKtMMYY72g4NgxtRq4jgh4Ih5YM=
 github.com/godbus/dbus/v5 v5.0.5/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/godbus/dbus/v5 v5.0.6 h1:mkgN1ofwASrYnJ5W6U/BxG15eXXXjirgZc7CLqkcaro=
+github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -124,6 +126,8 @@ github.com/google/cabbie v1.0.2/go.mod h1:6MmHaUrgfabehCHAIaxdrbmvHSxUVXj3Abs08F
 github.com/google/glazier v0.0.0-20210617205946-bf91b619f5d4/go.mod h1:g7oyIhindbeebnBh0hbFua5rv6XUt/nweDwIWdvxirg=
 github.com/google/glazier v0.0.0-20211020141234-79a2756d295f h1:wgupLmMh1RfLc/M7pQfZf+2hdV9in66rDgl7MGq3a0M=
 github.com/google/glazier v0.0.0-20211020141234-79a2756d295f/go.mod h1:h2R3DLUecGbLSyi6CcxBs5bdgtJhgK+lIffglvAcGKg=
+github.com/google/glazier v0.0.0-20211029225403-9f766cca891d h1:GBIF4RkD4E9USvSRT4O4tBCT77JExIr+qnruI9nkJQo=
+github.com/google/glazier v0.0.0-20211029225403-9f766cca891d/go.mod h1:h2R3DLUecGbLSyi6CcxBs5bdgtJhgK+lIffglvAcGKg=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -210,6 +214,8 @@ github.com/lestrrat-go/envload v0.0.0-20180220234015-a3eb8ddeffcc/go.mod h1:kopu
 github.com/lestrrat-go/strftime v0.0.0-20180821113735-8b31f9c59b0f/go.mod h1:RMlXygAD3c48Psmr06d2G75L4E4xxzxkIe/+ppX9eAU=
 github.com/lestrrat-go/strftime v1.0.5 h1:A7H3tT8DhTz8u65w+JRpiBxM4dINQhUXAZnhBa2xeOE=
 github.com/lestrrat-go/strftime v1.0.5/go.mod h1:E1nN3pCbtMSu1yjSVeyuRFVm/U0xoR76fd03sz+Qz4g=
+github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
+github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
@@ -269,6 +275,8 @@ github.com/scjalliance/comshim v0.0.0-20190308082608-cf06d2532c4e/go.mod h1:9Tc1
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shirou/gopsutil/v3 v3.21.9 h1:Vn4MUz2uXhqLSiCbGFRc0DILbMVLAY92DSkT8bsYrHg=
 github.com/shirou/gopsutil/v3 v3.21.9/go.mod h1:YWp/H8Qs5fVmf17v7JNZzA0mPJ+mS2e9JdiUF9LlKzQ=
+github.com/shirou/gopsutil/v3 v3.21.10 h1:flTg1DrnV/UVrBqjLgVgDJzx6lf+91rC64/dBHmO2IA=
+github.com/shirou/gopsutil/v3 v3.21.10/go.mod h1:t75NhzCZ/dYyPQjyQmrAYP6c8+LCdFANeBMdLPCNnew=
 github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -413,6 +421,8 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e h1:XMgFehsDnnLGtjvjOfqWSUzt0alpTR1RSEuznObga2c=
 golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211013075003-97ac67df715c h1:taxlMj0D/1sOAuv/CbSD+MMDof2vbyPTqz5FNYKpXt8=
+golang.org/x/sys v0.0.0-20211013075003-97ac67df715c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -455,6 +465,8 @@ golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9 h1:j/WeLF6Ew1lc/m8/bh5qleZ
 golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9/go.mod h1:EZevRvIGRh8jDMwuYL0/tlPns0KynquPZzb0SerIC1s=
 golift.io/starr v0.11.11 h1:jw50mPlMuTDKUu9JnZSutzdsQ4r4Ga0BPUPBF78vLcA=
 golift.io/starr v0.11.11/go.mod h1:2ZSbBMYCBGkgA18ihFRL6R4DelptIkAJrtW8wyxU9ew=
+golift.io/starr v0.11.12 h1:K4TYWt72sRXko9oMCLuRWNB2xsi9gmSPN8lN+I2hMvk=
+golift.io/starr v0.11.12/go.mod h1:2ZSbBMYCBGkgA18ihFRL6R4DelptIkAJrtW8wyxU9ew=
 golift.io/version v0.0.2 h1:i0gXRuSDHKs4O0sVDUg4+vNIuOxYoXhaxspftu2FRTE=
 golift.io/version v0.0.2/go.mod h1:76aHNz8/Pm7CbuxIsDi97jABL5Zui3f2uZxDm4vB6hU=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/pkg/apps/lidarr.go
+++ b/pkg/apps/lidarr.go
@@ -66,6 +66,8 @@ func (r *LidarrConfig) setup(timeout time.Duration) {
 		r.StuckItem = true
 	}
 
+	r.URL = strings.TrimRight(r.URL, "/")
+
 	if u, err := r.GetURL(); err != nil {
 		r.Errorf("Checking Lidarr Path: %v", err)
 	} else if u := strings.TrimRight(u, "/"); u != r.URL {

--- a/pkg/apps/radarr.go
+++ b/pkg/apps/radarr.go
@@ -68,6 +68,8 @@ func (r *RadarrConfig) setup(timeout time.Duration) {
 		r.StuckItem = true
 	}
 
+	r.URL = strings.TrimRight(r.URL, "/")
+
 	if u, err := r.GetURL(); err != nil {
 		r.Errorf("Checking Radarr Path: %v", err)
 	} else if u = strings.TrimRight(u, "/"); u != r.URL {

--- a/pkg/apps/readarr.go
+++ b/pkg/apps/readarr.go
@@ -61,6 +61,8 @@ func (r *ReadarrConfig) setup(timeout time.Duration) {
 		r.StuckItem = true
 	}
 
+	r.URL = strings.TrimRight(r.URL, "/")
+
 	if u, err := r.GetURL(); err != nil {
 		r.Errorf("Checking Readarr Path: %v", err)
 	} else if u = strings.TrimRight(u, "/"); u != r.URL {

--- a/pkg/apps/sonarr.go
+++ b/pkg/apps/sonarr.go
@@ -65,6 +65,8 @@ func (r *SonarrConfig) setup(timeout time.Duration) {
 		r.StuckItem = true
 	}
 
+	r.URL = strings.TrimRight(r.URL, "/")
+
 	if u, err := r.GetURL(); err != nil {
 		r.Errorf("Checking Sonarr Path: %v", err)
 	} else if u = strings.TrimRight(u, "/"); u != r.URL {

--- a/pkg/notifiarr/clientinfo.go
+++ b/pkg/notifiarr/clientinfo.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/Notifiarr/notifiarr/pkg/mnd"
@@ -226,6 +227,10 @@ func (c *Config) GetHostInfoUID() (*host.InfoStat, error) {
 		(hostInfo.VirtualizationSystem == "docker" || mnd.IsDocker) {
 		hostInfo.Platform = "Docker " + hostInfo.KernelVersion
 		hostInfo.PlatformFamily = "Docker"
+	}
+
+	if mnd.IsDocker && strings.HasSuffix(hostInfo.KernelVersion, "truenas") && len(hostInfo.Hostname) > 17 {
+		hostInfo.Hostname = hostInfo.Hostname[:len(hostInfo.Hostname)-17]
 	}
 
 	c.extras.hostInfo = hostInfo

--- a/pkg/services/interface.go
+++ b/pkg/services/interface.go
@@ -63,8 +63,8 @@ func (c *Config) SendResults(results *Results) {
 
 	resp, err := c.Notifiarr.SendData(notifiarr.SvcRoute.Path(results.What), results, true)
 	if err != nil {
-		c.Errorf("Sending service check update to Notifiarr, event: %s, buffer: %d/%d, error: %v",
-			results.What, len(c.checks), cap(c.checks), err)
+		c.Errorf("Sending %d service updates to Notifiarr, event: %s, buffer: %d/%d, error: %v",
+			len(results.Svcs), results.What, len(c.checks), cap(c.checks), err)
 		return
 	}
 

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -25,9 +25,6 @@ func (c *Config) Setup(services []*Service) (*notifiarr.ServiceConfig, error) {
 	}
 
 	services = append(services, c.collectApps()...)
-	if len(services) == 0 {
-		c.Disabled = true
-	}
 
 	return c.setup(services)
 }


### PR DESCRIPTION
- Allows sonarr commands to work from the website (fixes TBA/refreshseries).
- Minor REDME updates because @bakerboy448 is dyslexic.
- Service check updates are now sent even if no services are present.
- URLs that are correct no longer generate startup warnings.
- Random hostnames generated by Kubernetes on TrueNAS are fixed.
  - Other Kube uses will still not work well.
- Library updates.