### PR TITLE
fix bug causing crash in snapshot

### DIFF
--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -9,6 +9,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"sync"
@@ -157,7 +158,7 @@ func (c *Config) getSnapshot(ctx context.Context, s *Snapshot) ([]error, []error
 		errs = append(errs, err...)
 	}
 
-	if syn, err := GetSynology(c.Uptime); err != nil {
+	if syn, err := GetSynology(c.Uptime); err != nil && !errors.Is(err, ErrNotSynology) {
 		errs = append(errs, err)
 	} else if syn != nil {
 		syn.SetInfo(s.System.InfoStat)

--- a/pkg/snapshot/synology.go
+++ b/pkg/snapshot/synology.go
@@ -12,6 +12,8 @@ import (
 	"github.com/shirou/gopsutil/v3/host"
 )
 
+var ErrNotSynology = fmt.Errorf("the running host is not a Synology")
+
 // Synology is the data we care about from the config file.
 type Synology struct {
 	Build   string `json:"last_admin_login_build"` // 254263
@@ -30,7 +32,7 @@ type Synology struct {
 // GetSynology checks if the app is running on a Synology, and gets system info.
 func GetSynology(run bool) (*Synology, error) { //nolint:cyclop
 	if !run || !mnd.IsSynology {
-		return &Synology{}, nil
+		return nil, ErrNotSynology
 	}
 
 	file, err := os.Open(mnd.Synology)


### PR DESCRIPTION
Fixes a bug.
```
[INFO] 2021/12/22 12:21:15 [cron requested] Gathering and sending System Snapshot.
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x7af2f5]

goroutine 71 [running]:
github.com/Notifiarr/notifiarr/pkg/snapshot.(*Synology).SetInfo(...)
	github.com/Notifiarr/notifiarr/pkg/snapshot/synology.go:79
github.com/Notifiarr/notifiarr/pkg/snapshot.(*Config).getSnapshot(0xc00054e0a0, {0xa0a228, 0xc01a816960}, 0xc01a836280)
	github.com/Notifiarr/notifiarr/pkg/snapshot/snapshot.go:163 +0x315
github.com/Notifiarr/notifiarr/pkg/snapshot.(*Config).GetSnapshot(0xc00054e0a0)
	github.com/Notifiarr/notifiarr/pkg/snapshot/snapshot.go:147 +0x145
github.com/Notifiarr/notifiarr/pkg/notifiarr.(*Config).sendSnapshot(0xc0002d6380, {0x951476, 0x4})
	github.com/Notifiarr/notifiarr/pkg/notifiarr/snapcron.go:43 +0x4d
github.com/Notifiarr/notifiarr/pkg/notifiarr.(*Config).runTimerLoop(0xc0002d6380, {0xc00018a100, 0x0, 0x0}, {0xc0000a0700, 0x11, 0x20})
	github.com/Notifiarr/notifiarr/pkg/notifiarr/timers.go:208 +0x282
created by github.com/Notifiarr/notifiarr/pkg/notifiarr.(*Config).startTimers
	github.com/Notifiarr/notifiarr/pkg/notifiarr/timers.go:101 +0xc75
```