### PR TITLE
Allow disabling instances.

### DIFF
--- a/pkg/bindata/files/css/style.css
+++ b/pkg/bindata/files/css/style.css
@@ -243,6 +243,9 @@ a:hover {
 .text-yellow {
   color: #ffff00;
 }
+.text-orange {
+  color: #c38502;
+}
 .title .line {
   display: inline-block;
   padding-bottom: 10px;

--- a/pkg/bindata/files/js/golists.js
+++ b/pkg/bindata/files/js/golists.js
@@ -119,7 +119,7 @@ function addInstance(section, app)
         let nameval = ""
         let nameori = ""
         let extra = ""
-        let itype = "text"
+        let itype = "<input type=\"text\""
 
         // Blank items in the name list add a colspan to the next item.
         if (name == "") {
@@ -135,7 +135,7 @@ function addInstance(section, app)
             case "Password":
             case "APIKey":
                 extra = '<div style="width:35px; max-width:35px;" class="input-group-addon input-sm" onClick="togglePassword(\''+ prefix +'.'+ app +'.'+ index +'.'+ name + '\', $(this).find(\'i\'));"><i class="fas fa-low-vision secret-input"></i></div>';
-                itype = "password";
+                itype = "<input type=\"password\"";
                 break;
             case "Config.Interval":
             case "Interval":
@@ -144,8 +144,17 @@ function addInstance(section, app)
              break;
              case "Config.Timeout":
              case "Timeout":
-                nameval = "1m";
                 nameori = "1m";
+                itype = "<select type=\"select\""
+                extra = '<option value="-1s">Disabled</option><option value="0s">No Timeout</option><option selected value="1s">1 second</option>';
+                for (i = 2 ; i < 60 ; i++) {
+                    extra += '<option value="'+i+'s">'+i+' seconds</option>';
+                }
+                extra += '<option selected value="1m">1 minute</option>';
+                for (i = 1 ; i < 60 ; i++) {
+                    extra += '<option value="1m'+i+'s">1 min '+i+' sec</option>';
+                }
+                extra += '</select>';
              break;
              case "Config.URL":
              case "URL":
@@ -156,7 +165,7 @@ function addInstance(section, app)
         }
 
         row += '<td colspan="'+ colspan +'"><form class="form-inline"><div class="form-group" style="width:100%"><div class="input-group" style="width:100%">';
-        row += '<input type="'+ itype +'" name="'+ prefix +'.'+ app +'.'+ index +'.'+ name +'" '+
+        row += itype +'" name="'+ prefix +'.'+ app +'.'+ index +'.'+ name +'" '+
         'id="'+ prefix +'.'+ app +'.'+ index +'.'+ name +'" '+
         'name="'+ prefix +'.'+ app +'.'+ index +'.'+ name +'" '+
         'data-app="'+ app +'" data-index="'+ index +'" class="client-parameter form-control input-sm" data-group="'+ section +'" data-label="'+ app +' '+
@@ -271,11 +280,20 @@ function addCommand()
                     '<option selected value="false">Disabled</option></select>';
                 break;
             case "Timeout":
-                row += '<input type="text" name="Commands.'+ index +'.'+ name +'" '+
+                row += '<select type="select" name="Commands.'+ index +'.'+ name +'" '+
                     'id="Commands.'+ index +'.'+ name +'" '+
                     'name="Commands.'+ index +'.'+ name +'" '+
                     'data-app="Commands" data-index="'+ index +'" class="client-parameter form-control input-sm" data-group="commands" data-label="Command '+
-                    instance +' '+name+'" data-original="20s" value="20s">';
+                    instance +' '+name+'" data-original="20s" value="20s"><option value="0s">No Timeout</option><option value="1s">1 second</option>'+
+                    '<option value="2s">2 seconds</option><option value="3s">3 seconds</option><option value="4s">4 seconds</option>'+
+                    '<option value="5s">5 seconds</option><option value="6s">6 seconds</option><option value="7s">7 seconds</option>'+
+                    '<option value="8s">8 seconds</option><option value="9s">9 seconds</option><option value="10s">10 seconds</option>'+
+                    '<option value="15s">15 seconds</option><option value="20s">20 seconds</option><option value="25s">25 seconds</option>'+
+                    '<option value="30s">30 seconds</option><option value="45s">45 seconds</option><option value="1m">1 minute</option>'+
+                    '<option value="1m15s">1 min 15 sec</option><option value="1m30s">1 min 30 sec</option><option value="1m45s">1 min 45 sec</option>'+
+                    '<option value="2m">2 minutes</option><option value="2m30s">2 min 30 sec</option><option value="3m">3 minutes</option>'+
+                    '<option value="3m">4 minutes</option><option value="3m">5 minutes</option><option value="3m">6 minutes</option>'+
+                    '<option value="3m">7 minutes</option></select>';
                     break;
             case "Command":
                 extra = '<div onClick="browseFiles(\'#Commands\\\\.'+index+'\\\\.Command\');" style="max-width:35px;width:35px;cursor:pointer;font-size:16px;" class="input-group-addon input-sm"><a class="help-icon fas fa-folder-open"></a></div>';

--- a/pkg/bindata/templates/commands.html
+++ b/pkg/bindata/templates/commands.html
@@ -6,8 +6,8 @@
                                 </p>
                                 <hr>
                                 <p>
-                                    <h3><i class="fas fa-comment"></i> Notes</h3>
-                                    <li><i class="fas fa-star"></i> The <span class="text-brand">purple</span> button will not run a command that has been modified. Save & Reload first!</li>
+                                    <h3><i class="fas fa-comment text-orange"></i> Notes</h3>
+                                    <li><i class="fas fa-star text-dgrey"></i> The <span class="text-brand">purple</span> button will not run a command that has been modified. Save & Reload first!</li>
                                 </p>
                                 <div class="table-responsive">
                                     <table class="table bk-dark table-bordered">
@@ -63,8 +63,8 @@
                                                     <a onClick="dialog($(this), 'right')" class="help-icon far fa-question-circle"></a>
                                                     <span class="dialogTitle">Notify</span>
                                                 </td>
-                                                <td style="min-width:90px;width:90px;">
-                                                    <div style="display:none;" class="dialogText">Maximum amount of time to wait for the command to run. Recommend less than 60s.</div>
+                                                <td style="min-width:120px;width:120px;">
+                                                    <div style="display:none;" class="dialogText">Maximum amount of time to wait for the command to run. Recommend less than 1 minute.</div>
                                                     <a onClick="dialog($(this), 'right')" class="help-icon far fa-question-circle"></a>
                                                     <span class="dialogTitle">Timeout</span>
                                                 </td>
@@ -196,7 +196,35 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_COMMAND_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <input type="text" id="Commands.{{$index}}.Timeout" name="Commands.{{$index}}.Timeout" data-index="{{$index}}" data-app="Commands" class="client-parameter form-control input-sm" data-group="commands" data-label="Command {{instance $index}} Timeout" data-original="{{$app.Timeout}}" value="{{$app.Timeout}}">
+                                                                <select type="select" id="Commands.{{$index}}.Timeout" name="Commands.{{$index}}.Timeout" data-index="{{$index}}" data-app="Commands" class="client-parameter form-control input-sm" data-group="commands" data-label="Command {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                    <option value="0s">No Timeout</option>
+                                                                    <option value="1s">1 second</option>
+                                                                    <option value="2s">2 seconds</option>
+                                                                    <option value="3s">3 seconds</option>
+                                                                    <option value="4s">4 seconds</option>
+                                                                    <option value="5s">5 seconds</option>
+                                                                    <option value="6s">6 seconds</option>
+                                                                    <option value="7s">7 seconds</option>
+                                                                    <option value="8s">8 seconds</option>
+                                                                    <option value="9s">9 seconds</option>
+                                                                    <option value="10s">10 seconds</option>
+                                                                    <option value="15s">15 seconds</option>
+                                                                    <option value="20s">20 seconds</option>
+                                                                    <option value="25s">25 seconds</option>
+                                                                    <option value="30s">30 seconds</option>
+                                                                    <option value="45s">45 seconds</option>
+                                                                    <option value="1m">1 minute</option>
+                                                                    <option value="1m15s">1 min 15 sec</option>
+                                                                    <option value="1m30s">1 min 30 sec</option>
+                                                                    <option value="1m45s">1 min 45 sec</option>
+                                                                    <option value="2m">2 minutes</option>
+                                                                    <option value="2m30s">2 min 30 sec</option>
+                                                                    <option value="3m">3 minutes</option>
+                                                                    <option value="3m">4 minutes</option>
+                                                                    <option value="3m">5 minutes</option>
+                                                                    <option value="3m">6 minutes</option>
+                                                                    <option value="3m">7 minutes</option>
+                                                                </select>
                                                             </div>
                                                         </div>
                                                     </form>

--- a/pkg/bindata/templates/commands.html
+++ b/pkg/bindata/templates/commands.html
@@ -197,33 +197,33 @@
                                                                 </div>
                                                                 {{- end}}
                                                                 <select type="select" id="Commands.{{$index}}.Timeout" name="Commands.{{$index}}.Timeout" data-index="{{$index}}" data-app="Commands" class="client-parameter form-control input-sm" data-group="commands" data-label="Command {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
-                                                                    <option value="0s">No Timeout</option>
-                                                                    <option value="1s">1 second</option>
-                                                                    <option value="2s">2 seconds</option>
-                                                                    <option value="3s">3 seconds</option>
-                                                                    <option value="4s">4 seconds</option>
-                                                                    <option value="5s">5 seconds</option>
-                                                                    <option value="6s">6 seconds</option>
-                                                                    <option value="7s">7 seconds</option>
-                                                                    <option value="8s">8 seconds</option>
-                                                                    <option value="9s">9 seconds</option>
-                                                                    <option value="10s">10 seconds</option>
-                                                                    <option value="15s">15 seconds</option>
-                                                                    <option value="20s">20 seconds</option>
-                                                                    <option value="25s">25 seconds</option>
-                                                                    <option value="30s">30 seconds</option>
-                                                                    <option value="45s">45 seconds</option>
-                                                                    <option value="1m">1 minute</option>
-                                                                    <option value="1m15s">1 min 15 sec</option>
-                                                                    <option value="1m30s">1 min 30 sec</option>
-                                                                    <option value="1m45s">1 min 45 sec</option>
-                                                                    <option value="2m">2 minutes</option>
-                                                                    <option value="2m30s">2 min 30 sec</option>
-                                                                    <option value="3m">3 minutes</option>
-                                                                    <option value="3m">4 minutes</option>
-                                                                    <option value="3m">5 minutes</option>
-                                                                    <option value="3m">6 minutes</option>
-                                                                    <option value="3m">7 minutes</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 0)}}selected {{end}}value="0s">No Timeout</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 1)}}selected {{end}}value="1s">1 second</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 2)}}selected {{end}}value="2s">2 seconds</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 3)}}selected {{end}}value="3s">3 seconds</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 4)}}selected {{end}}value="4s">4 seconds</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 5)}}selected {{end}}value="5s">5 seconds</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 6)}}selected {{end}}value="6s">6 seconds</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 7)}}selected {{end}}value="7s">7 seconds</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 8)}}selected {{end}}value="8s">8 seconds</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 9)}}selected {{end}}value="9s">9 seconds</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 10)}}selected {{end}}value="10s">10 seconds</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 15)}}selected {{end}}value="15s">15 seconds</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 20)}}selected {{end}}value="20s">20 seconds</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 25)}}selected {{end}}value="25s">25 seconds</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 30)}}selected {{end}}value="30s">30 seconds</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 45)}}selected {{end}}value="45s">45 seconds</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m">1 minute</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 75)}}selected {{end}}value="1m15s">1 min 15 sec</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 90)}}selected {{end}}value="1m30s">1 min 30 sec</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 105)}}selected {{end}}value="1m45s">1 min 45 sec</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 120)}}selected {{end}}value="2m">2 minutes</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 150)}}selected {{end}}value="2m30s">2 min 30 sec</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 180)}}selected {{end}}value="3m">3 minutes</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 240)}}selected {{end}}value="4m">4 minutes</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 300)}}selected {{end}}value="5m">5 minutes</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 360)}}selected {{end}}value="6m">6 minutes</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 420)}}selected {{end}}value="7m">7 minutes</option>
                                                                 </select>
                                                             </div>
                                                         </div>

