### PR TITLE
Add config option to serialize operations.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	golift.io/deluge v0.9.4-0.20220103091211-1842b313e264
 	golift.io/qbit v0.0.0-20211121074815-1558e8969b98
 	golift.io/rotatorr v0.0.0-20210307012029-65b11a8ea8f9
-	golift.io/starr v0.13.1-0.20220117233154-f0fdc3b60b5c
+	golift.io/starr v0.13.1-0.20220205092923-cc43b6cff8e7
 	golift.io/version v0.0.2
 	golift.io/xtractr v0.0.11
 )

--- a/go.sum
+++ b/go.sum
@@ -678,6 +678,8 @@ golift.io/starr v0.13.1-0.20220117212508-f1d3ae11b103 h1:Nr5oYDKYTIcUcAi019ujfWV
 golift.io/starr v0.13.1-0.20220117212508-f1d3ae11b103/go.mod h1:IZIzdT5/NBdhM08xAEO5R1INgGN+Nyp4vCwvgHrbKVs=
 golift.io/starr v0.13.1-0.20220117233154-f0fdc3b60b5c h1:7qtem+mFuWd/m3ZS2NuzFwBfqvmij9ecjFYZ+SwGGU0=
 golift.io/starr v0.13.1-0.20220117233154-f0fdc3b60b5c/go.mod h1:IZIzdT5/NBdhM08xAEO5R1INgGN+Nyp4vCwvgHrbKVs=
+golift.io/starr v0.13.1-0.20220205092923-cc43b6cff8e7 h1:m1iNfB7cVl9fxZ/dNOE9DX4UwQlxF/NpP/LCu5rrySU=
+golift.io/starr v0.13.1-0.20220205092923-cc43b6cff8e7/go.mod h1:IZIzdT5/NBdhM08xAEO5R1INgGN+Nyp4vCwvgHrbKVs=
 golift.io/version v0.0.2 h1:i0gXRuSDHKs4O0sVDUg4+vNIuOxYoXhaxspftu2FRTE=
 golift.io/version v0.0.2/go.mod h1:76aHNz8/Pm7CbuxIsDi97jABL5Zui3f2uZxDm4vB6hU=
 golift.io/xtractr v0.0.11 h1:6SVjqX7aCT7Zl4y1rVunBnzwAqK56m90IMywbgeh3r8=

