### PR TITLE
Add starr app database backup corruption check.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 // home grown goodness.
 require (
 	golift.io/cnfg v0.1.1-0.20220103045145-0c0d80e8da3f
-	golift.io/deluge v0.9.3
+	golift.io/deluge v0.9.4-0.20220103091211-1842b313e264
 	golift.io/qbit v0.0.0-20211121074815-1558e8969b98
 	golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9
 	golift.io/starr v0.12.2-0.20220103050138-44b7a8ef1c52

--- a/go.sum
+++ b/go.sum
@@ -666,6 +666,10 @@ golift.io/cnfg v0.1.1-0.20220103045145-0c0d80e8da3f h1:lC5ZHwgsKkSgh7sUKFe74jMcE
 golift.io/cnfg v0.1.1-0.20220103045145-0c0d80e8da3f/go.mod h1:cjgsYXSEgyWJEbSk+QehZuGN26jw+1CzwceGCbJ0Lck=
 golift.io/deluge v0.9.3 h1:yO8S3x4ikGCWI4W7SmtNFVaaCeiudWUn5Zt3S5HmRQ8=
 golift.io/deluge v0.9.3/go.mod h1:4AEg/gqM2FiqLGAGT8ZYrYmeSVS8vTqTtG+nItc8CAk=
+golift.io/deluge v0.9.4-0.20220103090915-06a14c005fa3 h1:N7kO5wePH7oZD9MFU3AjvITKZPnW91DVBABNr1rokl8=
+golift.io/deluge v0.9.4-0.20220103090915-06a14c005fa3/go.mod h1:4AEg/gqM2FiqLGAGT8ZYrYmeSVS8vTqTtG+nItc8CAk=
+golift.io/deluge v0.9.4-0.20220103091211-1842b313e264 h1:rWXCarms5PwR/Vl6nA7cpSEZP4lB0Elio7MyitGbSyA=
+golift.io/deluge v0.9.4-0.20220103091211-1842b313e264/go.mod h1:4AEg/gqM2FiqLGAGT8ZYrYmeSVS8vTqTtG+nItc8CAk=
 golift.io/qbit v0.0.0-20211121074815-1558e8969b98 h1:Nr+zd738zKl3DVd1+DOp5vbkEmD7eAW4M4LEfh78JMs=
 golift.io/qbit v0.0.0-20211121074815-1558e8969b98/go.mod h1:dUZrJv4PE34QTxUSFXPSWw6P8kd0LFLR9CBOxD3HxYw=
 golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9 h1:j/WeLF6Ew1lc/m8/bh5qleZ66aSeJ72B1fUWigF69OE=

--- a/pkg/notifiarr/backups.go
+++ b/pkg/notifiarr/backups.go
@@ -98,6 +98,7 @@ func (c *Config) sendLidarrBackups(event EventType) {
 				name:  starr.Lidarr,
 				int:   i + 1,
 				app:   app,
+				cName: app.Name,
 			})
 		}
 	}
@@ -111,6 +112,7 @@ func (c *Config) sendProwlarrBackups(event EventType) {
 				name:  starr.Prowlarr,
 				int:   i + 1,
 				app:   app,
+				cName: app.Name,
 			})
 		}
 	}
@@ -124,6 +126,7 @@ func (c *Config) sendRadarrBackups(event EventType) {
 				name:  starr.Radarr,
 				int:   i + 1,
 				app:   app,
+				cName: app.Name,
 			})
 		}
 	}
@@ -137,6 +140,7 @@ func (c *Config) sendReadarrBackups(event EventType) {
 				name:  starr.Readarr,
 				int:   i + 1,
 				app:   app,
+				cName: app.Name,
 			})
 		}
 	}


### PR DESCRIPTION
This contribution adds a new feature that allows Notifiarr client to download backup files from starr apps. It then extracts those files, and checks the sqlite database file for corruption. Corrupt databases trigger notifications in your Discord. Closes #142. Also closes #148. Closes #155 by adding `-e` flag and formatting durations in two other libraries: https://github.com/golift/starr/pull/23, https://github.com/golift/cnfg/commit/ad131bdf6bbc936c2c4647e3c3cb715d7ebc70f1, plus a few changes locally.

This also adds prowler support. Service checks and corruption check at this point. It has no API methods.

Requires https://github.com/golift/starr/pull/17 and https://github.com/golift/starr/pull/22