--- a/pkg/bindata/templates/downloaders-rtorrent.html
+++ b/pkg/bindata/templates/downloaders-rtorrent.html
@@ -36,8 +36,8 @@
                                                     <a onClick="dialog($(this), 'right')" class="help-icon far fa-question-circle"></a>
                                                     <span class="dialogTitle">Interval</span>
                                                 </td>
-                                                <td style="min-width:90px;width:90px">
-                                                    <div style="display:none;" class="dialogText">This controls the maximum duration a request to this application may elapse.</div>
+                                                <td style="min-width:120px;width:120px">
+                                                    <div style="display:none;" class="dialogText">This controls the maximum duration a request to this application may elapse. Selecting <b>No Timeout</b> can be dangerous. Selecting <b>Disabled</b> completely disables the instance.</div>
                                                     <a onClick="dialog($(this), 'right')" class="help-icon far fa-question-circle"></a>
                                                     <span class="dialogTitle">Timeout</span>
                                                 </td>
@@ -158,7 +158,17 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_RTORRENT_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <input type="text" id="Apps.Rtorrent.{{$index}}.Timeout" name="Apps.Rtorrent.{{$index}}.Timeout" data-index="{{$index}}" data-app="Rtorrent" class="client-parameter form-control input-sm" data-group="download" data-label="rTorrent {{instance $index}} Timeout" data-original="{{$app.Timeout}}" value="{{$app.Timeout}}">
+                                                                <select type="text" id="Apps.Rtorrent.{{$index}}.Timeout" name="Apps.Rtorrent.{{$index}}.Timeout" data-index="{{$index}}" data-app="Rtorrent" class="client-parameter form-control input-sm" data-group="download" data-label="rTorrent {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                    <option value="-1s">Disabled</option>
+                                                                    <option value="0s">No Timeout</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds $i}}selected {{end}}value="{{$i}}s">{{$i}} second{{if not (eq $i (add 0 1))}}s{{end}}</option>
+                                                                    {{- end}}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m">1 minute</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 60 $i)}}selected {{end}}value="1m{{$i}}s">1 min {{$i}} sec</option>
+                                                                    {{- end}}
+                                                                </select>
                                                             </div>
                                                         </div>
                                                     </form>

--- a/pkg/bindata/templates/downloaders-rtorrent.html
+++ b/pkg/bindata/templates/downloaders-rtorrent.html
@@ -158,7 +158,7 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_RTORRENT_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <select type="text" id="Apps.Rtorrent.{{$index}}.Timeout" name="Apps.Rtorrent.{{$index}}.Timeout" data-index="{{$index}}" data-app="Rtorrent" class="client-parameter form-control input-sm" data-group="download" data-label="rTorrent {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                <select type="select" id="Apps.Rtorrent.{{$index}}.Timeout" name="Apps.Rtorrent.{{$index}}.Timeout" data-index="{{$index}}" data-app="Rtorrent" class="client-parameter form-control input-sm" data-group="download" data-label="rTorrent {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
                                                                     <option value="-1s">Disabled</option>
                                                                     <option value="0s">No Timeout</option>
                                                                     {{- range $i := one259 }}

--- a/pkg/bindata/templates/downloaders.html
+++ b/pkg/bindata/templates/downloaders.html
@@ -168,7 +168,7 @@
                                                                     {{- range $i := one259 }}
                                                                     <option {{if eq $app.Timeout.Seconds $i}}selected {{end}}value="{{$i}}s">{{$i}} second{{if not (eq $i (add 0 1))}}s{{end}}</option>
                                                                     {{- end}}
-                                                                    <option {{if eq $app.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m">1 minute</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m0s">1 minute</option>
                                                                     {{- range $i := one259 }}
                                                                     <option {{if eq $app.Timeout.Seconds (add 60 $i)}}selected {{end}}value="1m{{$i}}s">1 min {{$i}} sec</option>
                                                                     {{- end}}
@@ -329,7 +329,7 @@
                                                                     {{- range $i := one259 }}
                                                                     <option {{if eq $app.Timeout.Seconds $i}}selected {{end}}value="{{$i}}s">{{$i}} second{{if not (eq $i (add 0 1))}}s{{end}}</option>
                                                                     {{- end}}
-                                                                    <option {{if eq $app.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m">1 minute</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m0s">1 minute</option>
                                                                     {{- range $i := one259 }}
                                                                     <option {{if eq $app.Timeout.Seconds (add 60 $i)}}selected {{end}}value="1m{{$i}}s">1 min {{$i}} sec</option>
                                                                     {{- end}}

--- a/pkg/bindata/templates/downloaders.html
+++ b/pkg/bindata/templates/downloaders.html
@@ -668,7 +668,7 @@
                                                                     {{- range $i := one259 }}
                                                                     <option {{if eq $app.Timeout.Seconds $i}}selected {{end}}value="{{$i}}s">{{$i}} second{{if not (eq $i (add 0 1))}}s{{end}}</option>
                                                                     {{- end}}
-                                                                    <option {{if eq $app.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m">1 minute</option>
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m0s">1 minute</option>
                                                                     {{- range $i := one259 }}
                                                                     <option {{if eq $app.Timeout.Seconds (add 60 $i)}}selected {{end}}value="1m{{$i}}s">1 min {{$i}} sec</option>
                                                                     {{- end}}

--- a/pkg/bindata/templates/downloaders.html
+++ b/pkg/bindata/templates/downloaders.html
@@ -40,8 +40,8 @@
                                                     <a onClick="dialog($(this), 'right')" class="help-icon far fa-question-circle"></a>
                                                     <span class="dialogTitle">Interval</span>
                                                 </td>
-                                                <td style="min-width:90px;width:90px">
-                                                    <div style="display:none;" class="dialogText">This controls the maximum duration a request to this application may elapse.</div>
+                                                <td style="min-width:120px;width:120px">
+                                                    <div style="display:none;" class="dialogText">This controls the maximum duration a request to this application may elapse. Selecting <b>No Timeout</b> can be dangerous. Selecting <b>Disabled</b> completely disables the instance.</div>
                                                     <a onClick="dialog($(this), 'right')" class="help-icon far fa-question-circle"></a>
                                                     <span class="dialogTitle">Timeout</span>
                                                 </td>
@@ -162,7 +162,17 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_QBIT_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <input type="text" id="Apps.Qbit.{{$index}}.Config.Timeout" name="Apps.Qbit.{{$index}}.Config.Timeout" data-index="{{$index}}" data-app="Qbit" class="client-parameter form-control input-sm" data-group="download" data-label="Qbit {{instance $index}} Timeout" data-original="{{$app.Timeout}}" value="{{$app.Timeout}}">
+                                                                <select type="text" id="Apps.Qbit.{{$index}}.Config.Timeout" name="Apps.Qbit.{{$index}}.Config.Timeout" data-index="{{$index}}" data-app="Qbit" class="client-parameter form-control input-sm" data-group="download" data-label="Qbit {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                    <option value="-1s">Disabled</option>
+                                                                    <option value="0s">No Timeout</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds $i}}selected {{end}}value="{{$i}}s">{{$i}} second{{if not (eq $i (add 0 1))}}s{{end}}</option>
+                                                                    {{- end}}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m">1 minute</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 60 $i)}}selected {{end}}value="1m{{$i}}s">1 min {{$i}} sec</option>
+                                                                    {{- end}}
+                                                                </select>
                                                             </div>
                                                         </div>
                                                     </form>
@@ -210,7 +220,7 @@
                                                     <span class="dialogTitle">Interval</span>
                                                 </td>
                                                 <td>
-                                                    <div style="display:none;" class="dialogText">This controls the maximum duration a request to this application may elapse.</div>
+                                                    <div style="display:none;" class="dialogText">This controls the maximum duration a request to this application may elapse. Selecting <b>No Timeout</b> can be dangerous. Selecting <b>Disabled</b> completely disables the instance.</div>
                                                     <a onClick="dialog($(this), 'right')" class="help-icon far fa-question-circle"></a>
                                                     <span class="dialogTitle">Timeout</span>
                                                 </td>
@@ -313,7 +323,17 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_DELUGE_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <input type="text" id="Apps.Deluge.{{$index}}.Timeout" name="Apps.Deluge.{{$index}}.Timeout" data-index="{{$index}}" data-app="Deluge" class="client-parameter form-control input-sm" data-group="download" data-label="Deluge {{instance $index}} Timeout" data-original="{{$app.Timeout}}" value="{{$app.Timeout}}">
+                                                                <select type="text" id="Apps.Deluge.{{$index}}.Timeout" name="Apps.Deluge.{{$index}}.Timeout" data-index="{{$index}}" data-app="Deluge" class="client-parameter form-control input-sm" data-group="download" data-label="Deluge {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                    <option value="-1s">Disabled</option>
+                                                                    <option value="0s">No Timeout</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds $i}}selected {{end}}value="{{$i}}s">{{$i}} second{{if not (eq $i (add 0 1))}}s{{end}}</option>
+                                                                    {{- end}}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m">1 minute</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 60 $i)}}selected {{end}}value="1m{{$i}}s">1 min {{$i}} sec</option>
+                                                                    {{- end}}
+                                                                </select>
                                                             </div>
                                                         </div>
                                                     </form>
@@ -360,7 +380,7 @@
                                                     <span class="dialogTitle">Interval</span>
                                                 </td>
                                                 <td>
-                                                    <div style="display:none;" class="dialogText">This controls the maximum duration a request to this application may elapse.</div>
+                                                    <div style="display:none;" class="dialogText">This controls the maximum duration a request to this application may elapse. Selecting <b>No Timeout</b> can be dangerous. Selecting <b>Disabled</b> completely disables the instance.</div>
                                                     <a onClick="dialog($(this), 'right')" class="help-icon far fa-question-circle"></a>
                                                     <span class="dialogTitle">Timeout</span>
                                                 </td>
@@ -463,7 +483,17 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_SABNZBD_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <input type="text" id="Apps.SabNZB.{{$index}}.Timeout" name="Apps.SabNZB.{{$index}}.Timeout" data-index="{{$index}}" data-app="SabNZB" class="client-parameter form-control input-sm" data-group="download" data-label="SabNZB {{instance $index}} Timeout" data-original="{{$app.Timeout}}" value="{{$app.Timeout}}">
+                                                                <select type="text" id="Apps.SabNZB.{{$index}}.Timeout" name="Apps.SabNZB.{{$index}}.Timeout" data-index="{{$index}}" data-app="SabNZB" class="client-parameter form-control input-sm" data-group="download" data-label="SabNZB {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                    <option value="-1s">Disabled</option>
+                                                                    <option value="0s">No Timeout</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds $i}}selected {{end}}value="{{$i}}s">{{$i}} second{{if not (eq $i (add 0 1))}}s{{end}}</option>
+                                                                    {{- end}}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m">1 minute</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 60 $i)}}selected {{end}}value="1m{{$i}}s">1 min {{$i}} sec</option>
+                                                                    {{- end}}
+                                                                </select>
                                                             </div>
                                                         </div>
                                                     </form>
@@ -510,8 +540,8 @@
                                                     <a onClick="dialog($(this), 'right')" class="help-icon far fa-question-circle"></a>
                                                     <span class="dialogTitle">Interval</span>
                                                 </td>
-                                                <td style="min-width:90px;width:90px">
-                                                    <div style="display:none;" class="dialogText">This controls the maximum duration a request to this application may elapse.</div>
+                                                <td style="min-width:120px;width:120px">
+                                                    <div style="display:none;" class="dialogText">This controls the maximum duration a request to this application may elapse. Selecting <b>No Timeout</b> can be dangerous. Selecting <b>Disabled</b> completely disables the instance.</div>
                                                     <a onClick="dialog($(this), 'right')" class="help-icon far fa-question-circle"></a>
                                                     <span class="dialogTitle">Timeout</span>
                                                 </td>
@@ -632,7 +662,17 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_NZBGET_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <input type="text" id="Apps.NZBGet.{{$index}}.Config.Timeout" name="Apps.NZBGet.{{$index}}.Config.Timeout" data-index="{{$index}}" data-app="NZBGet" class="client-parameter form-control input-sm" data-group="download" data-label="NZBGet {{instance $index}} Timeout" data-original="{{$app.Timeout}}" value="{{$app.Timeout}}">
+                                                                <select type="text" id="Apps.NZBGet.{{$index}}.Config.Timeout" name="Apps.NZBGet.{{$index}}.Config.Timeout" data-index="{{$index}}" data-app="NZBGet" class="client-parameter form-control input-sm" data-group="download" data-label="NZBGet {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                    <option value="-1s">Disabled</option>
+                                                                    <option value="0s">No Timeout</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds $i}}selected {{end}}value="{{$i}}s">{{$i}} second{{if not (eq $i (add 0 1))}}s{{end}}</option>
+                                                                    {{- end}}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m">1 minute</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 60 $i)}}selected {{end}}value="1m{{$i}}s">1 min {{$i}} sec</option>
+                                                                    {{- end}}
+                                                                </select>
                                                             </div>
                                                         </div>
                                                     </form>

