### PR TITLE
fix deluge service check bug, and other bugs.

### DIFF
--- a/pkg/client/cli.go
+++ b/pkg/client/cli.go
@@ -26,11 +26,9 @@ var (
 
 // forceWriteWithExit is called only when a user passes --write on the command line.
 func (c *Client) forceWriteWithExit(fileName string) error {
-	if fileName == "-" {
-		fileName = c.Flags.ConfigFile
-	} else if fileName == "example" || fileName == "---" {
+	if fileName == "example" || fileName == "---" {
 		// Bubilding a default template.
-		fileName = c.Flags.ConfigFile
+		fileName = c.Flags.ConfigFile + ".new"
 		c.Config.LogFile = ""
 		c.Config.LogConfig.DebugLog = ""
 		c.Config.HTTPLog = ""
@@ -40,8 +38,8 @@ func (c *Client) forceWriteWithExit(fileName string) error {
 	}
 
 	f, err := c.Config.Write(fileName)
-	if err != nil { // f purposely shadowed.
-		return fmt.Errorf("writing config: %s: %w", f, err)
+	if err != nil {
+		return fmt.Errorf("writing config: %w", err)
 	}
 
 	c.Print("Wrote Config File:", f)

--- a/pkg/configfile/config.go
+++ b/pkg/configfile/config.go
@@ -33,8 +33,6 @@ const (
 	MsgConfigFound  = "Using Config File: "
 )
 
-var ErrFileExists = fmt.Errorf("file exists, refusing to overwrite")
-
 // Config represents the data in our config file.
 type Config struct {
 	BindAddr   string              `json:"bindAddr" toml:"bind_addr" xml:"bind_addr" yaml:"bindAddr"`

--- a/pkg/plex/plex.go
+++ b/pkg/plex/plex.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	"golift.io/cnfg"
@@ -58,6 +59,8 @@ func (s *Server) Configured() bool {
 
 // Validate checks input values and starts the cron interval if it's configured.
 func (s *Server) Validate() { //nolint:cyclop
+	s.URL = strings.TrimRight(s.URL, "/")
+
 	if s.SeriesPC > maximumComplete {
 		s.SeriesPC = maximumComplete
 	} else if s.SeriesPC != 0 && s.SeriesPC < minimumComplete {

--- a/pkg/services/apps.go
+++ b/pkg/services/apps.go
@@ -115,7 +115,7 @@ func (c *Config) collectDownloadApps(svcs []*Service) []*Service {
 			svcs = append(svcs, &Service{
 				Name:     d.Name,
 				Type:     CheckHTTP,
-				Value:    d.Config.URL,
+				Value:    strings.TrimSuffix(d.Config.URL, "/json"),
 				Expect:   "200",
 				Timeout:  cnfg.Duration{Duration: d.Timeout.Duration},
 				Interval: d.Interval,


### PR DESCRIPTION
Deluge service checks are returning a 405 Method Not Allowed. This fixes it. Confirmed twice.

Added two more fixes:
1. Do not overwrite files with config writing feature. Closes #151.
2. Strip slashes off the end of the Plex URL.