--- a/pkg/client/handlers_trash.go
+++ b/pkg/client/handlers_trash.go
@@ -54,33 +54,44 @@ func (c *Client) aggregateTrash(req *http.Request) (int, interface{}) {
 func (c *Client) aggregateTrashSonarr(ctx context.Context, wait *sync.WaitGroup,
 	instances notifiarr.IntList) []*notifiarr.SonarrTrashPayload {
 	output := []*notifiarr.SonarrTrashPayload{}
+
 	// Create our known+requested instances, so we can write slice values in go routines.
-	for i, app := range c.Config.Apps.Sonarr {
-		if instance := i + 1; instances.Has(instance) {
+	for idx, app := range c.Config.Apps.Sonarr {
+		if instance := idx + 1; instances.Has(instance) {
 			output = append(output, &notifiarr.SonarrTrashPayload{Instance: instance, Name: app.Name})
 		}
 	}
 
-	var err error
 	// Grab data for each requested instance in parallel/go routine.
 	for idx := range output {
+		if c.Config.Serial {
+			c.aggregateTrashSonarrCall(ctx, idx, output[idx].Instance, wait, output)
+			continue
+		}
+
 		wait.Add(1)
 
-		go func(idx, instance int) {
-			defer wait.Done()
-			// Add the profiles, and/or error into our data structure/output data.
-			app := c.Config.Apps.Sonarr[instance-1]
-			if output[idx].QualityProfiles, err = app.GetQualityProfilesContext(ctx); err != nil {
-				output[idx].Error = fmt.Sprintf("getting quality profiles: %v", err)
-				c.Errorf("Handling Sonarr API request (%d): %s", instance, output[idx].Error)
-			} else if output[idx].ReleaseProfiles, err = app.GetReleaseProfilesContext(ctx); err != nil {
-				output[idx].Error = fmt.Sprintf("getting release profiles: %v", err)
-				c.Errorf("Handling Sonarr API request (%d): %s", instance, output[idx].Error)
-			}
-		}(idx, output[idx].Instance)
+		go c.aggregateTrashSonarrCall(ctx, idx, output[idx].Instance, wait, output)
 	}
 
 	return output
+}
+
+func (c *Client) aggregateTrashSonarrCall(ctx context.Context,
+	idx, instance int, wait *sync.WaitGroup, output []*notifiarr.SonarrTrashPayload) {
+	defer wait.Done()
+
+	var err error
+
+	// Add the profiles, and/or error into our data structure/output data.
+	app := c.Config.Apps.Sonarr[instance-1]
+	if output[idx].QualityProfiles, err = app.GetQualityProfilesContext(ctx); err != nil {
+		output[idx].Error = fmt.Sprintf("getting quality profiles: %v", err)
+		c.Errorf("Handling Sonarr API request (%d): %s", instance, output[idx].Error)
+	} else if output[idx].ReleaseProfiles, err = app.GetReleaseProfilesContext(ctx); err != nil {
+		output[idx].Error = fmt.Sprintf("getting release profiles: %v", err)
+		c.Errorf("Handling Sonarr API request (%d): %s", instance, output[idx].Error)
+	}
 }
 
 // This is basically a duplicate of the above code.
@@ -94,24 +105,34 @@ func (c *Client) aggregateTrashRadarr(ctx context.Context, wait *sync.WaitGroup,
 		}
 	}
 
-	var err error
 	// Grab data for each requested instance in parallel/go routine.
 	for idx := range output {
+		if c.Config.Serial {
+			c.aggregateTrashRadarrCall(ctx, idx, output[idx].Instance, wait, output)
+			continue
+		}
+
 		wait.Add(1)
 
-		go func(idx, instance int) {
-			defer wait.Done()
-			// Add the profiles, and/or error into our data structure/output data.
-			app := c.Config.Apps.Radarr[instance-1]
-			if output[idx].QualityProfiles, err = app.GetQualityProfilesContext(ctx); err != nil {
-				output[idx].Error = fmt.Sprintf("getting quality profiles: %v", err)
-				c.Errorf("Handling Radarr API request (%d): %s", instance, output[idx].Error)
-			} else if output[idx].CustomFormats, err = app.GetCustomFormatsContext(ctx); err != nil {
-				output[idx].Error = fmt.Sprintf("getting custom formats: %v", err)
-				c.Errorf("Handling Radarr API request (%d): %s", instance, output[idx].Error)
-			}
-		}(idx, output[idx].Instance)
+		go c.aggregateTrashRadarrCall(ctx, idx, output[idx].Instance, wait, output)
 	}
 
 	return output
+}
+
+func (c *Client) aggregateTrashRadarrCall(ctx context.Context,
+	idx, instance int, wait *sync.WaitGroup, output []*notifiarr.RadarrTrashPayload) {
+	defer wait.Done()
+
+	var err error
+
+	// Add the profiles, and/or error into our data structure/output data.
+	app := c.Config.Apps.Radarr[instance-1]
+	if output[idx].QualityProfiles, err = app.GetQualityProfilesContext(ctx); err != nil {
+		output[idx].Error = fmt.Sprintf("getting quality profiles: %v", err)
+		c.Errorf("Handling Radarr API request (%d): %s", instance, output[idx].Error)
+	} else if output[idx].CustomFormats, err = app.GetCustomFormatsContext(ctx); err != nil {
+		output[idx].Error = fmt.Sprintf("getting custom formats: %v", err)
+		c.Errorf("Handling Radarr API request (%d): %s", instance, output[idx].Error)
+	}
 }

--- a/pkg/configfile/config.go
+++ b/pkg/configfile/config.go
@@ -43,6 +43,8 @@ type Config struct {
 	Mode       string              `json:"mode" toml:"mode" xml:"mode" yaml:"mode"`
 	Upstreams  []string            `json:"upstreams" toml:"upstreams" xml:"upstreams" yaml:"upstreams"`
 	Timeout    cnfg.Duration       `json:"timeout" toml:"timeout" xml:"timeout" yaml:"timeout"`
+	Serial     bool                `json:"serial" toml:"serial" xml:"serial" yaml:"serial"`
+	Retries    int                 `json:"retries" toml:"retries" xml:"retries" yaml:"retries"`
 	Plex       *plex.Server        `json:"plex" toml:"plex" xml:"plex" yaml:"plex"`
 	Snapshot   *snapshot.Config    `json:"snapshot" toml:"snapshot" xml:"snapshot" yaml:"snapshot"`
 	Services   *services.Config    `json:"services" toml:"services" xml:"services" yaml:"services"`
@@ -123,6 +125,8 @@ func (c *Config) Get(flag *Flags) (*notifiarr.Config, error) {
 		BaseURL:  notifiarr.BaseURL,
 		Timeout:  c.Timeout,
 		MaxBody:  c.MaxBody,
+		Retries:  c.Retries,
+		Serial:   c.Serial,
 		Services: svcs,
 	}
 	c.setup()

--- a/pkg/configfile/template.go
+++ b/pkg/configfile/template.go
@@ -57,7 +57,7 @@ bind_addr = "{{.BindAddr}}"
 ##
 quiet = {{.Quiet}}{{if .Debug}}
 
-## Debug prints more data and json payloads. Recommend setting debug_log if enabled.
+## Debug prints more data and json payloads. This increases application memory usage.
 debug = true
 max_body = {{ .MaxBody }} # maximum body size for debug logs. 0 = no limit.{{end}}{{if and .Mode (ne .Mode "production")}}
 
@@ -104,6 +104,10 @@ file_mode = "{{.FileMode.String}}"
 ## Web server and application timeouts.
 ##
 timeout = "{{.Timeout}}"
+
+## Setting serial to true makes the app use fewer threads when polling apps.
+## This spreads CPU usage out and uses a bit less memory.
+serial = {{.Serial}}
 
 
 ##################

--- a/pkg/notifiarr/notifiarr.go
+++ b/pkg/notifiarr/notifiarr.go
@@ -48,6 +48,7 @@ type Config struct {
 	Plex     *plex.Server     // plex sessions
 	Snap     *snapshot.Config // system snapshot data
 	Services *ServiceConfig
+	Serial   bool
 	Retries  int
 	BaseURL  string
 	Timeout  cnfg.Duration

--- a/pkg/notifiarr/notifiarr.go
+++ b/pkg/notifiarr/notifiarr.go
@@ -203,7 +203,8 @@ func (c *Config) setClientInfoTimerTriggers() {
 
 	if c.clientInfo.Actions.Dashboard.Interval.Duration > 0 {
 		c.Trigger.get(TrigDashboard).T = time.NewTicker(c.clientInfo.Actions.Dashboard.Interval.Duration)
-		c.Printf("==> Sending Current State Data for Dashboard, interval:%s", c.clientInfo.Actions.Dashboard.Interval)
+		c.Printf("==> Sending Current State Data for Dashboard, interval:%s, serial:%v",
+			c.clientInfo.Actions.Dashboard.Interval, c.Serial)
 	}
 
 	if len(c.clientInfo.Actions.Custom) > 0 { // This is not directly triggerable.
@@ -246,18 +247,16 @@ func (c *Config) makeCustomClientInfoTimerTriggers() {
 
 // Stop all internal cron timers and Triggers.
 func (c *Config) Stop(event EventType) {
+	// Neither of these if statemens should ever fire. That's a bug somewhere else.
 	if c == nil {
-		return
+		panic("Config is nil, cannot stop a nil config!!")
+	} else if c.Trigger.stop == nil {
+		panic("Notifiarr Timers cannot be stopped: not running!!")
 	}
 
-	c.Print("==> Stopping Notifiarr Timers.")
-
-	if c.Trigger.stop == nil {
-		c.Error("==> Notifiarr Timers cannot be stopped: not running!")
-		return
-	}
-
+	// This closes runTimerLoop() and fires stopTimerLoop().
 	c.Trigger.stop.C <- event
+	// Closes the Plex session holder.
 	defer close(c.Trigger.sess)
 	c.Trigger.sess = nil
 }

--- a/pkg/notifiarr/stuckitems.go
+++ b/pkg/notifiarr/stuckitems.go
@@ -95,6 +95,15 @@ func (c *Config) sendStuckQueueItems(event EventType) {
 
 // getQueues fires a routine for each app type and tries to get a lot of data fast!
 func (c *Config) getQueues() *QueuePayload {
+	if c.Serial {
+		return &QueuePayload{
+			Lidarr:  c.getFinishedItemsLidarr(),
+			Radarr:  c.getFinishedItemsRadarr(),
+			Readarr: c.getFinishedItemsReadarr(),
+			Sonarr:  c.getFinishedItemsSonarr(),
+		}
+	}
+
 	cue := &QueuePayload{}
 
 	var wg sync.WaitGroup

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -115,7 +115,13 @@ func (u *Command) replaceFile(ctx context.Context) (string, error) {
 		_ = os.Chmod(tempFile, mnd.Mode0755)
 	}
 
-	backupFile := u.Path + ".backup." + time.Now().Format("060102T150405")
+	suff := ""
+	if strings.HasSuffix(u.Path, ".exe") {
+		suff = ".exe"
+	}
+
+	backupFile := strings.TrimSuffix(u.Path, ".exe")
+	backupFile += ".backup." + time.Now().Format("060102T150405") + suff
 	u.Printf("[Update] Renaming %s => %s", u.Path, backupFile)
 
 	if err := os.Rename(u.Path, backupFile); err != nil {


### PR DESCRIPTION
The app currently runs many things in parallel, like getting data from all starr apps for dashboard. 

This contribution adds a flag stop running (probably) all routines in parallel and run them serially only.
This affects:
- dashboard
- trash aggregate api endpoint (used by website)
- the version api endpoint (used by website)
- stuck items check

This also includes an [update to the starr library](https://github.com/golift/starr/pull/35) that uses less memory when debug is disabled.