--- a/pkg/bindata/templates/downloaders.html
+++ b/pkg/bindata/templates/downloaders.html
@@ -162,7 +162,7 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_QBIT_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <select type="text" id="Apps.Qbit.{{$index}}.Config.Timeout" name="Apps.Qbit.{{$index}}.Config.Timeout" data-index="{{$index}}" data-app="Qbit" class="client-parameter form-control input-sm" data-group="download" data-label="Qbit {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                <select type="select" id="Apps.Qbit.{{$index}}.Config.Timeout" name="Apps.Qbit.{{$index}}.Config.Timeout" data-index="{{$index}}" data-app="Qbit" class="client-parameter form-control input-sm" data-group="download" data-label="Qbit {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
                                                                     <option value="-1s">Disabled</option>
                                                                     <option value="0s">No Timeout</option>
                                                                     {{- range $i := one259 }}
@@ -323,7 +323,7 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_DELUGE_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <select type="text" id="Apps.Deluge.{{$index}}.Timeout" name="Apps.Deluge.{{$index}}.Timeout" data-index="{{$index}}" data-app="Deluge" class="client-parameter form-control input-sm" data-group="download" data-label="Deluge {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                <select type="select" id="Apps.Deluge.{{$index}}.Timeout" name="Apps.Deluge.{{$index}}.Timeout" data-index="{{$index}}" data-app="Deluge" class="client-parameter form-control input-sm" data-group="download" data-label="Deluge {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
                                                                     <option value="-1s">Disabled</option>
                                                                     <option value="0s">No Timeout</option>
                                                                     {{- range $i := one259 }}
@@ -483,7 +483,7 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_SABNZBD_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <select type="text" id="Apps.SabNZB.{{$index}}.Timeout" name="Apps.SabNZB.{{$index}}.Timeout" data-index="{{$index}}" data-app="SabNZB" class="client-parameter form-control input-sm" data-group="download" data-label="SabNZB {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                <select type="select" id="Apps.SabNZB.{{$index}}.Timeout" name="Apps.SabNZB.{{$index}}.Timeout" data-index="{{$index}}" data-app="SabNZB" class="client-parameter form-control input-sm" data-group="download" data-label="SabNZB {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
                                                                     <option value="-1s">Disabled</option>
                                                                     <option value="0s">No Timeout</option>
                                                                     {{- range $i := one259 }}
@@ -662,7 +662,7 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_NZBGET_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <select type="text" id="Apps.NZBGet.{{$index}}.Config.Timeout" name="Apps.NZBGet.{{$index}}.Config.Timeout" data-index="{{$index}}" data-app="NZBGet" class="client-parameter form-control input-sm" data-group="download" data-label="NZBGet {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                <select type="select" id="Apps.NZBGet.{{$index}}.Config.Timeout" name="Apps.NZBGet.{{$index}}.Config.Timeout" data-index="{{$index}}" data-app="NZBGet" class="client-parameter form-control input-sm" data-group="download" data-label="NZBGet {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
                                                                     <option value="-1s">Disabled</option>
                                                                     <option value="0s">No Timeout</option>
                                                                     {{- range $i := one259 }}

--- a/pkg/bindata/templates/downloaders.html
+++ b/pkg/bindata/templates/downloaders.html
@@ -8,11 +8,11 @@
                                                     <div style="float: left;"><img src="{{files}}/images/logo/qbittorrent.png" style="height:50px;"></div>
                                                     <h2 class="mb-3" style="margin-bottom:-45px">qBittorrent</h2>
                                                     <div style="float: right;">
-                                                        <button id="download-Qbit-addbutton" onclick="addInstance('download', 'Qbit')" data-prefix="Apps" data-names='["Name","URL","User","Pass","Interval","Config.Timeout"]' type="button" title="Add another instance of Qbittorrent." class="add-new-item-button btn btn-primary"><i class="fa fa-plus"></i></button>
+                                                        <button id="download-Qbit-addbutton" onclick="addInstance('download', 'Qbit')" data-prefix="Apps" data-names='["Name","URL","User","Pass","Interval","Timeout"]' type="button" title="Add another instance of Qbittorrent." class="add-new-item-button btn btn-primary"><i class="fa fa-plus"></i></button>
                                                     </div>
                                                 </td>
                                                 <td colspan="7" class="tablet-hide desktop-hide">
-                                                    <button id="download-Qbit-addbutton" onclick="addInstance('download', 'Qbit')" data-prefix="Apps" data-names='["Name","URL","User","Pass","Interval","Config.Timeout"]' type="button" title="Add another instance of Qbittorrent." class="add-new-item-button btn btn-primary"><i class="fa fa-plus"></i></button>
+                                                    <button id="download-Qbit-addbutton" onclick="addInstance('download', 'Qbit')" data-prefix="Apps" data-names='["Name","URL","User","Pass","Interval","Timeout"]' type="button" title="Add another instance of Qbittorrent." class="add-new-item-button btn btn-primary"><i class="fa fa-plus"></i></button>
                                                     <h2 class="mb-3" style="margin-left:5px;display:inline;">qBittorrent</h2>
                                                     <div style="float:right;"><img src="{{files}}/images/logo/qbittorrent.png" style="height:50px;"></div>
                                                 </td>
@@ -162,7 +162,7 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_QBIT_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <select type="select" id="Apps.Qbit.{{$index}}.Config.Timeout" name="Apps.Qbit.{{$index}}.Config.Timeout" data-index="{{$index}}" data-app="Qbit" class="client-parameter form-control input-sm" data-group="download" data-label="Qbit {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                <select type="select" id="Apps.Qbit.{{$index}}.Timeout" name="Apps.Qbit.{{$index}}.Timeout" data-index="{{$index}}" data-app="Qbit" class="client-parameter form-control input-sm" data-group="download" data-label="Qbit {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
                                                                     <option value="-1s">Disabled</option>
                                                                     <option value="0s">No Timeout</option>
                                                                     {{- range $i := one259 }}
@@ -508,11 +508,11 @@
                                                     <div style="float: left;"><img src="{{files}}/images/logo/nzbget.png" style="height:50px;"></div>
                                                     <h2 class="mb-3" style="margin-bottom:-45px">NZBGet</h2>
                                                     <div style="float: right;">
-                                                        <button id="download-NZBGet-addbutton" onclick="addInstance('download', 'NZBGet')" data-prefix="Apps" data-names='["Name","Config.URL","Config.User","Config.Pass","Interval","Config.Timeout"]' type="button" title="Add another instance of NZBGet." class="add-new-item-button btn btn-primary"><i class="fa fa-plus"></i></button>
+                                                        <button id="download-NZBGet-addbutton" onclick="addInstance('download', 'NZBGet')" data-prefix="Apps" data-names='["Name","Config.URL","Config.User","Config.Pass","Interval","Timeout"]' type="button" title="Add another instance of NZBGet." class="add-new-item-button btn btn-primary"><i class="fa fa-plus"></i></button>
                                                     </div>
                                                 </td>
                                                 <td colspan="7" class="tablet-hide desktop-hide">
-                                                    <button id="download-NZBGet-addbutton" onclick="addInstance('download', 'NZBGet')" data-prefix="Apps" data-names='["Name","Config.URL","Config.User","Config.Pass","Interval","Config.Timeout"]' type="button" title="Add another instance of NZBGet." class="add-new-item-button btn btn-primary"><i class="fa fa-plus"></i></button>
+                                                    <button id="download-NZBGet-addbutton" onclick="addInstance('download', 'NZBGet')" data-prefix="Apps" data-names='["Name","Config.URL","Config.User","Config.Pass","Interval","Timeout"]' type="button" title="Add another instance of NZBGet." class="add-new-item-button btn btn-primary"><i class="fa fa-plus"></i></button>
                                                     <h2 class="mb-3" style="margin-left:5px;display:inline;">NZBGet</h2>
                                                     <div style="float:right;"><img src="{{files}}/images/logo/nzbget.png" style="height:50px;"></div>
                                                 </td>
@@ -662,7 +662,7 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_NZBGET_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <select type="select" id="Apps.NZBGet.{{$index}}.Config.Timeout" name="Apps.NZBGet.{{$index}}.Config.Timeout" data-index="{{$index}}" data-app="NZBGet" class="client-parameter form-control input-sm" data-group="download" data-label="NZBGet {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                <select type="select" id="Apps.NZBGet.{{$index}}.Timeout" name="Apps.NZBGet.{{$index}}.Timeout" data-index="{{$index}}" data-app="NZBGet" class="client-parameter form-control input-sm" data-group="download" data-label="NZBGet {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
                                                                     <option value="-1s">Disabled</option>
                                                                     <option value="0s">No Timeout</option>
                                                                     {{- range $i := one259 }}

--- a/pkg/bindata/templates/filewatcher.html
+++ b/pkg/bindata/templates/filewatcher.html
@@ -6,10 +6,10 @@
                                 </p>
                                 <hr>
                                 <p>
-                                    <h3><i class="fas fa-comment"></i> Notes</h3>
-                                    <li><i class="fas fa-star"></i> You must enable the <b>Log Watcher</b> feature and choose a channel on the Notifiarr website for this to work!</li>
-                                    <li><i class="fas fa-star"></i> Use <code>(?i)</code> as a prefix to make regular expressions case insensitive.</li>
-                                    <li><i class="fas fa-star"></i> Save and reload to enable newly added file watchers.</li>
+                                    <h3><i class="fas fa-comment text-orange"></i> Notes</h3>
+                                    <li><i class="fas fa-star text-dgrey"></i> You must enable the <b>Log Watcher</b> feature and choose a channel on the Notifiarr website for this to work!</li>
+                                    <li><i class="fas fa-star text-dgrey"></i> Use <code>(?i)</code> as a prefix to make regular expressions case insensitive.</li>
+                                    <li><i class="fas fa-star text-dgrey"></i> Save and reload to enable newly added file watchers.</li>
                                 </p>
                                 <div class="table-responsive">
                                     <table class="table bk-dark table-bordered">

--- a/pkg/bindata/templates/media.html
+++ b/pkg/bindata/templates/media.html
@@ -2,8 +2,17 @@
                                 <p>
                                     <h3><i class="fas fa-comment text-orange"></i> Notes</h3>
                                     <li><i class="fas fa-star text-dgrey"></i> The Plex integration is comprehensive, and many of the settings are configured on the Notifiarr.com website.</li>
-                                    <li><i class="fas fa-star text-dgrey"></i> The Tautulli integration is used to provide a Plex username to custom name mapping in notifications.</li>
-                                    <li><i class="fas fa-star text-dgrey"></i> Disable Ples or Tautulli by removing the URL or setting Timeout to Disabled. The client only supports one of each.</li>
+                                    <li>
+                                        <span style="display:none;" class="dialogTitle">Tautulli Integration Explained</span>
+                                        <div style="display:none;" class="dialogText">
+                                            This is entrirely optional. The Notifiarr website also provides this same feature and allows you to map Plex users to custom names.
+                                            <h4>Explained:</h4>
+                                            Tautulli provides a feature that allows you to give your Plex users custom usernames. By integrating Notifiarr client with Tautulli, those custom
+                                            usernames will be displayed in your chat server notifications. When not enabled, Plex usernames or email addresses are used instead. 
+                                        </div>
+                                        <a class="help-icon fas fa-star" onClick="dialog($(this), 'left')"></a> The Tautulli integration is used to provide a Plex username to custom name mapping in notifications.
+                                    </li>
+                                    <li><i class="fas fa-star text-dgrey"></i> Disable Plex or Tautulli by removing the URL or setting Timeout to Disabled. The client only supports one of each.</li>
                                 </p>
                                 <div class="table-responsive">
                                     <table class="table bk-dark table-bordered">

--- a/pkg/bindata/templates/media.html
+++ b/pkg/bindata/templates/media.html
@@ -1,8 +1,9 @@
                                 <h1><i class="fas fa-photo-video"></i> Media Apps</h1>
                                 <p>
-                                    <li style="list-style: disc;">The Plex integration is comprehensive, and many of the settings are configured on the Notifiarr.com website.</li>
-                                    <li style="list-style: disc;">The Tautulli integration is used to provide a Plex username to custom name mapping in notifications.</li>
-                                    <li style="list-style: disc;"><b>To disable Plex or Tautulli, simply remove the URL for the application.</b> The client only supports one of each.</li>
+                                    <h3><i class="fas fa-comment text-orange"></i> Notes</h3>
+                                    <li><i class="fas fa-star text-dgrey"></i> The Plex integration is comprehensive, and many of the settings are configured on the Notifiarr.com website.</li>
+                                    <li><i class="fas fa-star text-dgrey"></i> The Tautulli integration is used to provide a Plex username to custom name mapping in notifications.</li>
+                                    <li><i class="fas fa-star text-dgrey"></i> Disable Ples or Tautulli by removing the URL or setting Timeout to Disabled. The client only supports one of each.</li>
                                 </p>
                                 <div class="table-responsive">
                                     <table class="table bk-dark table-bordered">
@@ -99,7 +100,7 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_PLEX_TIMEOUT" .Flags.EnvPrefix}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <select type="text" id="Plex.Timeout" name="Plex.Timeout" class="client-parameter form-control input-sm" data-group="media" data-label="Plex Timeout" data-original="{{.Config.Plex.Timeout}}">
+                                                                <select type="select" id="Plex.Timeout" name="Plex.Timeout" class="client-parameter form-control input-sm" data-group="media" data-label="Plex Timeout" data-original="{{.Config.Plex.Timeout}}">
                                                                     <option value="-1s">Disabled</option>
                                                                     <option value="0s">No Timeout</option>
                                                                     {{- range $i := one259 }}
@@ -243,7 +244,7 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_TAUTULLI_TIMEOUT" .Flags.EnvPrefix}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <select type="text" id="Apps.Tautulli.Timeout" name="Apps.Tautulli.Timeout" class="client-parameter form-control input-sm" data-group="media" data-label="Tautulli Timeout" data-original="{{.Config.Apps.Tautulli.Timeout}}">
+                                                                <select type="select" id="Apps.Tautulli.Timeout" name="Apps.Tautulli.Timeout" class="client-parameter form-control input-sm" data-group="media" data-label="Tautulli Timeout" data-original="{{.Config.Apps.Tautulli.Timeout}}">
                                                                     <option value="-1s">Disabled</option>
                                                                     <option value="0s">No Timeout</option>
                                                                     {{- range $i := one259 }}

--- a/pkg/bindata/templates/media.html
+++ b/pkg/bindata/templates/media.html
@@ -32,8 +32,8 @@
                                                     <a onClick="dialog($(this), 'right')" class="help-icon far fa-question-circle"></a>
                                                     <span class="dialogTitle">Plex Token</span>
                                                 </td>
-                                                <td style="min-width:90px;width:90px">
-                                                    <div style="display:none;" class="dialogText">This controls the maximum duration a request to Plex may elapse.</div>
+                                                <td style="min-width:120px;width:120px">
+                                                    <div style="display:none;" class="dialogText">This controls the maximum duration a request to this application may elapse. Selecting <b>No Timeout</b> can be dangerous. Selecting <b>Disabled</b> completely disables the instance.</div>
                                                     <a onClick="dialog($(this), 'right')" class="help-icon far fa-question-circle"></a>
                                                     <span class="dialogTitle">Timeout</span>
                                                 </td>
@@ -99,7 +99,17 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_PLEX_TIMEOUT" .Flags.EnvPrefix}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <input type="text" id="Plex.Timeout" name="Plex.Timeout" class="client-parameter form-control input-sm" data-group="media" data-label="Plex Timeout" data-original="{{.Config.Plex.Timeout}}" value="{{.Config.Plex.Timeout}}">
+                                                                <select type="text" id="Plex.Timeout" name="Plex.Timeout" class="client-parameter form-control input-sm" data-group="media" data-label="Plex Timeout" data-original="{{.Config.Plex.Timeout}}">
+                                                                    <option value="-1s">Disabled</option>
+                                                                    <option value="0s">No Timeout</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $.Config.Plex.Timeout.Seconds $i}}selected {{end}}value="{{$i}}s">{{$i}} second{{if not (eq $i (add 0 1))}}s{{end}}</option>
+                                                                    {{- end}}
+                                                                    <option {{if eq $.Config.Plex.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m">1 minute</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $.Config.Plex.Timeout.Seconds (add 60 $i)}}selected {{end}}value="1m{{$i}}s">1 min {{$i}} sec</option>
+                                                                    {{- end}}
+                                                                </select>
                                                             </div>
                                                         </div>
                                                     </form>
@@ -134,7 +144,7 @@
                                                     <span class="dialogTitle">Interval</span>
                                                 </td>
                                                 <td>
-                                                    <div style="display:none;" class="dialogText">This controls the maximum duration a request to Tautulli may elapse.</div>
+                                                    <div style="display:none;" class="dialogText">This controls the maximum duration a request to this application may elapse. Selecting <b>No Timeout</b> can be dangerous. Selecting <b>Disabled</b> completely disables the instance.</div>
                                                     <a onClick="dialog($(this), 'right')" class="help-icon far fa-question-circle"></a>
                                                     <span class="dialogTitle">Timeout</span>
                                                 </td>
@@ -233,7 +243,17 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_TAUTULLI_TIMEOUT" .Flags.EnvPrefix}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <input type="text" id="Apps.Tautulli.Timeout" name="Apps.Tautulli.Timeout" class="client-parameter form-control input-sm" data-group="media" data-label="Tautulli Timeout" data-original="{{.Config.Apps.Tautulli.Timeout}}" value="{{.Config.Apps.Tautulli.Timeout}}">
+                                                                <select type="text" id="Apps.Tautulli.Timeout" name="Apps.Tautulli.Timeout" class="client-parameter form-control input-sm" data-group="media" data-label="Tautulli Timeout" data-original="{{.Config.Apps.Tautulli.Timeout}}">
+                                                                    <option value="-1s">Disabled</option>
+                                                                    <option value="0s">No Timeout</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $.Config.Apps.Tautulli.Timeout.Seconds $i}}selected {{end}}value="{{$i}}s">{{$i}} second{{if not (eq $i (add 0 1))}}s{{end}}</option>
+                                                                    {{- end}}
+                                                                    <option {{if eq $.Config.Apps.Tautulli.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m">1 minute</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $.Config.Apps.Tautulli.Timeout.Seconds (add 60 $i)}}selected {{end}}value="1m{{$i}}s">1 min {{$i}} sec</option>
+                                                                    {{- end}}
+                                                                </select>
                                                             </div>
                                                         </div>
                                                     </form>

--- a/pkg/bindata/templates/services.html
+++ b/pkg/bindata/templates/services.html
@@ -268,8 +268,9 @@
                                     </form>
                                 </div>
                                 <div class="col-lg-10 col-md-12 col-sm-12 mb">
-                                    <h3>Notes</h3>
-                                    <li><i class="fas fa-star"></i> Service Checks must have non-empty unique names.</li>
-                                    <li><i class="fas fa-star"></i> Do not add starr, media, snapshot, or downloader apps here (except Plex). If you wish to monitor an application configured on another page, just give it a name. Giving any app a name enables service checks.</li>
+                                    <h3><i class="fas fa-comment text-orange"></i> Notes</h3>
+                                    <li><i class="fas fa-star text-dgrey"></i> Service Checks must have non-empty unique names.</li>
+                                    <li><i class="fas fa-star text-dgrey"></i> Do not add starr, media, snapshot, or downloader apps here; <b>except Plex</b>. </li>
+                                    <li><i class="fas fa-star text-dgrey"></i> If you wish to monitor an application configured on another page, just give it a name. Giving any app a name enables service checks.</li>
                                 </div>
 {{- /* end of services (leave this comment) */ -}}

--- a/pkg/bindata/templates/snapshot-mysql.html
+++ b/pkg/bindata/templates/snapshot-mysql.html
@@ -1,7 +1,8 @@
-                                <p>
-                                    You may add MySQL credentials to your Notifiarr client configuration to snapshot MySQL service health.
-                                    This feature snapshots <code>SHOW PROCESSLIST</code> and <code>SHOW STATUS</code> data.
-                                    <br>Access to a database is not required. Example Grant: <code>GRANT PROCESS ON *.* to 'notifiarr'@'localhost'</code>
+                                </p>
+                                    <h3><i class="fas fa-comment text-orange"></i> MySQL Notes</h3>
+                                    <li><i class="fas fa-star"></i> You may add MySQL credentials to your Notifiarr client configuration to snapshot MySQL service health.</li>
+                                    <li><i class="fas fa-star"></i> This feature snapshots <code>SHOW PROCESSLIST</code> and <code>SHOW STATUS</code> data.</li>
+                                    <li><i class="fas fa-star"></i>Access to a database is not required. Example Grant: <code>GRANT PROCESS ON *.* to 'notifiarr'@'localhost'</code></li>
                                 </p>
                                 <div class="table-responsive">
                                     <table class="table bk-dark table-bordered">

--- a/pkg/bindata/templates/snapshot-mysql.html
+++ b/pkg/bindata/templates/snapshot-mysql.html
@@ -55,8 +55,8 @@
                                                     <a onClick="dialog($(this), 'right')" class="help-icon far fa-question-circle"></a>
                                                     <span class="dialogTitle">Interval</span>
                                                 </td>
-                                                <td style="min-width:90px;width:90px">
-                                                    <div style="display:none;" class="dialogText">This controls the maximum duration a request to this application may elapse.</div>
+                                                <td style="min-width:120px;width:120px">
+                                                    <div style="display:none;" class="dialogText">This controls the maximum duration a request to this application may elapse. Selecting <b>No Timeout</b> can be dangerous. Selecting <b>Disabled</b> completely disables the instance.</div>
                                                     <a onClick="dialog($(this), 'right')" class="help-icon far fa-question-circle"></a>
                                                     <span class="dialogTitle">Timeout</span>
                                                 </td>
@@ -177,7 +177,17 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_SNAPSHOT_MYSQL_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <input type="text" id="Snapshot.MySQL.{{$index}}.Timeout" name="Snapshot.MySQL.{{$index}}.Timeout" data-index="{{$index}}" data-app="MySQL" class="client-parameter form-control input-sm" data-group="snaps" data-label="MySQL {{instance $index}} Timeout" data-original="{{$app.Timeout}}" value="{{$app.Timeout}}">
+                                                                <select type="text" id="Snapshot.MySQL.{{$index}}.Timeout" name="Snapshot.MySQL.{{$index}}.Timeout" data-index="{{$index}}" data-app="MySQL" class="client-parameter form-control input-sm" data-group="snaps" data-label="MySQL {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                    <option value="-1s">Disabled</option>
+                                                                    <option value="0s">No Timeout</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds $i}}selected {{end}}value="{{$i}}s">{{$i}} second{{if not (eq $i (add 0 1))}}s{{end}}</option>
+                                                                    {{- end}}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m">1 minute</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 60 $i)}}selected {{end}}value="1m{{$i}}s">1 min {{$i}} sec</option>
+                                                                    {{- end}}
+                                                                </select>
                                                             </div>
                                                         </div>
                                                     </form>

--- a/pkg/bindata/templates/starr.html
+++ b/pkg/bindata/templates/starr.html
@@ -1,5 +1,9 @@
                                 <h1><i class="fas fa-star"></i> Starr Apps</h1>
                                 <p>Notifiarr client has deep integrations with the whole suite of Starr applications. The rest of the settings for these can be found on the Notifiarr.com website.</p>
+                                <p>
+                                    <h3><i class="fas fa-comment text-orange"></i> Notes</h3>
+                                    <li><i class="fas fa-star text-dgrey"></i> Temporarily disable an instance by setting the <b>Timeout</b> to <b>Disabled</b>.</li>
+                                </p>
                                 <div class="table-responsive">
                                     <table class="table table-bordered bk-dark" style="width:100%">
                                         <thead>
@@ -198,7 +202,7 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_LIDARR_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <select type="text" id="Apps.Lidarr.{{$index}}.Timeout" name="Apps.Lidarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Lidarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Lidarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                <select type="select" id="Apps.Lidarr.{{$index}}.Timeout" name="Apps.Lidarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Lidarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Lidarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
                                                                     <option value="-1s">Disabled</option>
                                                                     <option value="0s">No Timeout</option>
                                                                     {{- range $i := one259 }}
@@ -413,7 +417,7 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_PROWLARR_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <select type="text" id="Apps.Prowlarr.{{$index}}.Timeout" name="Apps.Prowlarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Prowlarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Prowlarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                <select type="select" id="Apps.Prowlarr.{{$index}}.Timeout" name="Apps.Prowlarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Prowlarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Prowlarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
                                                                     <option value="-1s">Disabled</option>
                                                                     <option value="0s">No Timeout</option>
                                                                     {{- range $i := one259 }}
@@ -630,7 +634,7 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_RADARR_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <select type="text" id="Apps.Radarr.{{$index}}.Timeout" name="Apps.Radarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Radarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Radarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                <select type="select" id="Apps.Radarr.{{$index}}.Timeout" name="Apps.Radarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Radarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Radarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
                                                                     <option value="-1s">Disabled</option>
                                                                     <option value="0s">No Timeout</option>
                                                                     {{- range $i := one259 }}
@@ -845,7 +849,7 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_READARR_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <select type="text" id="Apps.Readarr.{{$index}}.Timeout" name="Apps.Readarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Readarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Readarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                <select type="select" id="Apps.Readarr.{{$index}}.Timeout" name="Apps.Readarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Readarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Readarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
                                                                     <option value="-1s">Disabled</option>
                                                                     <option value="0s">No Timeout</option>
                                                                     {{- range $i := one259 }}
@@ -1060,7 +1064,7 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_SONARR_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <select type="text" id="Apps.Sonarr.{{$index}}.Timeout" name="Apps.Sonarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Sonarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Sonarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                <select type="select" id="Apps.Sonarr.{{$index}}.Timeout" name="Apps.Sonarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Sonarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Sonarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
                                                                     <option value="-1s">Disabled</option>
                                                                     <option value="0s">No Timeout</option>
                                                                     {{- range $i := one259 }}

--- a/pkg/bindata/templates/starr.html
+++ b/pkg/bindata/templates/starr.html
@@ -57,8 +57,8 @@
                                                     <a onClick="dialog($(this), 'right')" class="help-icon far fa-question-circle"></a>
                                                     <span class="dialogTitle">Interval</span>
                                                 </td>
-                                                <td style="width:90px;min-width:90px;">
-                                                    <div style="display:none;" class="dialogText">This controls the maximum duration a request to this application may elapse.</div>
+                                                <td style="min-width:120px;width:120px">
+                                                    <div style="display:none;" class="dialogText">This controls the maximum duration a request to this application may elapse. Selecting <b>No Timeout</b> can be dangerous. Selecting <b>Disabled</b> completely disables the instance.</div>
                                                     <a onClick="dialog($(this), 'right')" class="help-icon far fa-question-circle"></a>
                                                     <span class="dialogTitle">Timeout</span>
                                                 </td>
@@ -198,7 +198,17 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_LIDARR_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <input type="text" id="Apps.Lidarr.{{$index}}.Timeout" name="Apps.Lidarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Lidarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Lidarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}" value="{{$app.Timeout}}">
+                                                                <select type="text" id="Apps.Lidarr.{{$index}}.Timeout" name="Apps.Lidarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Lidarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Lidarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                    <option value="-1s">Disabled</option>
+                                                                    <option value="0s">No Timeout</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds $i}}selected {{end}}value="{{$i}}s">{{$i}} second{{if not (eq $i (add 0 1))}}s{{end}}</option>
+                                                                    {{- end}}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m">1 minute</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 60 $i)}}selected {{end}}value="1m{{$i}}s">1 min {{$i}} sec</option>
+                                                                    {{- end}}
+                                                                </select>
                                                             </div>
                                                         </div>
                                                     </form>
@@ -403,7 +413,17 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_PROWLARR_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <input type="text" id="Apps.Prowlarr.{{$index}}.Timeout" name="Apps.Prowlarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Prowlarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Prowlarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}" value="{{$app.Timeout}}">
+                                                                <select type="text" id="Apps.Prowlarr.{{$index}}.Timeout" name="Apps.Prowlarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Prowlarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Prowlarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                    <option value="-1s">Disabled</option>
+                                                                    <option value="0s">No Timeout</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds $i}}selected {{end}}value="{{$i}}s">{{$i}} second{{if not (eq $i (add 0 1))}}s{{end}}</option>
+                                                                    {{- end}}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m">1 minute</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 60 $i)}}selected {{end}}value="1m{{$i}}s">1 min {{$i}} sec</option>
+                                                                    {{- end}}
+                                                                </select>
                                                             </div>
                                                         </div>
                                                     </form>
