### PR TITLE
Adds support for multiple megaraid virtual disks.

### DIFF
--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -180,8 +180,16 @@ func (c *Client) loadSiteConfig() *website.ClientInfo {
 	}
 
 	if clientInfo.Actions.Snapshot != nil {
-		clientInfo.Actions.Snapshot.Plugins = c.Config.Snapshot.Plugins // use local data for plugins.
-		c.Config.Snapshot = clientInfo.Actions.Snapshot
+		c.Config.Snapshot.Interval.Duration = clientInfo.Actions.Snapshot.Interval.Duration
+		c.Config.Snapshot.ZFSPools = clientInfo.Actions.Snapshot.ZFSPools
+		c.Config.Snapshot.UseSudo = clientInfo.Actions.Snapshot.UseSudo
+		c.Config.Snapshot.Raid = clientInfo.Actions.Snapshot.Raid
+		c.Config.Snapshot.DriveData = clientInfo.Actions.Snapshot.DriveData
+		c.Config.Snapshot.DiskUsage = clientInfo.Actions.Snapshot.DiskUsage
+		c.Config.Snapshot.AllDrives = clientInfo.Actions.Snapshot.AllDrives
+		c.Config.Snapshot.IOTop = clientInfo.Actions.Snapshot.IOTop
+		c.Config.Snapshot.PSTop = clientInfo.Actions.Snapshot.PSTop
+		c.Config.Snapshot.MyTop = clientInfo.Actions.Snapshot.MyTop
 	}
 
 	if clientInfo.Actions.Plex != nil && c.Config.Plex != nil {

--- a/pkg/snapshot/raid.go
+++ b/pkg/snapshot/raid.go
@@ -1,11 +1,13 @@
 package snapshot
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"io/ioutil"
 	"os/exec"
 	"strings"
+	"sync"
 )
 
 func (s *Snapshot) getRaidData(ctx context.Context, useSudo, run bool) error {
@@ -60,6 +62,15 @@ Disk Cache Policy   : Enabled
 Encryption Type     : None
 Is VD Cached: No.
 */
+
+// MegaCLI represents the megaraid cli output.
+type MegaCLI struct {
+	Drive   string
+	Target  string
+	Adapter string
+	Data    map[string]string
+}
+
 func (s *Snapshot) getRaidMegaCLI(ctx context.Context, useSudo bool) error {
 	megacli, err := exec.LookPath("MegaCli64")
 	for _, s := range []string{"MegaCli", "megacli", "megacli64"} {
@@ -80,16 +91,47 @@ func (s *Snapshot) getRaidMegaCLI(ctx context.Context, useSudo bool) error {
 		return err
 	}
 
-	s.Raid.MegaCLI = make(map[string]string)
-
-	go func() {
-		for stdout.Scan() {
-			if split := strings.Split(strings.TrimSpace(stdout.Text()), ":"); len(split) == 2 { // nolint:gomnd
-				s.Raid.MegaCLI[strings.TrimSpace(split[0])] = strings.TrimSpace(split[1])
-			}
-		}
-		waitg.Done()
-	}()
+	go s.scanMegaCLI(stdout, waitg)
 
 	return runCommand(cmd, waitg)
+}
+
+func (s *Snapshot) scanMegaCLI(stdout *bufio.Scanner, waitg *sync.WaitGroup) {
+	var (
+		adapter string
+		current *MegaCLI
+	)
+
+	for stdout.Scan() {
+		text := stdout.Text()
+		if strings.HasPrefix(text, "Adapter ") {
+			if split := strings.Fields(text); len(split) > 1 {
+				adapter = split[1]
+			}
+
+			continue
+		}
+
+		if strings.HasPrefix(text, "Virtual Drive:") {
+			if current != nil {
+				s.Raid.MegaCLI = append(s.Raid.MegaCLI, current)
+			}
+
+			split := strings.Fields(text)
+			current = &MegaCLI{
+				Drive:   split[2],
+				Target:  strings.TrimRight(split[5], ")"),
+				Adapter: adapter,
+				Data:    make(map[string]string),
+			}
+
+			continue
+		}
+
+		if split := strings.Split(strings.TrimSpace(stdout.Text()), ":"); len(split) == 2 { // nolint:gomnd
+			current.Data[strings.TrimSpace(split[0])] = strings.TrimSpace(split[1])
+		}
+	}
+
+	waitg.Done()
 }

--- a/pkg/snapshot/raid.go
+++ b/pkg/snapshot/raid.go
@@ -65,10 +65,10 @@ Is VD Cached: No.
 
 // MegaCLI represents the megaraid cli output.
 type MegaCLI struct {
-	Drive   string
-	Target  string
-	Adapter string
-	Data    map[string]string
+	Drive   string            `json:"drive"`
+	Target  string            `json:"target"`
+	Adapter string            `json:"adapter"`
+	Data    map[string]string `json:"data"`
 }
 
 func (s *Snapshot) getRaidMegaCLI(ctx context.Context, useSudo bool) error {
@@ -131,6 +131,10 @@ func (s *Snapshot) scanMegaCLI(stdout *bufio.Scanner, waitg *sync.WaitGroup) {
 		if split := strings.Split(strings.TrimSpace(stdout.Text()), ":"); len(split) == 2 { // nolint:gomnd
 			current.Data[strings.TrimSpace(split[0])] = strings.TrimSpace(split[1])
 		}
+	}
+
+	if current != nil {
+		s.Raid.MegaCLI = append(s.Raid.MegaCLI, current)
 	}
 
 	waitg.Done()

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -61,7 +61,8 @@ type Plugins struct {
 var (
 	ErrPlatformUnsup = fmt.Errorf("the requested metric is not available on this platform, " +
 		"if you know how to collect it, please open an issue on the github repo")
-	ErrNonZeroExit = fmt.Errorf("cmd exited non-zero")
+	ErrNonZeroExit   = fmt.Errorf("cmd exited non-zero")
+	ErrMegaCLIOutput = fmt.Errorf("megaraid CLI output nor parseable")
 )
 
 // Snapshot is the output data sent to Notifiarr.
@@ -95,8 +96,8 @@ type Snapshot struct {
 
 // RaidData contains raid information from mdstat and/or megacli.
 type RaidData struct {
-	MDstat  string            `json:"mdstat,omitempty"`
-	MegaCLI map[string]string `json:"megacli,omitempty"`
+	MDstat  string     `json:"mdstat,omitempty"`
+	MegaCLI []*MegaCLI `json:"megacli,omitempty"`
 }
 
 // Partition is used for ZFS pools as well as normal Disk arrays.

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -61,8 +61,7 @@ type Plugins struct {
 var (
 	ErrPlatformUnsup = fmt.Errorf("the requested metric is not available on this platform, " +
 		"if you know how to collect it, please open an issue on the github repo")
-	ErrNonZeroExit   = fmt.Errorf("cmd exited non-zero")
-	ErrMegaCLIOutput = fmt.Errorf("megaraid CLI output nor parseable")
+	ErrNonZeroExit = fmt.Errorf("cmd exited non-zero")
 )
 
 // Snapshot is the output data sent to Notifiarr.


### PR DESCRIPTION
Closes #226 by exposing all the virtual disks to the website. Also fixes snapshots that were broken in a previous commit.