### PR TITLE
Move Starr checks after flag checks.

### DIFF
--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -110,6 +110,12 @@ func (c *Client) start() error { //nolint:cyclop
 	}
 
 	c.Logger.SetupLogging(c.Config.LogConfig)
+
+	// Make sure each app has a sane timeout.
+	if err = c.Config.Apps.Setup(c.Config.Timeout.Duration); err != nil {
+		return fmt.Errorf("setting up app: %w", err)
+	}
+
 	c.Printf("%s v%s-%s Starting! [PID: %v] %v",
 		c.Flags.Name(), version.Version, version.Revision, os.Getpid(), time.Now())
 	c.Printf("==> %s", msg)

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -110,15 +110,15 @@ func (c *Client) start() error { //nolint:cyclop
 	}
 
 	c.Logger.SetupLogging(c.Config.LogConfig)
+	c.Printf("%s v%s-%s Starting! [PID: %v] %v",
+		c.Flags.Name(), version.Version, version.Revision, os.Getpid(), time.Now())
+	c.Printf("==> %s", msg)
 
 	// Make sure each app has a sane timeout.
 	if err = c.Config.Apps.Setup(c.Config.Timeout.Duration); err != nil {
 		return fmt.Errorf("setting up app: %w", err)
 	}
 
-	c.Printf("%s v%s-%s Starting! [PID: %v] %v",
-		c.Flags.Name(), version.Version, version.Revision, os.Getpid(), time.Now())
-	c.Printf("==> %s", msg)
 	c.printUpdateMessage()
 
 	if err := c.loadAssetsTemplates(); err != nil {

--- a/pkg/configfile/config.go
+++ b/pkg/configfile/config.go
@@ -129,12 +129,6 @@ func (c *Config) Get(flag *Flags) (*notifiarr.Config, error) {
 		return nil, fmt.Errorf("environment variables: %w", err)
 	}
 
-	// Make sure each app has a sane timeout.
-	err := c.Apps.Setup(c.Timeout.Duration)
-	if err != nil {
-		return nil, fmt.Errorf("setting up app: %w", err)
-	}
-
 	if err := c.setupPassword(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Starr app checks happen on every invocation of the client, even -version. This fixes that by moving the starr app setup to after the startup flags are checked.