@@ -610,7 +630,17 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_RADARR_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <input type="text" id="Apps.Radarr.{{$index}}.Timeout" name="Apps.Radarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Radarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Radarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}" value="{{$app.Timeout}}">
+                                                                <select type="text" id="Apps.Radarr.{{$index}}.Timeout" name="Apps.Radarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Radarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Radarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                    <option value="-1s">Disabled</option>
+                                                                    <option value="0s">No Timeout</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds $i}}selected {{end}}value="{{$i}}s">{{$i}} second{{if not (eq $i (add 0 1))}}s{{end}}</option>
+                                                                    {{- end}}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m">1 minute</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 60 $i)}}selected {{end}}value="1m{{$i}}s">1 min {{$i}} sec</option>
+                                                                    {{- end}}
+                                                                </select>
                                                             </div>
                                                         </div>
                                                     </form>
@@ -815,7 +845,17 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_READARR_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <input type="text" id="Apps.Readarr.{{$index}}.Timeout" name="Apps.Readarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Readarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Readarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}" value="{{$app.Timeout}}">
+                                                                <select type="text" id="Apps.Readarr.{{$index}}.Timeout" name="Apps.Readarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Readarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Readarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                    <option value="-1s">Disabled</option>
+                                                                    <option value="0s">No Timeout</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds $i}}selected {{end}}value="{{$i}}s">{{$i}} second{{if not (eq $i (add 0 1))}}s{{end}}</option>
+                                                                    {{- end}}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m">1 minute</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 60 $i)}}selected {{end}}value="1m{{$i}}s">1 min {{$i}} sec</option>
+                                                                    {{- end}}
+                                                                </select>
                                                             </div>
                                                         </div>
                                                     </form>
