### PR TITLE
Channelize all website comms

### DIFF
--- a/pkg/client/client_other.go
+++ b/pkg/client/client_other.go
@@ -52,12 +52,16 @@ func (c *Client) handleAptHook() error {
 		} //nolint:wsl
 	}
 
-	resp, err := c.website.SendData(website.PkgRoute.Path("apt"), output, true)
+	resp, _, err := c.website.RawGetData(&website.Request{
+		Route:   website.PkgRoute,
+		Event:   "apt",
+		Payload: output,
+	})
 	//nolint:forbidigo
 	if err != nil {
-		fmt.Printf("ERROR Sending Notification to website.com: %v%s\n", err, resp)
+		fmt.Printf("ERROR Sending Notification to notifiarr.com: %v%s\n", err, resp)
 	} else {
-		fmt.Printf("Sent notification to website.com; install: %d, remove: %d%s\n",
+		fmt.Printf("Sent notification to notifiarr.com; install: %d, remove: %d%s\n",
 			output.Install, output.Remove, resp)
 	}
 

--- a/pkg/client/handlers_plex.go
+++ b/pkg/client/handlers_plex.go
@@ -80,7 +80,7 @@ func (c *Client) PlexHandler(w http.ResponseWriter, r *http.Request) { //nolint:
 	case strings.EqualFold(v.Event, "admin.database.corrupt"):
 		c.Printf("Plex Incoming Webhook: %s, %s '%s' ~> %s (relaying to Notifiarr)",
 			v.Server.Title, v.Account.Title, v.Event, v.Metadata.Title)
-		c.website.QueueData(&website.SendRequest{
+		c.website.SendData(&website.Request{
 			Route:      website.PlexRoute,
 			Event:      website.EventHook,
 			LogPayload: true,

--- a/pkg/client/tray.go
+++ b/pkg/client/tray.go
@@ -294,13 +294,13 @@ func (c *Client) watchGuiChannels() {
 		case <-menu["gh"].ClickedCh:
 			go ui.OpenURL("https://github.com/Notifiarr/notifiarr/")
 		case <-menu["hp"].ClickedCh:
-			go ui.OpenURL("https://website.com/")
+			go ui.OpenURL("https://notifiarr.com/")
 		case <-menu["wiki"].ClickedCh:
-			go ui.OpenURL("https://website.wiki/")
+			go ui.OpenURL("https://notifiarr.wiki/")
 		case <-menu["trash"].ClickedCh:
 			go ui.OpenURL("https://trash-guides.info/Notifiarr/Quick-Start/")
 		case <-menu["disc1"].ClickedCh:
-			go ui.OpenURL("https://website.com/discord")
+			go ui.OpenURL("https://notifiarr.com/discord")
 		case <-menu["disc2"].ClickedCh:
 			go ui.OpenURL("https://golift.io/discord")
 		case <-menu["sub"].ClickedCh:

--- a/pkg/logs/share/share.go
+++ b/pkg/logs/share/share.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Website interface {
-	QueueData(data *website.SendRequest)
+	SendData(data *website.Request)
 	HaveClientInfo() bool
 }
 
@@ -24,7 +24,7 @@ func Log(msg string) {
 		return
 	}
 
-	config.QueueData(&website.SendRequest{
+	config.SendData(&website.Request{
 		Payload:    &filewatch.Match{File: "client_error_log", Line: msg, Matches: []string{"[ERROR]"}},
 		Route:      website.LogLineRoute,
 		Event:      website.EventFile,

--- a/pkg/services/interface.go
+++ b/pkg/services/interface.go
@@ -148,7 +148,7 @@ func (s *Service) copyResults() *CheckResult {
 func (c *Config) SendResults(results *Results) {
 	results.Interval = c.Interval.Seconds()
 
-	c.Website.QueueData(&website.SendRequest{
+	c.Website.SendData(&website.Request{
 		Route:      website.SvcRoute,
 		Event:      results.What,
 		LogPayload: true,

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -115,7 +115,7 @@ func (c *Config) loadServiceStates() {
 
 	values, err := c.Website.GetValue(names...)
 	if err != nil {
-		c.Errorf("Getting initial service states from website.com: %v", err)
+		c.Errorf("Getting initial service states from website: %v", err)
 		return
 	}
 

--- a/pkg/triggers/backups/backups.go
+++ b/pkg/triggers/backups/backups.go
@@ -215,7 +215,7 @@ func (c *cmd) sendBackups(input *genericInstance) {
 		Files: fileList,
 	}
 
-	c.QueueData(&website.SendRequest{
+	c.SendData(&website.Request{
 		Route:      website.BackupRoute,
 		Event:      input.event,
 		LogPayload: true,

--- a/pkg/triggers/backups/corruption.go
+++ b/pkg/triggers/backups/corruption.go
@@ -238,7 +238,7 @@ func (c *cmd) sendAndLogAppCorruption(input *genericInstance) string {
 	backup.File = latest
 	backup.Date = fileList[0].Time.Round(time.Second)
 
-	c.QueueData(&website.SendRequest{
+	c.SendData(&website.Request{
 		Route:      website.CorruptRoute,
 		Event:      input.event,
 		LogPayload: true,

--- a/pkg/triggers/cfsync/radarr.go
+++ b/pkg/triggers/cfsync/radarr.go
@@ -73,7 +73,11 @@ func (c *cmd) syncRadarrCF(instance int, app *apps.RadarrConfig) error {
 		return fmt.Errorf("getting custom formats: %w", err)
 	}
 
-	body, err := c.SendData(website.CFSyncRoute.Path("", "app=radarr"), payload, false)
+	body, err := c.GetData(&website.Request{
+		Route:   website.CFSyncRoute,
+		Params:  []string{"app=radarr"},
+		Payload: payload,
+	})
 	if err != nil {
 		return fmt.Errorf("sending current formats: %w", err)
 	}
@@ -155,10 +159,12 @@ func (c *cmd) postbackRadarrCF(instance int, maps *cfMapIDpayload) error {
 		return nil
 	}
 
-	_, err := c.SendData(website.CFSyncRoute.Path("", "app=radarr", "updateIDs=true"), &RadarrTrashPayload{
-		Instance: instance,
-		NewMaps:  maps,
-	}, true)
+	_, err := c.GetData(&website.Request{
+		Route:      website.CFSyncRoute,
+		Params:     []string{"app=radarr", "updateIDs=true"},
+		Payload:    &RadarrTrashPayload{Instance: instance, NewMaps: maps},
+		LogPayload: true,
+	})
 	if err != nil {
 		c.radarrCF[instance] = maps
 		return fmt.Errorf("updating custom format ID map: %w", err)

--- a/pkg/triggers/cfsync/sonarr.go
+++ b/pkg/triggers/cfsync/sonarr.go
@@ -71,7 +71,11 @@ func (c *cmd) syncSonarrRP(instance int, app *apps.SonarrConfig) error {
 		return fmt.Errorf("getting release profiles: %w", err)
 	}
 
-	body, err := c.SendData(website.CFSyncRoute.Path("", "app=sonarr"), payload, false)
+	body, err := c.GetData(&website.Request{
+		Route:   website.CFSyncRoute,
+		Params:  []string{"app=sonarr"},
+		Payload: payload,
+	})
 	if err != nil {
 		return fmt.Errorf("sending current profiles: %w", err)
 	}
@@ -153,10 +157,12 @@ func (c *cmd) postbackSonarrRP(instance int, maps *cfMapIDpayload) error {
 		return nil
 	}
 
-	_, err := c.SendData(website.CFSyncRoute.Path("", "app=sonarr", "updateIDs=true"), &SonarrTrashPayload{
-		Instance: instance,
-		NewMaps:  maps,
-	}, true)
+	_, err := c.GetData(&website.Request{
+		Route:      website.CFSyncRoute,
+		Params:     []string{"app=sonarr", "updateIDs=true"},
+		Payload:    &SonarrTrashPayload{Instance: instance, NewMaps: maps},
+		LogPayload: true,
+	})
 	if err != nil {
 		c.sonarrRP[instance] = maps
 		return fmt.Errorf("updating quality release ID map: %w", err)

--- a/pkg/triggers/common/triggers.go
+++ b/pkg/triggers/common/triggers.go
@@ -84,3 +84,7 @@ func (c *Config) Stop(event website.EventType) {
 	<-c.stop.C // wait for done signal.
 	c.stop = nil
 }
+
+func (c *Config) SetClientInfo(ci *website.ClientInfo) {
+	c.ClientInfo = ci
+}

--- a/pkg/triggers/crontimer/custom.go
+++ b/pkg/triggers/crontimer/custom.go
@@ -54,7 +54,7 @@ func (t *Timer) Run(event website.EventType) {
 
 // run responds to the channel that the timer fired into.
 func (t *Timer) run(event website.EventType) {
-	t.website.QueueData(&website.SendRequest{
+	t.website.SendData(&website.Request{
 		Route:      website.Route(t.CronTimer.URI),
 		Event:      event,
 		Payload:    &struct{ Cron string }{Cron: "thingy"},

--- a/pkg/triggers/dashboard/dashboard.go
+++ b/pkg/triggers/dashboard/dashboard.go
@@ -159,7 +159,7 @@ func (c *Cmd) sendDashboardState(event website.EventType) {
 		apps   = time.Since(start).Round(time.Millisecond)
 	)
 
-	c.QueueData(&website.SendRequest{
+	c.SendData(&website.Request{
 		Route:      website.DashRoute,
 		Event:      event,
 		LogPayload: true,

--- a/pkg/triggers/filewatch/filewatch.go
+++ b/pkg/triggers/filewatch/filewatch.go
@@ -273,7 +273,7 @@ func (c *cmd) checkLineMatch(line *tail.Line, tail *WatchFile) {
 		Matches: tail.re.FindAllString(line.Text, -1),
 	}
 
-	c.QueueData(&website.SendRequest{
+	c.SendData(&website.Request{
 		Route:      website.LogLineRoute,
 		Event:      website.EventFile,
 		LogPayload: tail.LogMatch,

--- a/pkg/triggers/gaps/gaps.go
+++ b/pkg/triggers/gaps/gaps.go
@@ -80,7 +80,7 @@ func (c *cmd) sendGaps(event website.EventType) {
 			continue
 		}
 
-		c.QueueData(&website.SendRequest{
+		c.SendData(&website.Request{
 			Route:      website.DashRoute,
 			Event:      event,
 			LogPayload: true,

--- a/pkg/triggers/plexcron/meta.go
+++ b/pkg/triggers/plexcron/meta.go
@@ -61,7 +61,12 @@ func (c *cmd) sendPlexMeta(
 
 	wg.Wait()
 
-	return c.SendData(website.PlexRoute.Path(event), payload, true) //nolint:wrapcheck
+	return c.GetData(&website.Request{ //nolint:wrapcheck
+		Route:      website.PlexRoute,
+		Event:      event,
+		Payload:    payload,
+		LogPayload: true,
+	})
 }
 
 // getMetaSnap grabs some basic system info: cpu, memory, username.

--- a/pkg/triggers/plexcron/plexcron.go
+++ b/pkg/triggers/plexcron/plexcron.go
@@ -295,15 +295,17 @@ func (c *cmd) sendSessionDone(session *plex.Session) string {
 	snap := c.getMetaSnap(ctx)
 	cancel() //nolint:wsl
 
-	route := website.PlexRoute.Path(website.EventType(session.Type))
-
-	_, err := c.SendData(route, &website.Payload{
-		Snap: snap,
-		Plex: &plex.Sessions{Name: c.Plex.Name, Sessions: []*plex.Session{session}},
-	}, true)
-	if err != nil {
-		return statusError + ": sending to " + route + ": " + err.Error()
-	}
+	c.SendData(&website.Request{
+		Route: website.PlexRoute,
+		Event: website.EventType(session.Type),
+		Payload: &website.Payload{
+			Snap: snap,
+			Plex: &plex.Sessions{Name: c.Plex.Name, Sessions: []*plex.Session{session}},
+		},
+		LogMsg:     "Plex Completed Sessions",
+		LogPayload: true,
+		ErrorsOnly: true,
+	})
 
 	return statusSending
 }

--- a/pkg/triggers/snapcron/snapcron.go
+++ b/pkg/triggers/snapcron/snapcron.go
@@ -99,7 +99,7 @@ func (c *cmd) sendSnapshot(event website.EventType) {
 		}
 	}
 
-	c.QueueData(&website.SendRequest{
+	c.SendData(&website.Request{
 		Route:      website.SnapRoute,
 		Event:      event,
 		LogPayload: true,

--- a/pkg/triggers/stuckitems/stuckitems.go
+++ b/pkg/triggers/stuckitems/stuckitems.go
@@ -127,7 +127,7 @@ func (c *cmd) sendStuckQueueItems(event website.EventType) {
 		return
 	}
 
-	c.QueueData(&website.SendRequest{
+	c.SendData(&website.Request{
 		Route:      website.StuckRoute,
 		Event:      event,
 		LogPayload: true,

--- a/pkg/website/clientinfo.go
+++ b/pkg/website/clientinfo.go
@@ -131,7 +131,12 @@ func (s *Server) GetClientInfo() (*ClientInfo, error) {
 		return s.clientInfo, nil
 	}
 
-	body, err := s.SendData(ClientRoute.Path("reload"), s.Info(), true)
+	body, err := s.GetData(&Request{
+		Route:      ClientRoute,
+		Event:      EventStart,
+		Payload:    s.Info(),
+		LogPayload: true,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("sending client info: %w", err)
 	}
@@ -257,7 +262,12 @@ func (s *Server) GetHostInfo() (*host.InfoStat, error) { //nolint:cyclop
 }
 
 func (s *Server) PollForReload(event EventType) {
-	body, err := s.SendData(ClientRoute.Path(EventPoll), s.Info(), true)
+	body, err := s.GetData(&Request{
+		Route:      ClientRoute,
+		Event:      EventPoll,
+		Payload:    s.Info(),
+		LogPayload: true,
+	})
 	if err != nil {
 		s.config.Errorf("[%s requested] Polling Notifiarr: %v", event, err)
 		return

--- a/pkg/website/website_routes.go
+++ b/pkg/website/website_routes.go
@@ -36,14 +36,23 @@ type Payload struct {
 	Load *plex.IncomingWebhook `json:"payload,omitempty"`
 }
 
-// SendRequest is used when sending data through a channel.
-type SendRequest struct {
+// Request is used when sending data through a channel.
+type Request struct {
 	Route      Route
 	Event      EventType
 	Params     []string    // optional.
 	Payload    interface{} // data to send.
 	LogMsg     string      // if empty, nothing is logged.
 	LogPayload bool        // debug log the sent payload
+	ErrorsOnly bool        // only log errors.
+	respChan   chan *chResponse
+}
+
+// chResponse is used to send a website response through a channel.
+type chResponse struct {
+	*Response
+	Elapsed time.Duration
+	Error   error
 }
 
 // Route is used to give us methods on our route paths.


### PR DESCRIPTION
This moves the send data function to use a channel. All requests to the website are now handled in a single go routine.