### PR TITLE
Compose template

### DIFF
--- a/examples/compose.yml
+++ b/examples/compose.yml
@@ -1,0 +1,10 @@
+  notifiarr:
+    container_name: notifiarr
+    hostname: notifiarr
+    image: golift/notifiarr
+    restart: unless-stopped
+    ports:
+      - "5454:5454"
+    volumes:
+      - ${APPDATA}/notifiarr:/config
+      - /var/run/utmp:/var/run/utmp


### PR DESCRIPTION
Adds a basic docker-compose template for the notifiarr client.

This foregoes more advanced options such as SYS_RAWIO capabilities or passing through of devices for smart monitoring.