@@ -1020,7 +1060,17 @@
                                                                     <span class="dialogTitle" style="display:none;">Variable: {{printf "%s_SONARR_%d_TIMEOUT" $.Flags.EnvPrefix $index}}</span>
                                                                 </div>
                                                                 {{- end}}
-                                                                <input type="text" id="Apps.Sonarr.{{$index}}.Timeout" name="Apps.Sonarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Sonarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Sonarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}" value="{{$app.Timeout}}">
+                                                                <select type="text" id="Apps.Sonarr.{{$index}}.Timeout" name="Apps.Sonarr.{{$index}}.Timeout" data-index="{{$index}}" data-app="Sonarr" class="client-parameter form-control input-sm" data-group="starr" data-label="Sonarr {{instance $index}} Timeout" data-original="{{$app.Timeout}}">
+                                                                    <option value="-1s">Disabled</option>
+                                                                    <option value="0s">No Timeout</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds $i}}selected {{end}}value="{{$i}}s">{{$i}} second{{if not (eq $i (add 0 1))}}s{{end}}</option>
+                                                                    {{- end}}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 0 60)}}selected {{end}}value="1m">1 minute</option>
+                                                                    {{- range $i := one259 }}
+                                                                    <option {{if eq $app.Timeout.Seconds (add 60 $i)}}selected {{end}}value="1m{{$i}}s">1 min {{$i}} sec</option>
+                                                                    {{- end}}
+                                                                </select>
                                                             </div>
                                                         </div>
                                                     </form>

