### PR TITLE
Switch custom cron timers to POST.

### DIFF
--- a/pkg/configfile/template.go
+++ b/pkg/configfile/template.go
@@ -125,7 +125,7 @@ timeout = "{{.Timeout}}"
 ## Set apt to true to enable this integration. A true setting causes
 ## notifiarr to relay apt package install/update hooks to notifiarr.com.
 ##
-apt = "{{.EnableApt}}"
+apt = {{.EnableApt}}
 {{- end}}
 
 ## Setting serial to true makes the app use fewer threads when polling apps.

--- a/pkg/notifiarr/notifiarr.go
+++ b/pkg/notifiarr/notifiarr.go
@@ -229,7 +229,8 @@ func (c *Config) makeCustomClientInfoTimerTriggers() {
 	}
 
 	for _, custom := range c.clientInfo.Actions.Custom {
-		custom.setup(c)
+		custom.c, custom.ch = c, make(chan EventType, 1)
+		custom.URI = "/" + strings.TrimPrefix(custom.URI, "/")
 
 		var ticker *time.Ticker
 
@@ -241,7 +242,7 @@ func (c *Config) makeCustomClientInfoTimerTriggers() {
 		}
 
 		c.Trigger.add(&action{
-			Name: TriggerName(fmt.Sprintf("Running Custom Cron Timer '%s' GET %s", custom.Name, custom.URI)),
+			Name: TriggerName(fmt.Sprintf("Running Custom Cron Timer '%s' POST %s", custom.Name, custom.URI)),
 			Fn:   custom.run,
 			C:    custom.ch,
 			T:    ticker,

--- a/pkg/notifiarr/timers.go
+++ b/pkg/notifiarr/timers.go
@@ -43,8 +43,7 @@ type timerConfig struct {
 	URI      string        `json:"endpoint"` // endpoint for the URI.
 	Desc     string        `json:"description"`
 	ch       chan EventType
-	getdata  func(string) (*Response, error)
-	errorf   func(string, ...interface{})
+	c        *Config
 }
 
 type action struct {
@@ -67,14 +66,14 @@ func (t *timerConfig) Run(event EventType) {
 
 // run responds to the channel that the timer fired into.
 func (t *timerConfig) run(event EventType) {
-	if _, err := t.getdata(t.URI); err != nil {
-		t.errorf("[%s requested] Custom Timer Request for %s failed: %v", event, t.URI, err)
+	if _, err := t.c.SendData(t.URI, []byte("cronthingy"), true); err != nil {
+		t.c.Errorf("[%s requested] Custom Timer Request for %s failed: %v", event, t.URI, err)
 	}
 }
 
 // setup makes sure a timer has info to do it's job and log results.
 func (t *timerConfig) setup(c *Config) {
-	t.URI, t.errorf, t.getdata = c.BaseURL+"/"+t.URI, c.Errorf, c.GetData
+	t.URI, t.c = c.BaseURL+"/"+t.URI, c
 	t.ch = make(chan EventType, 1)
 }
 

--- a/pkg/notifiarr/timers.go
+++ b/pkg/notifiarr/timers.go
@@ -66,15 +66,10 @@ func (t *timerConfig) Run(event EventType) {
 
 // run responds to the channel that the timer fired into.
 func (t *timerConfig) run(event EventType) {
-	if _, err := t.c.SendData(t.URI, []byte("cronthingy"), true); err != nil {
+	payload := struct{ Cron string }{Cron: "thingy"}
+	if _, err := t.c.SendData(t.URI, payload, true); err != nil {
 		t.c.Errorf("[%s requested] Custom Timer Request for %s failed: %v", event, t.URI, err)
 	}
-}
-
-// setup makes sure a timer has info to do it's job and log results.
-func (t *timerConfig) setup(c *Config) {
-	t.URI, t.c = c.BaseURL+"/"+t.URI, c
-	t.ch = make(chan EventType, 1)
 }
 
 // runTimers converts all the tickers and triggers into []reflect.SelectCase.

--- a/pkg/notifiarr/website.go
+++ b/pkg/notifiarr/website.go
@@ -115,6 +115,7 @@ func (c *Config) getMetaSnap(ctx context.Context) *snapshot.Snapshot {
 	return snap
 }
 
+/*
 func (c *Config) GetData(url string) (*Response, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout.Duration)
 	defer cancel()
@@ -150,6 +151,7 @@ func (c *Config) GetData(url string) (*Response, error) {
 
 	return unmarshalResponse(http.MethodGet, url, resp.StatusCode, io.NopCloser(tee))
 }
+*/
 
 // SendData sends raw data to a notifiarr URL as JSON.
 func (c *Config) SendData(uri string, payload interface{}, log bool) (*Response, error) {

--- a/pkg/notifiarr/website.go
+++ b/pkg/notifiarr/website.go
@@ -189,18 +189,18 @@ func (c *Config) SendData(uri string, payload interface{}, log bool) (*Response,
 		return nil, err
 	}
 
-	return unmarshalResponse(http.MethodPost, c.BaseURL+uri, code, body)
+	return unmarshalResponse(c.BaseURL+uri, code, body)
 }
 
 // unmarshalResponse attempts to turn the reply from notifiarr.com into structured data.
-func unmarshalResponse(method, url string, code int, body io.ReadCloser) (*Response, error) {
+func unmarshalResponse(url string, code int, body io.ReadCloser) (*Response, error) {
 	defer body.Close()
 
 	var r Response
 
 	counter := datacounter.NewReaderCounter(body)
 	defer func() {
-		exp.NotifiarrCom.Add(method+" Bytes Received", int64(counter.Count()))
+		exp.NotifiarrCom.Add("POST Bytes Received", int64(counter.Count()))
 	}()
 
 	err := json.NewDecoder(counter).Decode(&r)
@@ -372,7 +372,7 @@ func (c *Config) SetValuesContext(ctx context.Context, values map[string][]byte)
 		return fmt.Errorf("inalid response (%d): %w", code, err)
 	}
 
-	_, err = unmarshalResponse(http.MethodPost, c.BaseURL+ClientRoute.Path("getStates"), code, body)
+	_, err = unmarshalResponse(c.BaseURL+ClientRoute.Path("getStates"), code, body)
 
 	return err
 }
@@ -402,7 +402,7 @@ func (c *Config) DelValueContext(ctx context.Context, keys ...string) error {
 		return fmt.Errorf("inalid response (%d): %w", code, err)
 	}
 
-	_, err = unmarshalResponse(http.MethodPost, c.BaseURL+ClientRoute.Path("setStates"), code, body)
+	_, err = unmarshalResponse(c.BaseURL+ClientRoute.Path("setStates"), code, body)
 	if err != nil {
 		return err
 	}
@@ -430,7 +430,7 @@ func (c *Config) GetValueContext(ctx context.Context, keys ...string) (map[strin
 		return nil, fmt.Errorf("inalid response (%d): %w", code, err)
 	}
 
-	resp, err := unmarshalResponse(http.MethodPost, c.BaseURL+ClientRoute.Path("getStates"), code, body)
+	resp, err := unmarshalResponse(c.BaseURL+ClientRoute.Path("getStates"), code, body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This switches custom cron timers from GET to POST so they contain host info.