--- a/pkg/client/handlers_trash.go
+++ b/pkg/client/handlers_trash.go
@@ -60,7 +60,7 @@ func (c *Client) aggregateTrashSonarr(
 
 	// Create our known+requested instances, so we can write slice values in go routines.
 	for idx, app := range c.Config.Apps.Sonarr {
-		if instance := idx + 1; instances.Has(instance) {
+		if instance := idx + 1; instances.Has(instance) && app.URL != "" && app.APIKey != "" && app.Timeout.Duration >= 0 {
 			output = append(output, &cfsync.SonarrTrashPayload{Instance: instance, Name: app.Name})
 		}
 	}
@@ -110,7 +110,7 @@ func (c *Client) aggregateTrashRadarr(
 	output := []*cfsync.RadarrTrashPayload{}
 	// Create our known+requested instances, so we can write slice values in go routines.
 	for i, app := range c.Config.Apps.Radarr {
-		if instance := i + 1; instances.Has(instance) {
+		if instance := i + 1; instances.Has(instance) && app.URL != "" && app.APIKey != "" && app.Timeout.Duration >= 0 {
 			output = append(output, &cfsync.RadarrTrashPayload{Instance: instance, Name: app.Name})
 		}
 	}

--- a/pkg/client/handlers_version.go
+++ b/pkg/client/handlers_version.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/Notifiarr/notifiarr/pkg/apps"
+	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/Notifiarr/notifiarr/pkg/plex"
 )
 
@@ -79,6 +80,10 @@ func (c *Client) appStatsForVersion(ctx context.Context) map[string]interface{} 
 
 func getLidarrVersion(ctx context.Context, wait *sync.WaitGroup, lidarrs []*apps.LidarrConfig, lid []*conTest, fg bool) {
 	for idx, app := range lidarrs {
+		if app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0 {
+			lid[idx] = &conTest{Instance: idx + 1, Up: false, Status: mnd.Disabled}
+		}
+
 		if fg {
 			stat, err := app.GetSystemStatusContext(ctx)
 			lid[idx] = &conTest{Instance: idx + 1, Up: err == nil, Status: stat}
@@ -98,6 +103,10 @@ func getLidarrVersion(ctx context.Context, wait *sync.WaitGroup, lidarrs []*apps
 
 func getProwlarrVersion(ctx context.Context, wait *sync.WaitGroup, prowlarrs []*apps.ProwlarrConfig, prl []*conTest, fg bool) {
 	for idx, app := range prowlarrs {
+		if app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0 {
+			prl[idx] = &conTest{Instance: idx + 1, Up: false, Status: mnd.Disabled}
+		}
+
 		if fg {
 			stat, err := app.GetSystemStatusContext(ctx)
 			prl[idx] = &conTest{Instance: idx + 1, Up: err == nil, Status: stat}
@@ -117,6 +126,10 @@ func getProwlarrVersion(ctx context.Context, wait *sync.WaitGroup, prowlarrs []*
 
 func getRadarrVersion(ctx context.Context, wait *sync.WaitGroup, radarrs []*apps.RadarrConfig, rad []*conTest, fg bool) {
 	for idx, app := range radarrs {
+		if app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0 {
+			rad[idx] = &conTest{Instance: idx + 1, Up: false, Status: mnd.Disabled}
+		}
+
 		if fg {
 			stat, err := app.GetSystemStatusContext(ctx)
 			rad[idx] = &conTest{Instance: idx + 1, Up: err == nil, Status: stat}
@@ -136,6 +149,10 @@ func getRadarrVersion(ctx context.Context, wait *sync.WaitGroup, radarrs []*apps
 
 func getReadarrVersion(ctx context.Context, wait *sync.WaitGroup, readarrs []*apps.ReadarrConfig, read []*conTest, fg bool) {
 	for idx, app := range readarrs {
+		if app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0 {
+			read[idx] = &conTest{Instance: idx + 1, Up: false, Status: mnd.Disabled}
+		}
+
 		if fg {
 			stat, err := app.GetSystemStatusContext(ctx)
 			read[idx] = &conTest{Instance: idx + 1, Up: err == nil, Status: stat}
@@ -155,6 +172,10 @@ func getReadarrVersion(ctx context.Context, wait *sync.WaitGroup, readarrs []*ap
 
 func getSonarrVersion(ctx context.Context, wait *sync.WaitGroup, sonarrs []*apps.SonarrConfig, son []*conTest, fg bool) {
 	for idx, app := range sonarrs {
+		if app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0 {
+			son[idx] = &conTest{Instance: idx + 1, Up: false, Status: mnd.Disabled}
+		}
+
 		if fg {
 			stat, err := app.GetSystemStatusContext(ctx)
 			son[idx] = &conTest{Instance: idx + 1, Up: err == nil, Status: stat}

--- a/pkg/client/html_templates.go
+++ b/pkg/client/html_templates.go
@@ -115,6 +115,15 @@ func (c *Client) getFuncMap() template.FuncMap {
 			}
 			return "0"
 		},
+		"one259": func() (num []float64) {
+			for i := float64(1); i < 60; i++ {
+				num = append(num, i)
+			}
+			return num
+		},
+		"add": func(i, j float64) float64 {
+			return i + j
+		},
 	}
 }
 

--- a/pkg/plex/plex.go
+++ b/pkg/plex/plex.go
@@ -41,7 +41,7 @@ var ErrNoURLToken = fmt.Errorf("token or URL for Plex missing")
 
 // Configured returns true ifthe server is configured, false otherwise.
 func (s *Server) Configured() bool {
-	return s != nil && s.URL != "" && s.Token != ""
+	return s != nil && s.URL != "" && s.Token != "" && s.Timeout.Duration >= 0
 }
 
 // Validate checks input values and starts the cron interval if it's configured.

--- a/pkg/services/apps.go
+++ b/pkg/services/apps.go
@@ -23,6 +23,10 @@ func (c *Config) collectApps() []*Service {
 
 func (c *Config) collectLidarrApps(svcs []*Service) []*Service {
 	for _, app := range c.Apps.Lidarr {
+		if app.Timeout.Duration < 0 {
+			continue
+		}
+
 		if app.Interval.Duration == 0 {
 			app.Interval.Duration = DefaultCheckInterval
 		}
@@ -44,6 +48,10 @@ func (c *Config) collectLidarrApps(svcs []*Service) []*Service {
 
 func (c *Config) collectProwlarrApps(svcs []*Service) []*Service {
 	for _, app := range c.Apps.Prowlarr {
+		if app.Timeout.Duration < 0 {
+			continue
+		}
+
 		if app.Interval.Duration == 0 {
 			app.Interval.Duration = DefaultCheckInterval
 		}
@@ -65,6 +73,10 @@ func (c *Config) collectProwlarrApps(svcs []*Service) []*Service {
 
 func (c *Config) collectRadarrApps(svcs []*Service) []*Service {
 	for _, app := range c.Apps.Radarr {
+		if app.Timeout.Duration < 0 {
+			continue
+		}
+
 		if app.Interval.Duration == 0 {
 			app.Interval.Duration = DefaultCheckInterval
 		}
@@ -86,6 +98,10 @@ func (c *Config) collectRadarrApps(svcs []*Service) []*Service {
 
 func (c *Config) collectReadarrApps(svcs []*Service) []*Service {
 	for _, app := range c.Apps.Readarr {
+		if app.Timeout.Duration < 0 {
+			continue
+		}
+
 		if app.Interval.Duration == 0 {
 			app.Interval.Duration = DefaultCheckInterval
 		}
@@ -107,6 +123,10 @@ func (c *Config) collectReadarrApps(svcs []*Service) []*Service {
 
 func (c *Config) collectSonarrApps(svcs []*Service) []*Service {
 	for _, app := range c.Apps.Sonarr {
+		if app.Timeout.Duration < 0 {
+			continue
+		}
+
 		if app.Interval.Duration == 0 {
 			app.Interval.Duration = DefaultCheckInterval
 		}
@@ -126,9 +146,13 @@ func (c *Config) collectSonarrApps(svcs []*Service) []*Service {
 	return svcs
 }
 
-func (c *Config) collectDownloadApps(svcs []*Service) []*Service { //nolint:funlen,cyclop
+func (c *Config) collectDownloadApps(svcs []*Service) []*Service { //nolint:funlen,cyclop,gocognit
 	// Deluge instanceapp.
 	for _, app := range c.Apps.Deluge {
+		if app.Timeout.Duration < 0 {
+			continue
+		}
+
 		if app.Interval.Duration == 0 {
 			app.Interval.Duration = DefaultCheckInterval
 		}
@@ -147,6 +171,10 @@ func (c *Config) collectDownloadApps(svcs []*Service) []*Service { //nolint:funl
 
 	// NZBGet instances.
 	for _, app := range c.Apps.NZBGet {
+		if app.Timeout.Duration < 0 {
+			continue
+		}
+
 		if app.Interval.Duration == 0 {
 			app.Interval.Duration = DefaultCheckInterval
 		}
@@ -165,6 +193,10 @@ func (c *Config) collectDownloadApps(svcs []*Service) []*Service { //nolint:funl
 
 	// Qbittorrent instanceapp.
 	for _, app := range c.Apps.Qbit {
+		if app.Timeout.Duration < 0 {
+			continue
+		}
+
 		if app.Interval.Duration == 0 {
 			app.Interval.Duration = DefaultCheckInterval
 		}
@@ -183,6 +215,10 @@ func (c *Config) collectDownloadApps(svcs []*Service) []*Service { //nolint:funl
 
 	// rTorrent instanceapp.
 	for _, app := range c.Apps.Rtorrent {
+		if app.Timeout.Duration < 0 {
+			continue
+		}
+
 		if app.Interval.Duration == 0 {
 			app.Interval.Duration = DefaultCheckInterval
 		}
@@ -201,6 +237,10 @@ func (c *Config) collectDownloadApps(svcs []*Service) []*Service { //nolint:funl
 
 	// SabNBZd instanceapp.
 	for _, app := range c.Apps.SabNZB {
+		if app.Timeout.Duration < 0 {
+			continue
+		}
+
 		if app.Interval.Duration == 0 {
 			app.Interval.Duration = DefaultCheckInterval
 		}
@@ -223,6 +263,10 @@ func (c *Config) collectDownloadApps(svcs []*Service) []*Service { //nolint:funl
 func (c *Config) collectTautulliApp(svcs []*Service) []*Service {
 	// Tautulli instance (1).
 	if app := c.Apps.Tautulli; app != nil && app.URL != "" && app.Name != "" {
+		if app.Timeout.Duration < 0 {
+			return svcs
+		}
+
 		if app.Interval.Duration == 0 {
 			app.Interval.Duration = DefaultCheckInterval
 		}
@@ -246,12 +290,14 @@ func (c *Config) collectMySQLApps(svcs []*Service) []*Service {
 	}
 
 	for _, plugin := range c.Plugins.MySQL {
-		if plugin.Interval.Duration == 0 {
-			plugin.Interval.Duration = DefaultCheckInterval
+		if plugin.Timeout.Duration < 0 {
+			continue
+		} else if plugin.Timeout.Duration == 0 {
+			plugin.Timeout.Duration = DefaultTimeout
 		}
 
-		if plugin.Timeout.Duration == 0 {
-			plugin.Timeout.Duration = DefaultTimeout
+		if plugin.Interval.Duration == 0 {
+			plugin.Interval.Duration = DefaultCheckInterval
 		}
 
 		host := strings.TrimLeft(strings.TrimRight(plugin.Host, ")"), "@tcp(")

--- a/pkg/triggers/backups/backups.go
+++ b/pkg/triggers/backups/backups.go
@@ -42,7 +42,7 @@ func (c *cmd) makeBackupTriggersLidarr() {
 	var ticker *time.Ticker
 
 	for _, app := range c.Apps.Lidarr {
-		if app.Backup != mnd.Disabled {
+		if app.Backup != mnd.Disabled && app.Timeout.Duration >= 0 && app.URL != "" {
 			ticker = time.NewTicker(lidarrBackupCheckDur)
 			break
 		}
@@ -60,7 +60,7 @@ func (c *cmd) makeBackupTriggersRadarr() {
 	var ticker *time.Ticker
 
 	for _, app := range c.Apps.Radarr {
-		if app.Backup != mnd.Disabled {
+		if app.Backup != mnd.Disabled && app.Timeout.Duration >= 0 && app.URL != "" {
 			ticker = time.NewTicker(radarrBackupCheckDur)
 			break
 		}
@@ -78,7 +78,7 @@ func (c *cmd) makeBackupTriggersReadarr() {
 	var ticker *time.Ticker
 
 	for _, app := range c.Apps.Readarr {
-		if app.Backup != mnd.Disabled {
+		if app.Backup != mnd.Disabled && app.Timeout.Duration >= 0 && app.URL != "" {
 			ticker = time.NewTicker(readarrBackupCheckDur)
 			break
 		}
@@ -96,7 +96,7 @@ func (c *cmd) makeBackupTriggersSonarr() {
 	var ticker *time.Ticker
 
 	for _, app := range c.Apps.Sonarr {
-		if app.Backup != mnd.Disabled {
+		if app.Backup != mnd.Disabled && app.Timeout.Duration >= 0 && app.URL != "" {
 			ticker = time.NewTicker(sonarrBackupCheckDur)
 			break
 		}
@@ -114,7 +114,7 @@ func (c *cmd) makeBackupTriggersProwlarr() {
 	var ticker *time.Ticker
 
 	for _, app := range c.Apps.Prowlarr {
-		if app.Backup != mnd.Disabled {
+		if app.Backup != mnd.Disabled && app.Timeout.Duration >= 0 && app.URL != "" {
 			ticker = time.NewTicker(prowlarrBackupCheckDur)
 			break
 		}
@@ -137,6 +137,7 @@ func (c *cmd) sendLidarrBackups(event website.EventType) {
 				int:   idx + 1,
 				app:   app,
 				cName: app.Name,
+				skip:  app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0,
 			})
 		}
 	}
@@ -151,6 +152,7 @@ func (c *cmd) sendProwlarrBackups(event website.EventType) {
 				int:   idx + 1,
 				app:   app,
 				cName: app.Name,
+				skip:  app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0,
 			})
 		}
 	}
@@ -165,6 +167,7 @@ func (c *cmd) sendRadarrBackups(event website.EventType) {
 				int:   idx + 1,
 				app:   app,
 				cName: app.Name,
+				skip:  app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0,
 			})
 		}
 	}
@@ -179,6 +182,7 @@ func (c *cmd) sendReadarrBackups(event website.EventType) {
 				int:   idx + 1,
 				app:   app,
 				cName: app.Name,
+				skip:  app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0,
 			})
 		}
 	}
@@ -193,12 +197,17 @@ func (c *cmd) sendSonarrBackups(event website.EventType) {
 				cName: app.Name,
 				int:   idx + 1,
 				app:   app,
+				skip:  app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0,
 			})
 		}
 	}
 }
 
 func (c *cmd) sendBackups(input *genericInstance) {
+	if input.skip {
+		return
+	}
+
 	fileList, err := input.app.GetBackupFiles()
 	if err != nil {
 		c.Errorf("[%s requested] Getting %s Backup Files (%d): %v", input.event, input.name, input.int, err)

--- a/pkg/triggers/backups/config.go
+++ b/pkg/triggers/backups/config.go
@@ -71,6 +71,7 @@ type Info struct {
 // genericInstance is used to abstract all starr apps to reusable methods.
 // It's also used in the go file.
 type genericInstance struct {
+	skip  bool
 	event website.EventType
 	last  string      // app.Corrupt
 	name  starr.App   // Lidarr, Radarr, ..

--- a/pkg/triggers/cfsync/common.go
+++ b/pkg/triggers/cfsync/common.go
@@ -89,7 +89,7 @@ func (c *cmd) create() {
 		C:    make(chan website.EventType, 1),
 		T:    radarrTicker,
 	}, &common.Action{
-		Name: TrigCFSyncSonarr,
+		Name: TrigRPSyncSonarr,
 		Fn:   c.syncSonarr,
 		C:    make(chan website.EventType, 1),
 		T:    sonarrTicker,

--- a/pkg/triggers/cfsync/radarr.go
+++ b/pkg/triggers/cfsync/radarr.go
@@ -42,7 +42,8 @@ func (c *cmd) syncRadarr(event website.EventType) {
 
 	for i, app := range c.Apps.Radarr {
 		instance := i + 1
-		if app.URL == "" || app.APIKey == "" || !c.ClientInfo.Actions.Sync.RadarrInstances.Has(instance) {
+		if app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0 ||
+			!c.ClientInfo.Actions.Sync.RadarrInstances.Has(instance) {
 			c.Debugf("CF Sync Skipping Radarr instance %d. Not in sync list: %v",
 				instance, c.ClientInfo.Actions.Sync.RadarrInstances)
 			continue

--- a/pkg/triggers/cfsync/sonarr.go
+++ b/pkg/triggers/cfsync/sonarr.go
@@ -40,7 +40,8 @@ func (c *cmd) syncSonarr(event website.EventType) {
 
 	for i, app := range c.Apps.Sonarr {
 		instance := i + 1
-		if app.URL == "" || app.APIKey == "" || !c.ClientInfo.Actions.Sync.SonarrInstances.Has(instance) {
+		if app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0 ||
+			!c.ClientInfo.Actions.Sync.SonarrInstances.Has(instance) {
 			c.Debugf("CF Sync Skipping Sonarr instance %d. Not in sync list: %v",
 				instance, c.ClientInfo.Actions.Sync.SonarrInstances)
 			continue

--- a/pkg/triggers/cfsync/sonarr.go
+++ b/pkg/triggers/cfsync/sonarr.go
@@ -10,7 +10,7 @@ import (
 	"golift.io/starr/sonarr"
 )
 
-const TrigCFSyncSonarr common.TriggerName = "Starting Sonarr QP TRaSH sync."
+const TrigRPSyncSonarr common.TriggerName = "Starting Sonarr Release Profile TRaSH sync."
 
 // SonarrTrashPayload is the payload sent and received
 // to/from notifarr.com when updating custom formats for Sonarr.
@@ -25,7 +25,7 @@ type SonarrTrashPayload struct {
 
 // SyncSonarrRP initializes a release profile sync with sonarr.
 func (a *Action) SyncSonarrRP(event website.EventType) {
-	a.cmd.Exec(event, TrigCFSyncSonarr)
+	a.cmd.Exec(event, TrigRPSyncSonarr)
 }
 
 // syncSonarr triggers a custom format sync for Sonarr.

--- a/pkg/triggers/dashboard/dashboard.go
+++ b/pkg/triggers/dashboard/dashboard.go
@@ -255,7 +255,7 @@ func (c *Cmd) getDelugeStates() []*State {
 	states := []*State{}
 
 	for instance, app := range c.Apps.Deluge {
-		if app.Deluge.URL == "" {
+		if app.Timeout.Duration < 0 || app.Deluge.URL == "" {
 			continue
 		}
 
@@ -277,7 +277,7 @@ func (c *Cmd) getLidarrStates() []*State {
 	states := []*State{}
 
 	for instance, app := range c.Apps.Lidarr {
-		if app.URL == "" {
+		if app.Timeout.Duration < 0 || app.URL == "" {
 			continue
 		}
 
@@ -299,7 +299,7 @@ func (c *Cmd) getRadarrStates() []*State {
 	states := []*State{}
 
 	for instance, app := range c.Apps.Radarr {
-		if app.URL == "" {
+		if app.Timeout.Duration < 0 || app.URL == "" {
 			continue
 		}
 
@@ -321,7 +321,7 @@ func (c *Cmd) getReadarrStates() []*State {
 	states := []*State{}
 
 	for instance, app := range c.Apps.Readarr {
-		if app.URL == "" {
+		if app.Timeout.Duration < 0 || app.URL == "" {
 			continue
 		}
 
@@ -343,7 +343,7 @@ func (c *Cmd) getQbitStates() []*State {
 	states := []*State{}
 
 	for instance, app := range c.Apps.Qbit {
-		if app.URL == "" {
+		if app.Timeout.Duration < 0 || app.URL == "" {
 			continue
 		}
 
@@ -365,7 +365,7 @@ func (c *Cmd) getSonarrStates() []*State {
 	states := []*State{}
 
 	for instance, app := range c.Apps.Sonarr {
-		if app.URL == "" {
+		if app.Timeout.Duration < 0 || app.URL == "" {
 			continue
 		}
 
@@ -877,7 +877,7 @@ func (c *Cmd) getSabNZBStates() []*State {
 	states := []*State{}
 
 	for instance, app := range c.Apps.SabNZB {
-		if app.URL == "" {
+		if app.Timeout.Duration < 0 || app.URL == "" {
 			continue
 		}
 

--- a/pkg/triggers/dashboard/nzbget.go
+++ b/pkg/triggers/dashboard/nzbget.go
@@ -16,7 +16,7 @@ func (c *Cmd) getNZBGetStates() []*State {
 	states := []*State{}
 
 	for instance, app := range c.Apps.NZBGet {
-		if app.URL == "" {
+		if app.Timeout.Duration < 0 || app.URL == "" {
 			continue
 		}
 

--- a/pkg/triggers/dashboard/rtorrent.go
+++ b/pkg/triggers/dashboard/rtorrent.go
@@ -15,7 +15,7 @@ func (c *Cmd) getRtorrentStates() []*State {
 	states := []*State{}
 
 	for instance, app := range c.Apps.Rtorrent {
-		if app.URL == "" {
+		if app.Timeout.Duration < 0 || app.URL == "" {
 			continue
 		}
 

--- a/pkg/triggers/gaps/gaps.go
+++ b/pkg/triggers/gaps/gaps.go
@@ -64,7 +64,8 @@ func (c *cmd) sendGaps(event website.EventType) {
 
 	for idx, app := range c.Apps.Radarr {
 		instance := idx + 1
-		if app.URL == "" || app.APIKey == "" || !c.ClientInfo.Actions.Gaps.Instances.Has(instance) {
+		if app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0 ||
+			!c.ClientInfo.Actions.Gaps.Instances.Has(instance) {
 			continue
 		}
 

--- a/pkg/triggers/stuckitems/stuckitems.go
+++ b/pkg/triggers/stuckitems/stuckitems.go
@@ -70,27 +70,27 @@ func (a *Action) Create() {
 }
 
 // getTicker only returns a ticker if at least 1 app has stuck items turned on.
-func getTicker(apps *apps.Apps) *time.Ticker {
+func getTicker(apps *apps.Apps) *time.Ticker { //nolint:gocognit,cyclop
 	for _, app := range apps.Lidarr {
-		if app.StuckItem {
+		if app.StuckItem && app.URL != "" && app.APIKey != "" && app.Timeout.Duration >= 0 {
 			return time.NewTicker(stuckDur)
 		}
 	}
 
 	for _, app := range apps.Radarr {
-		if app.StuckItem {
+		if app.StuckItem && app.URL != "" && app.APIKey != "" && app.Timeout.Duration >= 0 {
 			return time.NewTicker(stuckDur)
 		}
 	}
 
 	for _, app := range apps.Readarr {
-		if app.StuckItem {
+		if app.StuckItem && app.URL != "" && app.APIKey != "" && app.Timeout.Duration >= 0 {
 			return time.NewTicker(stuckDur)
 		}
 	}
 
 	for _, app := range apps.Sonarr {
-		if app.StuckItem {
+		if app.StuckItem && app.URL != "" && app.APIKey != "" && app.Timeout.Duration >= 0 {
 			return time.NewTicker(stuckDur)
 		}
 	}
@@ -181,7 +181,7 @@ func (c *cmd) getFinishedItemsLidarr() ItemList { //nolint:dupl,cyclop
 	for idx, app := range c.Apps.Lidarr {
 		instance := idx + 1
 
-		if !app.StuckItem {
+		if !app.StuckItem || app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0 {
 			continue
 		}
 
@@ -227,7 +227,7 @@ func (c *cmd) getFinishedItemsRadarr() ItemList { //nolint:cyclop
 	for idx, app := range c.Apps.Radarr {
 		instance := idx + 1
 
-		if !app.StuckItem {
+		if !app.StuckItem || app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0 {
 			continue
 		}
 
@@ -275,7 +275,7 @@ func (c *cmd) getFinishedItemsReadarr() ItemList { //nolint:dupl,cyclop
 	for idx, app := range c.Apps.Readarr {
 		instance := idx + 1
 
-		if !app.StuckItem {
+		if !app.StuckItem || app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0 {
 			continue
 		}
 
@@ -321,7 +321,7 @@ func (c *cmd) getFinishedItemsSonarr() ItemList { //nolint:cyclop
 	for idx, app := range c.Apps.Sonarr {
 		instance := idx + 1
 
-		if !app.StuckItem {
+		if !app.StuckItem || app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0 {
 			continue
 		}
 


### PR DESCRIPTION
Closes #243. This allows an instance (starr, downloads, etc) to be disabled by setting the timeout to 'Disabled' in UI (or `-1s` in config file). This also adds selectors to all the timeouts instead of raw text input.