### PR TITLE
Fixes

### DIFF
--- a/pkg/apps/apps.go
+++ b/pkg/apps/apps.go
@@ -54,12 +54,10 @@ type Logger struct {
 	Errorf func(string, ...interface{}) `toml:"-" xml:"-" json:"-"`
 	Debugf func(string, ...interface{}) `toml:"-" xml:"-" json:"-"`
 }
+
 type starrConfig struct {
-	Name      string        `toml:"name" xml:"name" json:"name"`
-	Interval  cnfg.Duration `toml:"interval" xml:"interval" json:"interval"`
-	StuckItem bool          `toml:"stuck_items" xml:"stuck_items" json:"stuckItems"`
-	Corrupt   string        `toml:"corrupt" xml:"corrupt" json:"corrupt"`
-	Backup    string        `toml:"backup" xml:"backup" json:"backup"`
+	Name     string        `toml:"name" xml:"name" json:"name"`
+	Interval cnfg.Duration `toml:"interval" xml:"interval" json:"interval"`
 }
 
 // Errors sent to client web requests.

--- a/pkg/apps/lidarr.go
+++ b/pkg/apps/lidarr.go
@@ -50,6 +50,11 @@ type LidarrConfig struct {
 	errorf         func(string, ...interface{}) `toml:"-" xml:"-" json:"-"`
 }
 
+// Enabled returns true if the Lidarr instance is enabled and usable.
+func (l *LidarrConfig) Enabled() bool {
+	return l != nil && l.Config != nil && l.URL != "" && l.APIKey != "" && l.Timeout.Duration > 0
+}
+
 func (a *Apps) setupLidarr() error {
 	for idx, app := range a.Lidarr {
 		if app.Config == nil || app.Config.URL == "" {

--- a/pkg/apps/prowlarr.go
+++ b/pkg/apps/prowlarr.go
@@ -23,6 +23,11 @@ type ProwlarrConfig struct {
 	errorf             func(string, ...interface{}) `toml:"-" xml:"-" json:"-"`
 }
 
+// Enabled returns true if the Prowlarr instance is enabled and usable.
+func (p *ProwlarrConfig) Enabled() bool {
+	return p != nil && p.Config != nil && p.URL != "" && p.APIKey != "" && p.Timeout.Duration > 0
+}
+
 func (a *Apps) setupProwlarr() error {
 	for idx, app := range a.Prowlarr {
 		if app.Config == nil || app.Config.URL == "" {

--- a/pkg/apps/radarr.go
+++ b/pkg/apps/radarr.go
@@ -53,6 +53,11 @@ type RadarrConfig struct {
 	errorf         func(string, ...interface{}) `toml:"-" xml:"-" json:"-"`
 }
 
+// Enabled returns true if the Radarr instance is enabled and usable.
+func (r *RadarrConfig) Enabled() bool {
+	return r != nil && r.Config != nil && r.URL != "" && r.APIKey != "" && r.Timeout.Duration > 0
+}
+
 func (a *Apps) setupRadarr() error {
 	for idx, app := range a.Radarr {
 		if app.Config == nil || app.Config.URL == "" {

--- a/pkg/apps/readarr.go
+++ b/pkg/apps/readarr.go
@@ -44,6 +44,11 @@ type ReadarrConfig struct {
 	errorf           func(string, ...interface{}) `toml:"-" xml:"-" json:"-"`
 }
 
+// Enabled returns true if the Readarr instance is enabled and usable.
+func (r *ReadarrConfig) Enabled() bool {
+	return r != nil && r.Config != nil && r.URL != "" && r.APIKey != "" && r.Timeout.Duration > 0
+}
+
 func (a *Apps) setupReadarr() error {
 	for idx, app := range a.Readarr {
 		if app.Config == nil || app.Config.URL == "" {

--- a/pkg/apps/sonarr.go
+++ b/pkg/apps/sonarr.go
@@ -53,6 +53,11 @@ type SonarrConfig struct {
 	errorf func(string, ...interface{}) `toml:"-" xml:"-" json:"-"`
 }
 
+// Enabled returns true if the Sonarr instance is enabled and usable.
+func (s *SonarrConfig) Enabled() bool {
+	return s != nil && s.Config != nil && s.URL != "" && s.APIKey != "" && s.Timeout.Duration > 0
+}
+
 func (a *Apps) setupSonarr() error {
 	for idx, app := range a.Sonarr {
 		if app.Config == nil || app.Config.URL == "" {

--- a/pkg/bindata/templates/index.html
+++ b/pkg/bindata/templates/index.html
@@ -91,10 +91,7 @@
                                     <li><a class="nav-link text-grey" onClick="triggerAction('snapshot')">System Snapshot</a></li>
                                     <li><a class="nav-link text-grey" onClick="triggerAction('dashboard')">Dashboard States</a></li>
                                     <li><a class="nav-link text-grey" onClick="triggerAction('sessions')">Plex Sessions</a></li>
-                                    <li><a class="nav-link text-grey" onClick="triggerAction('stuckitems/lidarr')">Lidarr Stuck Items</a></li>
-                                    <li><a class="nav-link text-grey" onClick="triggerAction('stuckitems/radarr')">Radarr Stuck Items</a></li>
-                                    <li><a class="nav-link text-grey" onClick="triggerAction('stuckitems/readarr')">Readarr Stuck Items</a></li>
-                                    <li><a class="nav-link text-grey" onClick="triggerAction('stuckitems/sonarr')">Sonarr Stuck Items</a></li>
+                                    <li><a class="nav-link text-grey" onClick="triggerAction('stuckitems')">Stuck Items</a></li>
                                     <li><a class="nav-link text-grey" onClick="triggerAction('corrupt/lidarr')">Lidarr Corruption</a></li>
                                     <li><a class="nav-link text-grey" onClick="triggerAction('corrupt/prowlarr')">Prowlarr Corruption</a></li>
                                     <li><a class="nav-link text-grey" onClick="triggerAction('corrupt/radarr')">Radarr Corruption</a></li>

--- a/pkg/bindata/templates/triggers.html
+++ b/pkg/bindata/templates/triggers.html
@@ -34,27 +34,9 @@
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td>{{index .Expvar.TimerCounts "Checking Lidarr queue and sending incomplete items."}}</td>
+                                            <td>{{index .Expvar.TimerCounts "Sending cached stuck items to website."}}</td>
                                             <td>
-                                                <a href="#triggers" onClick="triggerAction('stuckitems/lidarr')">Lidarr Stuck Queue Items Check</a></td><td>Checks all your Lidarr apps for stuck items and sends them if they exist.
-                                            </td>
-                                        </tr>
-                                          <tr>
-                                            <td>{{index .Expvar.TimerCounts "Checking Radarr queue and sending incomplete items."}}</td>
-                                            <td>
-                                                <a href="#triggers" onClick="triggerAction('stuckitems/radarr')">Radarr Stuck Queue Items Check</a></td><td>Checks all your Radarr apps for stuck items and sends them if they exist.
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>{{index .Expvar.TimerCounts "Checking Readarr queue and sending incomplete items."}}</td>
-                                            <td>
-                                                <a href="#triggers" onClick="triggerAction('stuckitems/readarr')">Readarr Stuck Queue Items Check</a></td><td>Checks all your Readarr apps for stuck items and sends them if they exist.
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>{{index .Expvar.TimerCounts "Checking Sonarr queue and sending incomplete items."}}</td>
-                                            <td>
-                                                <a href="#triggers" onClick="triggerAction('stuckitems/sonarr')">Sonarr Stuck Queue Items Check</a></td><td>Checks all your Sonarr apps for stuck items and sends them if they exist.
+                                                <a href="#triggers" onClick="triggerAction('stuckitems')">Send Stuck Queue Items</a></td><td>Sends cached stuck queue items to website.
                                             </td>
                                         </tr>
                                         <tr>

--- a/pkg/client/handlers.go
+++ b/pkg/client/handlers.go
@@ -252,25 +252,8 @@ func (c *Client) runTrigger(source website.EventType, trigger, content string) (
 
 		return http.StatusOK, "Plex sessions triggered."
 	case "stuckitems":
-		switch strings.ToLower(content) {
-		case starr.Lidarr.Lower():
-			c.triggers.StarrQueue.LidarrStuckItems(source)
-		case starr.Radarr.Lower():
-			c.triggers.StarrQueue.RadarrStuckItems(source)
-		case starr.Readarr.Lower():
-			c.triggers.StarrQueue.ReadarrStuckItems(source)
-		case starr.Sonarr.Lower():
-			c.triggers.StarrQueue.SonarrStuckItems(source)
-		default: // XXX: need to get rid of this path.
-			c.triggers.StarrQueue.LidarrStuckItems(source)
-			c.triggers.StarrQueue.RadarrStuckItems(source)
-			c.triggers.StarrQueue.ReadarrStuckItems(source)
-			c.triggers.StarrQueue.SonarrStuckItems(source)
-
-			return http.StatusOK, "Stuck Queue Items triggered for all Starr apps."
-		}
-
-		return http.StatusOK, "Stuck Queue Items triggered for " + title.String(content) + "."
+		c.triggers.StarrQueue.StuckItems(source)
+		return http.StatusOK, "Stuck Queue Items triggered."
 	case "dashboard":
 		c.triggers.Dashboard.Send(source)
 		return http.StatusOK, "Dashboard states triggered."

--- a/pkg/client/handlers_trash.go
+++ b/pkg/client/handlers_trash.go
@@ -60,7 +60,7 @@ func (c *Client) aggregateTrashSonarr(
 
 	// Create our known+requested instances, so we can write slice values in go routines.
 	for idx, app := range c.Config.Apps.Sonarr {
-		if instance := idx + 1; instances.Has(instance) && app.URL != "" && app.APIKey != "" && app.Timeout.Duration >= 0 {
+		if instance := idx + 1; instances.Has(instance) && app.Enabled() {
 			output = append(output, &cfsync.SonarrTrashPayload{Instance: instance, Name: app.Name})
 		}
 	}
@@ -110,7 +110,7 @@ func (c *Client) aggregateTrashRadarr(
 	output := []*cfsync.RadarrTrashPayload{}
 	// Create our known+requested instances, so we can write slice values in go routines.
 	for i, app := range c.Config.Apps.Radarr {
-		if instance := i + 1; instances.Has(instance) && app.URL != "" && app.APIKey != "" && app.Timeout.Duration >= 0 {
+		if instance := i + 1; instances.Has(instance) && app.Enabled() {
 			output = append(output, &cfsync.RadarrTrashPayload{Instance: instance, Name: app.Name})
 		}
 	}

--- a/pkg/client/init.go
+++ b/pkg/client/init.go
@@ -20,6 +20,8 @@ func (c *Client) PrintStartupInfo(clientInfo *website.ClientInfo) {
 	if clientInfo != nil {
 		c.Printf("==> %s", clientInfo)
 		c.printVersionChangeInfo()
+	} else {
+		clientInfo = &website.ClientInfo{}
 	}
 
 	switch hi, err := c.website.GetHostInfo(); {
@@ -34,11 +36,11 @@ func (c *Client) PrintStartupInfo(clientInfo *website.ClientInfo) {
 
 	c.Printf("==> %s <==", mnd.HelpLink)
 	c.Printf("==> Startup Settings <==")
-	c.printLidarr()
-	c.printProwlarr()
-	c.printRadarr()
-	c.printReadarr()
-	c.printSonarr()
+	c.printLidarr(&clientInfo.Actions.Apps.Lidarr)
+	c.printProwlarr(&clientInfo.Actions.Apps.Prowlarr)
+	c.printRadarr(&clientInfo.Actions.Apps.Radarr)
+	c.printReadarr(&clientInfo.Actions.Apps.Readarr)
+	c.printSonarr(&clientInfo.Actions.Apps.Sonarr)
 	c.printDeluge()
 	c.printNZBGet()
 	c.printQbit()
@@ -135,122 +137,93 @@ func (c *Client) printPlex() {
 }
 
 // printLidarr is called on startup to print info about each configured server.
-func (c *Client) printLidarr() {
+func (c *Client) printLidarr(app *website.InstanceConfig) {
+	s := "s"
 	if len(c.Config.Lidarr) == 1 {
-		f := c.Config.Lidarr[0]
-
-		c.Printf(" => Lidarr Config: 1 server: %s apikey:%v timeout:%s verify_ssl:%v stuck_items:%v corrupt:%v backup:%v",
-			f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, f.StuckItem, f.Corrupt != "" &&
-				f.Corrupt != mnd.Disabled, f.Backup != mnd.Disabled)
-
-		return
+		s = ""
 	}
 
-	c.Print(" => Lidarr Config:", len(c.Config.Lidarr), "servers")
+	c.Print(" => Lidarr Config:", len(c.Config.Lidarr), "server"+s)
 
-	for i, f := range c.Config.Lidarr {
+	for idx, f := range c.Config.Lidarr {
 		c.Printf(" =>    Server %d: %s apikey:%v timeout:%s verify_ssl:%v stuck_items:%v corrupt:%v backup:%v",
-			i+1, f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, f.StuckItem,
-			f.Corrupt != "" && f.Corrupt != mnd.Disabled, f.Backup != mnd.Disabled)
+			idx+1, f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, app.Stuck(idx+1),
+			app.Corrupt(idx+1) != "" && app.Corrupt(idx+1) != mnd.Disabled, app.Backup(idx+1) != mnd.Disabled)
 	}
 }
 
 // printProwlarr is called on startup to print info about each configured server.
-func (c *Client) printProwlarr() {
+func (c *Client) printProwlarr(app *website.InstanceConfig) {
+	s := "s"
 	if len(c.Config.Prowlarr) == 1 {
-		f := c.Config.Prowlarr[0]
-
-		c.Printf(" => Prowlarr Config: 1 server: %s apikey:%v timeout:%s verify_ssl:%v corrupt:%v backup:%v",
-			f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, f.Corrupt != "" &&
-				f.Corrupt != mnd.Disabled, f.Backup != mnd.Disabled)
-
-		return
+		s = ""
 	}
 
-	c.Print(" => Prowlarr Config:", len(c.Config.Prowlarr), "servers")
+	c.Print(" => Prowlarr Config:", len(c.Config.Prowlarr), "server"+s)
 
-	for i, f := range c.Config.Prowlarr {
+	for idx, f := range c.Config.Prowlarr {
 		c.Printf(" =>    Server %d: %s apikey:%v timeout:%s verify_ssl:%v corrupt:%v backup:%v",
-			i+1, f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, f.Corrupt != "" &&
-				f.Corrupt != mnd.Disabled, f.Backup != mnd.Disabled)
+			idx+1, f.URL, f.APIKey != "", f.Timeout, f.ValidSSL,
+			app.Corrupt(idx+1) != "" && app.Corrupt(idx+1) != mnd.Disabled, app.Backup(idx+1) != mnd.Disabled)
 	}
 }
 
 // printRadarr is called on startup to print info about each configured server.
-func (c *Client) printRadarr() {
+func (c *Client) printRadarr(app *website.InstanceConfig) {
+	s := "s"
 	if len(c.Config.Radarr) == 1 {
-		f := c.Config.Radarr[0]
-
-		c.Printf(" => Radarr Config: 1 server: %s apikey:%v timeout:%s verify_ssl:%v stuck_items:%v corrupt:%v backup:%v",
-			f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, f.StuckItem, f.Corrupt != "" &&
-				f.Corrupt != mnd.Disabled, f.Backup != mnd.Disabled)
-
-		return
+		s = ""
 	}
 
-	c.Print(" => Radarr Config:", len(c.Config.Radarr), "servers")
+	c.Print(" => Radarr Config:", len(c.Config.Radarr), "server"+s)
 
-	for i, f := range c.Config.Radarr {
+	for idx, f := range c.Config.Radarr {
 		c.Printf(" =>    Server %d: %s apikey:%v timeout:%s verify_ssl:%v stuck_items:%v corrupt:%v backup:%v",
-			i+1, f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, f.StuckItem, f.Corrupt != "" &&
-				f.Corrupt != mnd.Disabled, f.Backup != mnd.Disabled)
+			idx+1, f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, app.Stuck(idx+1),
+			app.Corrupt(idx+1) != "" && app.Corrupt(idx+1) != mnd.Disabled, app.Backup(idx+1) != mnd.Disabled)
 	}
 }
 
 // printReadarr is called on startup to print info about each configured server.
-func (c *Client) printReadarr() {
+func (c *Client) printReadarr(app *website.InstanceConfig) {
+	s := "s"
 	if len(c.Config.Readarr) == 1 {
-		f := c.Config.Readarr[0]
-
-		c.Printf(" => Readarr Config: 1 server: %s apikey:%v timeout:%s verify_ssl:%v stuck_items:%v corrupt:%v backup:%v",
-			f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, f.StuckItem, f.Corrupt != "" &&
-				f.Corrupt != mnd.Disabled, f.Backup != mnd.Disabled)
-
-		return
+		s = ""
 	}
 
-	c.Print(" => Readarr Config:", len(c.Config.Readarr), "servers")
+	c.Print(" => Readarr Config:", len(c.Config.Readarr), "server"+s)
 
-	for i, f := range c.Config.Readarr {
+	for idx, f := range c.Config.Readarr {
 		c.Printf(" =>    Server %d: %s apikey:%v timeout:%s verify_ssl:%v stuck_items:%v corrupt:%v backup:%v",
-			i+1, f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, f.StuckItem, f.Corrupt != "" &&
-				f.Corrupt != mnd.Disabled, f.Backup != mnd.Disabled)
+			idx+1, f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, app.Stuck(idx+1),
+			app.Corrupt(idx+1) != "" && app.Corrupt(idx+1) != mnd.Disabled, app.Backup(idx+1) != mnd.Disabled)
 	}
 }
 
 // printSonarr is called on startup to print info about each configured server.
-func (c *Client) printSonarr() {
+func (c *Client) printSonarr(app *website.InstanceConfig) {
+	s := "s"
 	if len(c.Config.Sonarr) == 1 {
-		f := c.Config.Sonarr[0]
-
-		c.Printf(" => Sonarr Config: 1 server: %s apikey:%v timeout:%s verify_ssl:%v stuck_items:%v corrupt:%v backup:%v",
-			f.URL, f.APIKey != "", f.Timeout.String(), f.ValidSSL, f.StuckItem, f.Corrupt != "" &&
-				f.Corrupt != mnd.Disabled, f.Backup != mnd.Disabled)
-
-		return
+		s = ""
 	}
 
-	c.Print(" => Sonarr Config:", len(c.Config.Sonarr), "servers")
+	c.Print(" => Sonarr Config:", len(c.Config.Sonarr), "server"+s)
 
-	for i, f := range c.Config.Sonarr {
+	for idx, f := range c.Config.Sonarr {
 		c.Printf(" =>    Server %d: %s apikey:%v timeout:%s verify_ssl:%v stuck_items:%v corrupt:%v backup:%v",
-			i+1, f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, f.StuckItem, f.Corrupt != "" &&
-				f.Corrupt != mnd.Disabled, f.Backup != mnd.Disabled)
+			idx+1, f.URL, f.APIKey != "", f.Timeout, f.ValidSSL, app.Stuck(idx+1),
+			app.Corrupt(idx+1) != "" && app.Corrupt(idx+1) != mnd.Disabled, app.Backup(idx+1) != mnd.Disabled)
 	}
 }
 
 // printDeluge is called on startup to print info about each configured server.
 func (c *Client) printDeluge() {
+	s := "s'"
 	if len(c.Config.Deluge) == 1 {
-		f := c.Config.Deluge[0]
-
-		c.Printf(" => Deluge Config: 1 server: %s password:%v timeout:%s verify_ssl:%v",
-			f.Config.URL, f.Password != "", cnfg.Duration{Duration: f.Timeout.Duration}, f.VerifySSL)
-
-		return
+		s = ""
 	}
 
-	c.Print(" => Deluge Config:", len(c.Config.Deluge), "servers")
+	c.Print(" => Deluge Config:", len(c.Config.Deluge), "server"+s)
 
 	for i, f := range c.Config.Deluge {
 		c.Printf(" =>    Server %d: %s password:%v timeout:%s verify_ssl:%v",
@@ -260,16 +233,12 @@ func (c *Client) printDeluge() {
 
 // printNZBGet is called on startup to print info about each configured server.
 func (c *Client) printNZBGet() {
+	s := "s"
 	if len(c.Config.NZBGet) == 1 {
-		f := c.Config.NZBGet[0]
-
-		c.Printf(" => NZBGet Config: 1 server: %s username:%s password:%v timeout:%s verify_ssl:%v",
-			f.Config.URL, f.User, f.Pass != "", cnfg.Duration{Duration: f.Timeout.Duration}, f.VerifySSL)
-
-		return
+		s = ""
 	}
 
-	c.Print(" => NZBGet Config:", len(c.Config.NZBGet), "servers")
+	c.Print(" => NZBGet Config:", len(c.Config.NZBGet), "server"+s)
 
 	for i, f := range c.Config.NZBGet {
 		c.Printf(" =>    Server %d: %s username:%s password:%v timeout:%s verify_ssl:%v",
@@ -279,16 +248,12 @@ func (c *Client) printNZBGet() {
 
 // printQbit is called on startup to print info about each configured server.
 func (c *Client) printQbit() {
+	s := "s"
 	if len(c.Config.Qbit) == 1 {
-		f := c.Config.Qbit[0]
-
-		c.Printf(" => Qbit Config: 1 server: %s username:%s password:%v timeout:%s verify_ssl:%v",
-			f.Config.URL, f.User, f.Pass != "", cnfg.Duration{Duration: f.Timeout.Duration}, f.VerifySSL)
-
-		return
+		s = ""
 	}
 
-	c.Print(" => Qbit Config:", len(c.Config.Qbit), "servers")
+	c.Print(" => Qbit Config:", len(c.Config.Qbit), "server"+s)
 
 	for i, f := range c.Config.Qbit {
 		c.Printf(" =>    Server %d: %s username:%s password:%v timeout:%s verify_ssl:%v",
@@ -298,16 +263,12 @@ func (c *Client) printQbit() {
 
 // printRtorrent is called on startup to print info about each configured server.
 func (c *Client) printRtorrent() {
+	s := "s"
 	if len(c.Config.Rtorrent) == 1 {
-		f := c.Config.Rtorrent[0]
-
-		c.Printf(" => rTorrent Config: 1 server: %s username:%s password:%v timeout:%s verify_ssl:%v",
-			f.URL, f.User, f.Pass != "", cnfg.Duration{Duration: f.Timeout.Duration}, f.VerifySSL)
-
-		return
+		s = ""
 	}
 
-	c.Print(" => rTorrent Config:", len(c.Config.Rtorrent), "servers")
+	c.Print(" => rTorrent Config:", len(c.Config.Rtorrent), "server"+s)
 
 	for i, f := range c.Config.Rtorrent {
 		c.Printf(" =>    Server %d: %s username:%s password:%v timeout:%s verify_ssl:%v",
@@ -317,15 +278,12 @@ func (c *Client) printRtorrent() {
 
 // printSABnzbd is called on startup to print info about each configured SAB downloader.
 func (c *Client) printSABnzbd() {
+	s := "s"
 	if len(c.Config.SabNZB) == 1 {
-		f := c.Config.SabNZB[0]
-
-		c.Printf(" => SABnzbd Config: 1 server: %s api_key:%v timeout:%s", f.URL, f.APIKey != "", f.Timeout)
-
-		return
+		s = ""
 	}
 
-	c.Print(" => SABnzbd Config:", len(c.Config.SabNZB), "servers")
+	c.Print(" => SABnzbd Config:", len(c.Config.SabNZB), "server"+s)
 
 	for i, f := range c.Config.SabNZB {
 		c.Printf(" =>    Server %d: %s, api_key:%v timeout:%s", i+1, f.URL, f.APIKey != "", f.Timeout)
@@ -351,18 +309,12 @@ func (c *Client) printMySQL() {
 		return
 	}
 
+	s := "s"
 	if len(c.Config.Snapshot.MySQL) == 1 {
-		if m := c.Config.Snapshot.MySQL[0]; m.Name != "" {
-			c.Printf(" => MySQL Config: 1 server: %s user:%v timeout:%s check_interval:%s name:%s",
-				m.Host, m.User, m.Timeout, m.Interval, m.Name)
-		} else {
-			c.Printf(" => MySQL Config: 1 server: %s user:%v timeout:%s", m.Host, m.User, m.Timeout)
-		}
-
-		return
+		s = ""
 	}
 
-	c.Print(" => MySQL Config:", len(c.Config.Snapshot.MySQL), "servers")
+	c.Print(" => MySQL Config:", len(c.Config.Snapshot.MySQL), "server"+s)
 
 	for i, m := range c.Config.Snapshot.MySQL {
 		if m.Name != "" {

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -82,15 +82,19 @@ func Start() error {
 	client := newDefaults()
 	client.Flags.ParseArgs(os.Args[1:])
 
+	//nolint:forbidigo,wrapcheck
 	switch {
+	case client.Flags.LongVerReq: // print version and exit.
+		_, err := fmt.Println(version.Print(client.Flags.Name()))
+		return err
 	case client.Flags.VerReq: // print version and exit.
-		fmt.Println(version.Print(client.Flags.Name())) //nolint:forbidigo
-		return nil
+		_, err := fmt.Println(client.Flags.Name() + " " + version.Version + "-" + version.Revision)
+		return err
 	case client.Flags.PSlist: // print process list and exit.
 		return printProcessList()
 	case client.Flags.Fortune: // print fortune and exit.
-		fmt.Println(Fortune()) //nolint:forbidigo
-		return nil
+		_, err := fmt.Println(Fortune())
+		return err
 	case client.Flags.Curl != "": // curl a URL and exit.
 		return curlURL(client.Flags.Curl, client.Flags.Headers)
 	default:

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -195,65 +195,7 @@ func (c *Client) loadSiteConfig() *website.ClientInfo {
 		c.Config.Snapshot.MyTop = clientInfo.Actions.Snapshot.MyTop
 	}
 
-	c.loadSiteAppsConfig(clientInfo)
-
 	return clientInfo
-}
-
-func (c *Client) loadSiteAppsConfig(clientInfo *website.ClientInfo) { //nolint:cyclop
-	for _, app := range clientInfo.Actions.Apps.Lidarr {
-		if app.Instance < 1 || app.Instance > len(c.Config.Apps.Lidarr) {
-			c.ErrorfNoShare("Website provided configuration for missing Lidarr app: %d:%s", app.Instance, app.Name)
-			continue
-		}
-
-		c.Config.Apps.Lidarr[app.Instance-1].StuckItem = app.Stuck
-		c.Config.Apps.Lidarr[app.Instance-1].Corrupt = app.Corrupt
-		c.Config.Apps.Lidarr[app.Instance-1].Backup = app.Backup
-	}
-
-	for _, app := range clientInfo.Actions.Apps.Prowlarr {
-		if app.Instance < 1 || app.Instance > len(c.Config.Apps.Prowlarr) {
-			c.ErrorfNoShare("Website provided configuration for missing Prowlarr app: %d:%s", app.Instance, app.Name)
-			continue
-		}
-
-		c.Config.Apps.Prowlarr[app.Instance-1].Corrupt = app.Corrupt
-		c.Config.Apps.Prowlarr[app.Instance-1].Backup = app.Backup
-	}
-
-	for _, app := range clientInfo.Actions.Apps.Radarr {
-		if app.Instance < 1 || app.Instance > len(c.Config.Apps.Radarr) {
-			c.ErrorfNoShare("Website provided configuration for missing Radarr app: %d:%s", app.Instance, app.Name)
-			continue
-		}
-
-		c.Config.Apps.Radarr[app.Instance-1].StuckItem = app.Stuck
-		c.Config.Apps.Radarr[app.Instance-1].Corrupt = app.Corrupt
-		c.Config.Apps.Radarr[app.Instance-1].Backup = app.Backup
-	}
-
-	for _, app := range clientInfo.Actions.Apps.Readarr {
-		if app.Instance < 1 || app.Instance > len(c.Config.Apps.Readarr) {
-			c.ErrorfNoShare("Website provided configuration for missing Readarr app: %d:%s", app.Instance, app.Name)
-			continue
-		}
-
-		c.Config.Apps.Readarr[app.Instance-1].StuckItem = app.Stuck
-		c.Config.Apps.Readarr[app.Instance-1].Corrupt = app.Corrupt
-		c.Config.Apps.Readarr[app.Instance-1].Backup = app.Backup
-	}
-
-	for _, app := range clientInfo.Actions.Apps.Sonarr {
-		if app.Instance < 1 || app.Instance > len(c.Config.Apps.Sonarr) {
-			c.ErrorfNoShare("Website provided configuration for missing Sonarr app: %d:%s", app.Instance, app.Name)
-			continue
-		}
-
-		c.Config.Apps.Sonarr[app.Instance-1].StuckItem = app.Stuck
-		c.Config.Apps.Sonarr[app.Instance-1].Corrupt = app.Corrupt
-		c.Config.Apps.Sonarr[app.Instance-1].Backup = app.Backup
-	}
 }
 
 // configureServices is called on startup and on reload, so be careful what goes in here.

--- a/pkg/configfile/flags.go
+++ b/pkg/configfile/flags.go
@@ -16,6 +16,7 @@ import (
 type Flags struct {
 	*flag.FlagSet `json:"-"`
 	VerReq        bool     `json:"verReq"`
+	LongVerReq    bool     `json:"longVerReq"`
 	Restart       bool     `json:"restart"`
 	AptHook       bool     `json:"aptHook"`
 	Updated       bool     `json:"updated"`
@@ -39,7 +40,8 @@ func (f *Flags) ParseArgs(args []string) {
 	f.StringSliceVarP(&f.ExtraConf, "extraconfig", "e", nil, "This app supports multiple config files. "+
 		"Separate with commas, or pass -e more than once.")
 	f.StringVarP(&f.EnvPrefix, "prefix", "p", mnd.DefaultEnvPrefix, "Environment Variable Prefix.")
-	f.BoolVarP(&f.VerReq, "version", "v", false, "Print the version and exit.")
+	f.BoolVar(&f.LongVerReq, "version", false, "Print the long version and exit.")
+	f.BoolVarP(&f.VerReq, "v", "v", false, "Print the version and exit.")
 	f.BoolVar(&f.Fortune, "fortune", false, "Print a fortune and exit.")
 	f.StringVar(&f.Curl, "curl", "", "GET a URL and display headers and payload.")
 	f.StringSliceVar(&f.Headers, "header", nil, "Use with --curl to add a request header.")

--- a/pkg/services/apps.go
+++ b/pkg/services/apps.go
@@ -23,12 +23,13 @@ func (c *Config) collectApps() []*Service {
 
 func (c *Config) collectLidarrApps(svcs []*Service) []*Service {
 	for _, app := range c.Apps.Lidarr {
-		if app.Timeout.Duration < 0 {
+		if !app.Enabled() {
 			continue
 		}
 
-		if app.Interval.Duration == 0 {
-			app.Interval.Duration = DefaultCheckInterval
+		interval := app.Interval
+		if interval.Duration == 0 {
+			interval.Duration = DefaultCheckInterval
 		}
 
 		if app.Name != "" {
@@ -38,7 +39,7 @@ func (c *Config) collectLidarrApps(svcs []*Service) []*Service {
 				Value:    app.URL + "/api/v1/system/status?apikey=" + app.APIKey,
 				Expect:   "200",
 				Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-				Interval: app.Interval,
+				Interval: interval,
 				validSSL: app.ValidSSL,
 			})
 		}
@@ -49,12 +50,13 @@ func (c *Config) collectLidarrApps(svcs []*Service) []*Service {
 
 func (c *Config) collectProwlarrApps(svcs []*Service) []*Service {
 	for _, app := range c.Apps.Prowlarr {
-		if app.Timeout.Duration < 0 {
+		if !app.Enabled() {
 			continue
 		}
 
-		if app.Interval.Duration == 0 {
-			app.Interval.Duration = DefaultCheckInterval
+		interval := app.Interval
+		if interval.Duration == 0 {
+			interval.Duration = DefaultCheckInterval
 		}
 
 		if app.Name != "" {
@@ -64,7 +66,7 @@ func (c *Config) collectProwlarrApps(svcs []*Service) []*Service {
 				Value:    app.URL + "/api/v1/system/status?apikey=" + app.APIKey,
 				Expect:   "200",
 				Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-				Interval: app.Interval,
+				Interval: interval,
 				validSSL: app.ValidSSL,
 			})
 		}
@@ -75,12 +77,13 @@ func (c *Config) collectProwlarrApps(svcs []*Service) []*Service {
 
 func (c *Config) collectRadarrApps(svcs []*Service) []*Service {
 	for _, app := range c.Apps.Radarr {
-		if app.Timeout.Duration < 0 {
+		if !app.Enabled() {
 			continue
 		}
 
-		if app.Interval.Duration == 0 {
-			app.Interval.Duration = DefaultCheckInterval
+		interval := app.Interval
+		if interval.Duration == 0 {
+			interval.Duration = DefaultCheckInterval
 		}
 
 		if app.Name != "" {
@@ -90,7 +93,7 @@ func (c *Config) collectRadarrApps(svcs []*Service) []*Service {
 				Value:    app.URL + "/api/v3/system/status?apikey=" + app.APIKey,
 				Expect:   "200",
 				Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-				Interval: app.Interval,
+				Interval: interval,
 				validSSL: app.ValidSSL,
 			})
 		}
@@ -101,12 +104,13 @@ func (c *Config) collectRadarrApps(svcs []*Service) []*Service {
 
 func (c *Config) collectReadarrApps(svcs []*Service) []*Service {
 	for _, app := range c.Apps.Readarr {
-		if app.Timeout.Duration < 0 {
+		if !app.Enabled() {
 			continue
 		}
 
-		if app.Interval.Duration == 0 {
-			app.Interval.Duration = DefaultCheckInterval
+		interval := app.Interval
+		if interval.Duration == 0 {
+			interval.Duration = DefaultCheckInterval
 		}
 
 		if app.Name != "" {
@@ -116,7 +120,7 @@ func (c *Config) collectReadarrApps(svcs []*Service) []*Service {
 				Value:    app.URL + "/api/v1/system/status?apikey=" + app.APIKey,
 				Expect:   "200",
 				Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-				Interval: app.Interval,
+				Interval: interval,
 				validSSL: app.ValidSSL,
 			})
 		}
@@ -127,12 +131,13 @@ func (c *Config) collectReadarrApps(svcs []*Service) []*Service {
 
 func (c *Config) collectSonarrApps(svcs []*Service) []*Service {
 	for _, app := range c.Apps.Sonarr {
-		if app.Timeout.Duration < 0 {
+		if !app.Enabled() {
 			continue
 		}
 
-		if app.Interval.Duration == 0 {
-			app.Interval.Duration = DefaultCheckInterval
+		interval := app.Interval
+		if interval.Duration == 0 {
+			interval.Duration = DefaultCheckInterval
 		}
 
 		if app.Name != "" {
@@ -142,7 +147,7 @@ func (c *Config) collectSonarrApps(svcs []*Service) []*Service {
 				Value:    app.URL + "/api/v3/system/status?apikey=" + app.APIKey,
 				Expect:   "200",
 				Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-				Interval: app.Interval,
+				Interval: interval,
 				validSSL: app.ValidSSL,
 			})
 		}
@@ -158,8 +163,9 @@ func (c *Config) collectDownloadApps(svcs []*Service) []*Service { //nolint:funl
 			continue
 		}
 
-		if app.Interval.Duration == 0 {
-			app.Interval.Duration = DefaultCheckInterval
+		interval := app.Interval
+		if interval.Duration == 0 {
+			interval.Duration = DefaultCheckInterval
 		}
 
 		if app.Name != "" {
@@ -169,7 +175,7 @@ func (c *Config) collectDownloadApps(svcs []*Service) []*Service { //nolint:funl
 				Value:    strings.TrimSuffix(app.Config.URL, "/json"),
 				Expect:   "200",
 				Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-				Interval: app.Interval,
+				Interval: interval,
 				validSSL: app.VerifySSL,
 			})
 		}
@@ -181,18 +187,27 @@ func (c *Config) collectDownloadApps(svcs []*Service) []*Service { //nolint:funl
 			continue
 		}
 
-		if app.Interval.Duration == 0 {
-			app.Interval.Duration = DefaultCheckInterval
+		interval := app.Interval
+		if interval.Duration == 0 {
+			interval.Duration = DefaultCheckInterval
+		}
+
+		prefix := "" // add auth to the url here. woo, hacky, but it works!
+		if !strings.Contains(app.Config.URL, "@") {
+			prefix = "http://" + app.User + ":" + app.Pass + "@"
+			if strings.HasPrefix(app.Config.URL, "https://") {
+				prefix = "https://" + app.User + ":" + app.Pass + "@"
+			}
 		}
 
 		if app.Name != "" {
 			svcs = append(svcs, &Service{
 				Name:     app.Name,
 				Type:     CheckHTTP,
-				Value:    app.Config.URL,
+				Value:    prefix + strings.TrimPrefix(strings.TrimPrefix(app.Config.URL, "https://"), "http://"),
 				Expect:   "200",
 				Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-				Interval: app.Interval,
+				Interval: interval,
 				validSSL: app.VerifySSL,
 			})
 		}
@@ -204,8 +219,9 @@ func (c *Config) collectDownloadApps(svcs []*Service) []*Service { //nolint:funl
 			continue
 		}
 
-		if app.Interval.Duration == 0 {
-			app.Interval.Duration = DefaultCheckInterval
+		interval := app.Interval
+		if interval.Duration == 0 {
+			interval.Duration = DefaultCheckInterval
 		}
 
 		if app.Name != "" {
@@ -215,7 +231,7 @@ func (c *Config) collectDownloadApps(svcs []*Service) []*Service { //nolint:funl
 				Value:    app.URL,
 				Expect:   "200",
 				Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-				Interval: app.Interval,
+				Interval: interval,
 				validSSL: app.VerifySSL,
 			})
 		}
@@ -227,8 +243,9 @@ func (c *Config) collectDownloadApps(svcs []*Service) []*Service { //nolint:funl
 			continue
 		}
 
-		if app.Interval.Duration == 0 {
-			app.Interval.Duration = DefaultCheckInterval
+		interval := app.Interval
+		if interval.Duration == 0 {
+			interval.Duration = DefaultCheckInterval
 		}
 
 		if app.Name != "" {
@@ -238,7 +255,7 @@ func (c *Config) collectDownloadApps(svcs []*Service) []*Service { //nolint:funl
 				Value:    app.URL,
 				Expect:   "200,401", // could not find a 200...
 				Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-				Interval: app.Interval,
+				Interval: interval,
 				validSSL: app.VerifySSL,
 			})
 		}
@@ -250,8 +267,9 @@ func (c *Config) collectDownloadApps(svcs []*Service) []*Service { //nolint:funl
 			continue
 		}
 
-		if app.Interval.Duration == 0 {
-			app.Interval.Duration = DefaultCheckInterval
+		interval := app.Interval
+		if interval.Duration == 0 {
+			interval.Duration = DefaultCheckInterval
 		}
 
 		if app.Name != "" {
@@ -261,7 +279,7 @@ func (c *Config) collectDownloadApps(svcs []*Service) []*Service { //nolint:funl
 				Value:    app.URL + "/api?mode=version&apikey=" + app.APIKey,
 				Expect:   "200",
 				Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-				Interval: app.Interval,
+				Interval: interval,
 				validSSL: app.VerifySSL,
 			})
 		}
@@ -277,8 +295,9 @@ func (c *Config) collectTautulliApp(svcs []*Service) []*Service {
 			return svcs
 		}
 
-		if app.Interval.Duration == 0 {
-			app.Interval.Duration = DefaultCheckInterval
+		interval := app.Interval
+		if interval.Duration == 0 {
+			interval.Duration = DefaultCheckInterval
 		}
 
 		svcs = append(svcs, &Service{
@@ -287,7 +306,7 @@ func (c *Config) collectTautulliApp(svcs []*Service) []*Service {
 			Value:    app.URL + "/api/v2?cmd=status&apikey=" + app.APIKey,
 			Expect:   "200",
 			Timeout:  app.Timeout,
-			Interval: app.Interval,
+			Interval: interval,
 			validSSL: app.VerifySSL,
 		})
 	}
@@ -307,8 +326,9 @@ func (c *Config) collectMySQLApps(svcs []*Service) []*Service {
 			plugin.Timeout.Duration = DefaultTimeout
 		}
 
-		if plugin.Interval.Duration == 0 {
-			plugin.Interval.Duration = DefaultCheckInterval
+		interval := plugin.Interval
+		if interval.Duration == 0 {
+			interval.Duration = DefaultCheckInterval
 		}
 
 		host := strings.TrimLeft(strings.TrimRight(plugin.Host, ")"), "@tcp(")
@@ -325,7 +345,7 @@ func (c *Config) collectMySQLApps(svcs []*Service) []*Service {
 			Type:     CheckTCP,
 			Value:    host,
 			Timeout:  plugin.Timeout,
-			Interval: plugin.Interval,
+			Interval: interval,
 		})
 	}
 

--- a/pkg/services/checks.go
+++ b/pkg/services/checks.go
@@ -242,3 +242,10 @@ func (s *Service) checkPING() *result {
 		output: "ping does not work yet",
 	}
 }
+
+func (s *Service) Due() bool {
+	s.svc.RLock()
+	defer s.svc.RUnlock()
+
+	return time.Since(s.svc.LastCheck) > s.Interval.Duration
+}

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -116,10 +116,3 @@ type service struct {
 	proc         *procExpect // only used for process checks.
 	sync.RWMutex `json:"-"`
 }
-
-func (s *service) Due(interval time.Duration) bool {
-	s.RLock()
-	defer s.RUnlock()
-
-	return time.Since(s.LastCheck) > interval
-}

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -116,3 +116,10 @@ type service struct {
 	proc         *procExpect // only used for process checks.
 	sync.RWMutex `json:"-"`
 }
+
+func (s *service) Due(interval time.Duration) bool {
+	s.RLock()
+	defer s.RUnlock()
+
+	return time.Since(s.LastCheck) > interval
+}

--- a/pkg/services/interface.go
+++ b/pkg/services/interface.go
@@ -46,7 +46,7 @@ func (c *Config) RunCheck(source website.EventType, name string) error {
 
 // runCheck runs a service check if it is due. Passing force runs it regardless.
 func (c *Config) runCheck(svc *Service, force bool) bool {
-	if force || svc.svc.Due(svc.Interval.Duration) {
+	if force || svc.Due() {
 		c.checks <- svc
 		return <-c.done
 	}

--- a/pkg/services/interface.go
+++ b/pkg/services/interface.go
@@ -46,10 +46,7 @@ func (c *Config) RunCheck(source website.EventType, name string) error {
 
 // runCheck runs a service check if it is due. Passing force runs it regardless.
 func (c *Config) runCheck(svc *Service, force bool) bool {
-	svc.svc.RLock()
-	defer svc.svc.RUnlock()
-
-	if force || svc.svc.LastCheck.Add(svc.Interval.Duration).Before(time.Now()) {
+	if force || svc.svc.Due(svc.Interval.Duration) {
 		c.checks <- svc
 		return <-c.done
 	}

--- a/pkg/triggers/backups/backups.go
+++ b/pkg/triggers/backups/backups.go
@@ -43,8 +43,8 @@ func (c *cmd) makeBackupTriggersLidarr() {
 	var ticker *time.Ticker
 
 	//nolint:gosec
-	for _, app := range c.Apps.Lidarr {
-		if app.Backup != mnd.Disabled && app.Timeout.Duration >= 0 && app.URL != "" {
+	for idx, app := range c.Apps.Lidarr {
+		if c.HaveClientInfo() && c.ClientInfo.Actions.Apps.Lidarr.Backup(idx+1) != mnd.Disabled && app.Enabled() {
 			randomTime := time.Duration(rand.Intn(randomMinutes))*time.Second +
 				time.Duration(rand.Intn(randomMinutes))*time.Minute
 			ticker = time.NewTicker(checkInterval + randomTime)
@@ -65,8 +65,8 @@ func (c *cmd) makeBackupTriggersRadarr() {
 	var ticker *time.Ticker
 
 	//nolint:gosec
-	for _, app := range c.Apps.Radarr {
-		if app.Backup != mnd.Disabled && app.Timeout.Duration >= 0 && app.URL != "" {
+	for idx, app := range c.Apps.Radarr {
+		if c.HaveClientInfo() && c.ClientInfo.Actions.Apps.Radarr.Backup(idx+1) != mnd.Disabled && app.Enabled() {
 			randomTime := time.Duration(rand.Intn(randomMinutes))*time.Second +
 				time.Duration(rand.Intn(randomMinutes))*time.Minute
 			ticker = time.NewTicker(checkInterval + randomTime)
@@ -87,8 +87,8 @@ func (c *cmd) makeBackupTriggersReadarr() {
 	var ticker *time.Ticker
 
 	//nolint:gosec
-	for _, app := range c.Apps.Readarr {
-		if app.Backup != mnd.Disabled && app.Timeout.Duration >= 0 && app.URL != "" {
+	for idx, app := range c.Apps.Readarr {
+		if c.HaveClientInfo() && c.ClientInfo.Actions.Apps.Readarr.Backup(idx+1) != mnd.Disabled && app.Enabled() {
 			randomTime := time.Duration(rand.Intn(randomMinutes))*time.Second +
 				time.Duration(rand.Intn(randomMinutes))*time.Minute
 			ticker = time.NewTicker(checkInterval + randomTime)
@@ -109,8 +109,8 @@ func (c *cmd) makeBackupTriggersSonarr() {
 	var ticker *time.Ticker
 
 	//nolint:gosec
-	for _, app := range c.Apps.Sonarr {
-		if app.Backup != mnd.Disabled && app.Timeout.Duration >= 0 && app.URL != "" {
+	for idx, app := range c.Apps.Sonarr {
+		if c.HaveClientInfo() && c.ClientInfo.Actions.Apps.Sonarr.Backup(idx+1) != mnd.Disabled && app.Enabled() {
 			randomTime := time.Duration(rand.Intn(randomMinutes))*time.Second +
 				time.Duration(rand.Intn(randomMinutes))*time.Minute
 			ticker = time.NewTicker(checkInterval + randomTime)
@@ -131,8 +131,8 @@ func (c *cmd) makeBackupTriggersProwlarr() {
 	var ticker *time.Ticker
 
 	//nolint:gosec
-	for _, app := range c.Apps.Prowlarr {
-		if app.Backup != mnd.Disabled && app.Timeout.Duration >= 0 && app.URL != "" {
+	for idx, app := range c.Apps.Prowlarr {
+		if c.HaveClientInfo() && c.ClientInfo.Actions.Apps.Prowlarr.Backup(idx+1) != mnd.Disabled && app.Enabled() {
 			randomTime := time.Duration(rand.Intn(randomMinutes))*time.Second +
 				time.Duration(rand.Intn(randomMinutes))*time.Minute
 			ticker = time.NewTicker(checkInterval + randomTime)
@@ -151,7 +151,8 @@ func (c *cmd) makeBackupTriggersProwlarr() {
 
 func (c *cmd) sendLidarrBackups(event website.EventType) {
 	for idx, app := range c.Apps.Lidarr {
-		if app.Backup != mnd.Disabled || event != website.EventCron {
+		if event != website.EventCron ||
+			(c.HaveClientInfo() && c.ClientInfo.Actions.Apps.Lidarr.Backup(idx+1) != mnd.Disabled) {
 			c.sendBackups(&genericInstance{
 				event: event,
 				name:  starr.Lidarr,
@@ -166,7 +167,8 @@ func (c *cmd) sendLidarrBackups(event website.EventType) {
 
 func (c *cmd) sendProwlarrBackups(event website.EventType) {
 	for idx, app := range c.Apps.Prowlarr {
-		if app.Backup != mnd.Disabled || event != website.EventCron {
+		if event != website.EventCron ||
+			(c.HaveClientInfo() && c.ClientInfo.Actions.Apps.Prowlarr.Backup(idx+1) != mnd.Disabled) {
 			c.sendBackups(&genericInstance{
 				event: event,
 				name:  starr.Prowlarr,
@@ -181,7 +183,8 @@ func (c *cmd) sendProwlarrBackups(event website.EventType) {
 
 func (c *cmd) sendRadarrBackups(event website.EventType) {
 	for idx, app := range c.Apps.Radarr {
-		if app.Backup != mnd.Disabled || event != website.EventCron {
+		if event != website.EventCron ||
+			(c.HaveClientInfo() && c.ClientInfo.Actions.Apps.Radarr.Backup(idx+1) != mnd.Disabled) {
 			c.sendBackups(&genericInstance{
 				event: event,
 				name:  starr.Radarr,
@@ -196,7 +199,8 @@ func (c *cmd) sendRadarrBackups(event website.EventType) {
 
 func (c *cmd) sendReadarrBackups(event website.EventType) {
 	for idx, app := range c.Apps.Readarr {
-		if app.Backup != mnd.Disabled || event != website.EventCron {
+		if event != website.EventCron ||
+			(c.HaveClientInfo() && c.ClientInfo.Actions.Apps.Readarr.Backup(idx+1) != mnd.Disabled) {
 			c.sendBackups(&genericInstance{
 				event: event,
 				name:  starr.Readarr,
@@ -211,7 +215,8 @@ func (c *cmd) sendReadarrBackups(event website.EventType) {
 
 func (c *cmd) sendSonarrBackups(event website.EventType) {
 	for idx, app := range c.Apps.Sonarr {
-		if app.Backup != mnd.Disabled || event != website.EventCron {
+		if event != website.EventCron ||
+			(c.HaveClientInfo() && c.ClientInfo.Actions.Apps.Sonarr.Backup(idx+1) != mnd.Disabled) {
 			c.sendBackups(&genericInstance{
 				event: event,
 				name:  starr.Sonarr,

--- a/pkg/triggers/backups/config.go
+++ b/pkg/triggers/backups/config.go
@@ -16,6 +16,11 @@ type Action struct {
 
 type cmd struct {
 	*common.Config
+	lidarr   map[int]string
+	prowlarr map[int]string
+	radarr   map[int]string
+	readarr  map[int]string
+	sonarr   map[int]string
 }
 
 // Errors returned by this package.
@@ -85,7 +90,14 @@ type Payload struct {
 
 // New configures the library.
 func New(config *common.Config) *Action {
-	return &Action{cmd: &cmd{Config: config}}
+	return &Action{cmd: &cmd{
+		Config:   config,
+		lidarr:   make(map[int]string),
+		prowlarr: make(map[int]string),
+		radarr:   make(map[int]string),
+		readarr:  make(map[int]string),
+		sonarr:   make(map[int]string),
+	}}
 }
 
 // Create sets up all the triggers.

--- a/pkg/triggers/backups/corruption.go
+++ b/pkg/triggers/backups/corruption.go
@@ -50,8 +50,8 @@ func (c *cmd) makeCorruptionTriggersLidarr() {
 	var ticker *time.Ticker
 
 	//nolint:gosec
-	for _, app := range c.Apps.Lidarr {
-		if app.Corrupt != mnd.Disabled && app.Timeout.Duration >= 0 && app.URL != "" {
+	for idx, app := range c.Apps.Lidarr {
+		if app.Enabled() && c.HaveClientInfo() && c.ClientInfo.Actions.Apps.Lidarr.Corrupt(idx+1) != mnd.Disabled {
 			randomTime := time.Duration(rand.Intn(randomMinutes))*time.Second +
 				time.Duration(rand.Intn(randomMinutes))*time.Minute
 			ticker = time.NewTicker(checkInterval + randomTime)
@@ -72,8 +72,8 @@ func (c *cmd) makeCorruptionTriggersProwlarr() {
 	var ticker *time.Ticker
 
 	//nolint:gosec
-	for _, app := range c.Apps.Prowlarr {
-		if app.Corrupt != mnd.Disabled && app.Timeout.Duration >= 0 && app.URL != "" {
+	for idx, app := range c.Apps.Prowlarr {
+		if app.Enabled() && c.HaveClientInfo() && c.ClientInfo.Actions.Apps.Prowlarr.Corrupt(idx+1) != mnd.Disabled {
 			randomTime := time.Duration(rand.Intn(randomMinutes))*time.Second +
 				time.Duration(rand.Intn(randomMinutes))*time.Minute
 			ticker = time.NewTicker(checkInterval + randomTime)
@@ -94,8 +94,8 @@ func (c *cmd) makeCorruptionTriggersRadarr() {
 	var ticker *time.Ticker
 
 	//nolint:gosec
-	for _, app := range c.Apps.Radarr {
-		if app.Corrupt != mnd.Disabled && app.Timeout.Duration >= 0 && app.URL != "" {
+	for idx, app := range c.Apps.Radarr {
+		if app.Enabled() && c.HaveClientInfo() && c.ClientInfo.Actions.Apps.Radarr.Corrupt(idx+1) != mnd.Disabled {
 			randomTime := time.Duration(rand.Intn(randomMinutes))*time.Second +
 				time.Duration(rand.Intn(randomMinutes))*time.Minute
 			ticker = time.NewTicker(checkInterval + randomTime)
@@ -116,8 +116,8 @@ func (c *cmd) makeCorruptionTriggersReadarr() {
 	var ticker *time.Ticker
 
 	//nolint:gosec
-	for _, app := range c.Apps.Readarr {
-		if app.Corrupt != mnd.Disabled && app.Timeout.Duration >= 0 && app.URL != "" {
+	for idx, app := range c.Apps.Readarr {
+		if app.Enabled() && c.HaveClientInfo() && c.ClientInfo.Actions.Apps.Readarr.Corrupt(idx+1) != mnd.Disabled {
 			randomTime := time.Duration(rand.Intn(randomMinutes))*time.Second +
 				time.Duration(rand.Intn(randomMinutes))*time.Minute
 			ticker = time.NewTicker(checkInterval + randomTime)
@@ -138,8 +138,8 @@ func (c *cmd) makeCorruptionTriggersSonarr() {
 	var ticker *time.Ticker
 
 	//nolint:gosec
-	for _, app := range c.Apps.Sonarr {
-		if app.Corrupt != mnd.Disabled && app.Timeout.Duration >= 0 && app.URL != "" {
+	for idx, app := range c.Apps.Sonarr {
+		if app.Enabled() && c.HaveClientInfo() && c.ClientInfo.Actions.Apps.Sonarr.Corrupt(idx+1) != mnd.Disabled {
 			randomTime := time.Duration(rand.Intn(randomMinutes))*time.Second +
 				time.Duration(rand.Intn(randomMinutes))*time.Minute
 			ticker = time.NewTicker(checkInterval + randomTime)
@@ -157,12 +157,12 @@ func (c *cmd) makeCorruptionTriggersSonarr() {
 }
 
 func (c *cmd) sendLidarrCorruption(event website.EventType) {
-	for i, app := range c.Apps.Lidarr {
-		app.Corrupt = c.sendAndLogAppCorruption(&genericInstance{
+	for idx, app := range c.Apps.Lidarr {
+		c.lidarr[idx] = c.sendAndLogAppCorruption(&genericInstance{
 			event: event,
-			last:  app.Corrupt,
+			last:  c.lidarr[idx],
 			name:  starr.Lidarr,
-			int:   i + 1,
+			int:   idx + 1,
 			app:   app.Lidarr,
 			cName: app.Name,
 			skip:  app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0,
@@ -171,12 +171,12 @@ func (c *cmd) sendLidarrCorruption(event website.EventType) {
 }
 
 func (c *cmd) sendProwlarrCorruption(event website.EventType) {
-	for i, app := range c.Apps.Prowlarr {
-		app.Corrupt = c.sendAndLogAppCorruption(&genericInstance{
+	for idx, app := range c.Apps.Prowlarr {
+		c.prowlarr[idx] = c.sendAndLogAppCorruption(&genericInstance{
 			event: event,
-			last:  app.Corrupt,
+			last:  c.prowlarr[idx],
 			name:  starr.Prowlarr,
-			int:   i + 1,
+			int:   idx + 1,
 			app:   app.Prowlarr,
 			cName: app.Name,
 			skip:  app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0,
@@ -185,12 +185,12 @@ func (c *cmd) sendProwlarrCorruption(event website.EventType) {
 }
 
 func (c *cmd) sendRadarrCorruption(event website.EventType) {
-	for i, app := range c.Apps.Radarr {
-		app.Corrupt = c.sendAndLogAppCorruption(&genericInstance{
+	for idx, app := range c.Apps.Radarr {
+		c.radarr[idx] = c.sendAndLogAppCorruption(&genericInstance{
 			event: event,
-			last:  app.Corrupt,
+			last:  c.radarr[idx],
 			name:  starr.Radarr,
-			int:   i + 1,
+			int:   idx + 1,
 			app:   app.Radarr,
 			cName: app.Name,
 			skip:  app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0,
@@ -199,12 +199,12 @@ func (c *cmd) sendRadarrCorruption(event website.EventType) {
 }
 
 func (c *cmd) sendReadarrCorruption(event website.EventType) {
-	for i, app := range c.Apps.Readarr {
-		app.Corrupt = c.sendAndLogAppCorruption(&genericInstance{
+	for idx, app := range c.Apps.Readarr {
+		c.readarr[idx] = c.sendAndLogAppCorruption(&genericInstance{
 			event: event,
-			last:  app.Corrupt,
+			last:  c.readarr[idx],
 			name:  starr.Readarr,
-			int:   i + 1,
+			int:   idx + 1,
 			app:   app.Readarr,
 			cName: app.Name,
 			skip:  app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0,
@@ -213,12 +213,12 @@ func (c *cmd) sendReadarrCorruption(event website.EventType) {
 }
 
 func (c *cmd) sendSonarrCorruption(event website.EventType) {
-	for i, app := range c.Apps.Sonarr {
-		app.Corrupt = c.sendAndLogAppCorruption(&genericInstance{
+	for idx, app := range c.Apps.Sonarr {
+		c.sonarr[idx] = c.sendAndLogAppCorruption(&genericInstance{
 			event: event,
-			last:  app.Corrupt,
+			last:  c.sonarr[idx],
 			name:  starr.Sonarr,
-			int:   i + 1,
+			int:   idx + 1,
 			app:   app.Sonarr,
 			cName: app.Name,
 			skip:  app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0,

--- a/pkg/triggers/backups/corruption.go
+++ b/pkg/triggers/backups/corruption.go
@@ -289,15 +289,15 @@ func (c *cmd) checkBackupFileCorruption(
 	remotePath string,
 ) (*Info, error) {
 	// XXX: Set TMPDIR to configure this.
-	folder, err := os.CreateTemp("", "notifiarr_tmp_dir")
+	folder, err := os.MkdirTemp("", "notifiarr_tmp_dir")
 	if err != nil {
 		return nil, fmt.Errorf("creating temporary folder: %w", err)
 	}
 
-	defer os.RemoveAll(folder.Name()) // clean up when we're done.
+	defer os.RemoveAll(folder) // clean up when we're done.
 	c.Debugf("[%s requested] Downloading %s backup file (%d): %s", input.event, input.name, input.int, remotePath)
 
-	fileName, err := input.saveBackupFile(ctx, remotePath, folder.Name())
+	fileName, err := input.saveBackupFile(ctx, remotePath, folder)
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +306,7 @@ func (c *cmd) checkBackupFileCorruption(
 
 	_, newFiles, err := xtractr.ExtractZIP(&xtractr.XFile{
 		FilePath:  fileName,
-		OutputDir: folder.Name(),
+		OutputDir: folder,
 		FileMode:  mnd.Mode0600,
 		DirMode:   mnd.Mode0750,
 	})

--- a/pkg/triggers/common/triggers.go
+++ b/pkg/triggers/common/triggers.go
@@ -42,13 +42,15 @@ type Action struct {
 }
 
 // Exec runs a trigger. This is abastraction method used in a bunch of places.
-func (c *Config) Exec(event website.EventType, name TriggerName) {
+func (c *Config) Exec(event website.EventType, name TriggerName) bool {
 	trig := c.Get(name)
 	if c.stop == nil || trig == nil || trig.C == nil {
-		return
+		return false
 	}
 
 	trig.C <- event
+
+	return true
 }
 
 // Get a trigger by unique name. May return nil, and that could cause a panic.
@@ -85,6 +87,7 @@ func (c *Config) Stop(event website.EventType) {
 	c.stop = nil
 }
 
-func (c *Config) SetClientInfo(ci *website.ClientInfo) {
-	c.ClientInfo = ci
+// WithInstance returns a trigger name with an instance ID.
+func (name TriggerName) WithInstance(instance int) TriggerName {
+	return TriggerName(fmt.Sprintf(string(name), instance))
 }

--- a/pkg/triggers/starrqueue/radarr.go
+++ b/pkg/triggers/starrqueue/radarr.go
@@ -1,78 +1,83 @@
 package starrqueue
 
 import (
-	"fmt"
-	"math/rand"
 	"strings"
 	"time"
 
+	"github.com/Notifiarr/notifiarr/pkg/apps"
 	"github.com/Notifiarr/notifiarr/pkg/triggers/common"
 	"github.com/Notifiarr/notifiarr/pkg/website"
 )
 
-const TrigRadarrQueue common.TriggerName = "Checking Radarr queue and sending incomplete items."
+const TrigRadarrQueue common.TriggerName = "Storing Radarr instance %d queue."
 
-// RadarrStuckItems sends Radarr's stuck items to the website.
-func (a *Action) RadarrStuckItems(event website.EventType) {
-	a.cmd.Exec(event, TrigRadarrQueue)
-}
-
-func (c *cmd) setupRadarr() {
-	var ticker *time.Ticker
-
-	for _, app := range c.Apps.Radarr {
-		if app.StuckItem && app.URL != "" && app.APIKey != "" && app.Timeout.Duration >= 0 {
-			ticker = time.NewTicker(queueDuration + time.Duration(rand.Intn(randomSeconds))) //nolint:gosec
-			break
-		}
-	}
-
-	c.Add(&common.Action{
-		Name: TrigRadarrQueue,
-		Fn:   c.radarrStuckItems,
-		C:    make(chan website.EventType, 1),
-		T:    ticker,
-	})
-}
-
-func (c *cmd) radarrStuckItems(event website.EventType) {
-	start := time.Now()
-
-	if cue := c.getFinishedItemsRadarr(); !cue.Empty() {
-		c.SendData(&website.Request{
-			Route:      website.StuckRoute,
-			Event:      event,
-			LogPayload: true,
-			LogMsg: fmt.Sprintf("Radarr Queue: %d stuck items (elapsed:%s)",
-				cue.Len(), time.Since(start).Round(time.Millisecond)),
-			Payload: map[string]ItemList{"radarr": cue},
-		})
+// StoreRadarr fetches and stores the Radarr queue immediately for the specified instance.
+// Does not send data to the website.
+func (a *Action) StoreRadarr(event website.EventType, instance int) {
+	if name := TrigRadarrQueue.WithInstance(instance); !a.cmd.Exec(event, name) {
+		a.cmd.Errorf("Failed! %s Disbled?", name)
 	}
 }
 
-func (c *cmd) getFinishedItemsRadarr() ItemList { //nolint:cyclop
-	stuck := make(ItemList)
+type radarrApp struct {
+	app *apps.RadarrConfig
+	cmd *cmd
+	idx int
+}
+
+// storeQueue runs at an interval and saves the queue for an app internally.
+func (app *radarrApp) storeQueue(event website.EventType) {
+	var err error
+	if app.cmd.radarr[app.idx], err = app.app.GetQueue(queueItemsMax, 1); err != nil {
+		app.cmd.Errorf("Getting Radarr Queue (instance %d): %v", app.idx+1, err)
+		return
+	}
+
+	for _, item := range app.cmd.radarr[app.idx].Records {
+		item.Quality = nil
+		item.CustomFormats = nil
+		item.Languages = nil
+	}
+}
+
+func (c *cmd) setupRadarr() bool {
+	var enabled bool
 
 	for idx, app := range c.Apps.Radarr {
+		if !app.Enabled() || !c.HaveClientInfo() {
+			continue
+		}
+
+		var ticker *time.Ticker
+
 		instance := idx + 1
-
-		if !app.StuckItem || app.URL == "" || app.APIKey == "" || app.Timeout.Duration < 0 {
-			continue
+		if c.ClientInfo.Actions.Apps.Radarr.Finished(instance) {
+			ticker = time.NewTicker(finishedDuration)
+		} else if c.ClientInfo.Actions.Apps.Radarr.Stuck(instance) {
+			ticker = time.NewTicker(stuckDuration)
 		}
 
-		if app.Radarr == nil {
-			c.Errorf("Getting Radarr Queue (%d): Radarr config is nil? This is probably a bug.", instance)
-			continue
+		if ticker != nil {
+			enabled = true
+
+			c.Add(&common.Action{
+				Hide: true,
+				Name: TrigRadarrQueue.WithInstance(instance),
+				Fn:   (&radarrApp{app: app, cmd: c, idx: idx}).storeQueue,
+				C:    make(chan website.EventType, 1),
+				T:    ticker,
+			})
 		}
+	}
 
-		start := time.Now()
+	return enabled
+}
 
-		queue, err := app.GetQueue(queueItemsMax, 1)
-		if err != nil {
-			c.Errorf("Getting Radarr Queue (%d): %v", instance, err)
-			continue
-		}
+func (c *cmd) getFinishedItemsRadarr() itemList {
+	stuck := make(itemList)
 
+	for idx, queue := range c.radarr {
+		instance := idx + 1
 		stuckapp := stuck[instance]
 
 		for _, item := range queue.Records {
@@ -81,14 +86,10 @@ func (c *cmd) getFinishedItemsRadarr() ItemList { //nolint:cyclop
 				continue
 			}
 
-			item.Quality = nil
-			item.CustomFormats = nil
-			item.Languages = nil
 			stuckapp.Queue = append(stuckapp.Queue, item)
 		}
 
-		stuckapp.Name = app.Name
-		stuckapp.Elapsed = time.Since(start)
+		stuckapp.Name = c.Apps.Radarr[idx].Name // this should be safe.
 		stuck[instance] = stuckapp
 
 		c.Debugf("Checking Radarr (%d) Queue for Stuck Items, queue size: %d, stuck: %d",

--- a/pkg/triggers/starrqueue/stuckitems.go
+++ b/pkg/triggers/starrqueue/stuckitems.go
@@ -1,9 +1,15 @@
 package starrqueue
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/Notifiarr/notifiarr/pkg/triggers/common"
+	"github.com/Notifiarr/notifiarr/pkg/website"
+	"golift.io/starr/lidarr"
+	"golift.io/starr/radarr"
+	"golift.io/starr/readarr"
+	"golift.io/starr/sonarr"
 )
 
 /* This file contains the procedures to send stuck download queue items to notifiarr. */
@@ -15,13 +21,17 @@ type Action struct {
 
 type cmd struct {
 	*common.Config
+	lidarr  map[int]*lidarr.Queue
+	radarr  map[int]*radarr.Queue
+	readarr map[int]*readarr.Queue
+	sonarr  map[int]*sonarr.Queue
 }
 
 const (
-	// How often to check starr apps for queue list.
-	queueDuration = 4*time.Minute + 45*time.Second
-	// Between 0 and this number of seconds will be added to each queueDuration.
-	randomSeconds = 30
+	// How often to check starr apps for queue list when stuck items is enabled.
+	stuckDuration = 5 * time.Minute
+	// How often to check starr apps for queue list when finished items is enabled.
+	finishedDuration = time.Minute
 	// This is the max number of queued items to inspect/send.
 	queueItemsMax = 100
 )
@@ -33,28 +43,94 @@ const (
 	completed = "completed"
 )
 
-type ListItem struct {
-	Elapsed time.Duration `json:"elapsed"`
-	Name    string        `json:"name"`
-	Queue   []interface{} `json:"queue"`
-}
-
-type ItemList map[int]ListItem
+const TrigStuckItems common.TriggerName = "Sending cached stuck items to website."
 
 // New configures the library.
 func New(config *common.Config) *Action {
 	return &Action{cmd: &cmd{Config: config}}
 }
 
-// Create initializes the library.
-func (a *Action) Create() {
-	a.cmd.setupLidarr()
-	a.cmd.setupRadarr()
-	a.cmd.setupReadarr()
-	a.cmd.setupSonarr()
+// Run initializes the library.
+func (a *Action) Run() {
+	a.cmd.lidarr = make(map[int]*lidarr.Queue)
+	a.cmd.radarr = make(map[int]*radarr.Queue)
+	a.cmd.readarr = make(map[int]*readarr.Queue)
+	a.cmd.sonarr = make(map[int]*sonarr.Queue)
+	lidarr := a.cmd.setupLidarr()
+	radarr := a.cmd.setupRadarr()
+	readarr := a.cmd.setupReadarr()
+	sonarr := a.cmd.setupSonarr()
+
+	if lidarr || radarr || readarr || sonarr {
+		a.cmd.Add(&common.Action{
+			Name: TrigStuckItems,
+			Fn:   a.cmd.sendStuckQueues,
+			C:    make(chan website.EventType, 1),
+			T:    time.NewTicker(stuckDuration),
+		})
+	}
 }
 
-func (i ItemList) Len() int {
+// Stop just frees up memory. The are no routines to stop.
+func (a *Action) Stop() {
+	for idx := range a.cmd.lidarr {
+		for i := range a.cmd.lidarr[idx].Records {
+			a.cmd.lidarr[idx].Records[i] = nil
+		}
+
+		a.cmd.lidarr[idx] = nil
+		delete(a.cmd.lidarr, idx)
+	}
+
+	for idx := range a.cmd.radarr {
+		for i := range a.cmd.radarr[idx].Records {
+			a.cmd.radarr[idx].Records[i] = nil
+		}
+
+		a.cmd.radarr[idx] = nil
+		delete(a.cmd.radarr, idx)
+	}
+
+	for idx := range a.cmd.readarr {
+		for i := range a.cmd.readarr[idx].Records {
+			a.cmd.readarr[idx].Records[i] = nil
+		}
+
+		a.cmd.readarr[idx] = nil
+		delete(a.cmd.readarr, idx)
+	}
+
+	for idx := range a.cmd.sonarr {
+		for i := range a.cmd.sonarr[idx].Records {
+			a.cmd.sonarr[idx].Records[i] = nil
+		}
+
+		a.cmd.sonarr[idx] = nil
+		delete(a.cmd.sonarr, idx)
+	}
+
+	a.cmd.lidarr = nil
+	a.cmd.radarr = nil
+	a.cmd.readarr = nil
+	a.cmd.sonarr = nil
+}
+
+// StuckItems sends the stuck queues items for all apps.
+// Does not fetch fresh data first, uses cache.
+func (a *Action) StuckItems(event website.EventType) {
+	a.cmd.Exec(event, TrigStuckItems)
+}
+
+// listItem is data formatted for sending a json payload to the website.
+type listItem struct {
+	Name  string        `json:"name"`
+	Queue []interface{} `json:"queue"`
+}
+
+// itemList stores an instance->queue map.
+type itemList map[int]listItem
+
+func (i itemList) Len() int {
 	count := 0
 
 	for _, v := range i {
@@ -64,6 +140,39 @@ func (i ItemList) Len() int {
 	return count
 }
 
-func (i ItemList) Empty() bool {
+func (i itemList) Empty() bool {
 	return i.Len() < 1
+}
+
+// sendStuckQueues gathers the stuck quues from cache and sends them.
+func (c *cmd) sendStuckQueues(event website.EventType) {
+	lidarr := c.getFinishedItemsLidarr()
+	radarr := c.getFinishedItemsRadarr()
+	readarr := c.getFinishedItemsReadarr()
+	sonarr := c.getFinishedItemsSonarr()
+
+	if lidarr.Empty() && radarr.Empty() && readarr.Empty() && sonarr.Empty() {
+		return
+	}
+
+	type stuckPaylod struct {
+		Lidarr  itemList `json:"lidarr"`
+		Radarr  itemList `json:"radarr"`
+		Readarr itemList `json:"readarr"`
+		Sonarr  itemList `json:"sonarr"`
+	}
+
+	c.SendData(&website.Request{
+		Route:      website.StuckRoute,
+		Event:      event,
+		LogPayload: true,
+		LogMsg: fmt.Sprintf("Stuck Items; Lidarr: %d, Radarr: %d, Readarr: %d, Sonarr: %d",
+			lidarr.Len(), radarr.Len(), readarr.Len(), sonarr.Len()),
+		Payload: stuckPaylod{
+			Lidarr:  lidarr,
+			Radarr:  radarr,
+			Readarr: readarr,
+			Sonarr:  sonarr,
+		},
+	})
 }

--- a/pkg/triggers/triggers.go
+++ b/pkg/triggers/triggers.go
@@ -94,8 +94,7 @@ type run interface {
 func (a *Actions) Start() {
 	defer a.timers.Run() // unexported fields do not get picked up by reflection.
 
-	ci, _ := a.timers.GetClientInfo()
-	a.timers.SetClientInfo(ci)
+	a.timers.ClientInfo, _ = a.timers.GetClientInfo()
 
 	actions := reflect.ValueOf(a).Elem()
 	for i := 0; i < actions.NumField(); i++ {

--- a/pkg/website/hostinfo.go
+++ b/pkg/website/hostinfo.go
@@ -1,0 +1,81 @@
+package website
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Notifiarr/notifiarr/pkg/mnd"
+	"github.com/Notifiarr/notifiarr/pkg/snapshot"
+	"github.com/shirou/gopsutil/v3/host"
+)
+
+// hostInfoNoError will return nil if there is an error, otherwise a copy of the host info.
+func (s *Server) hostInfoNoError() *host.InfoStat {
+	if s.hostInfo == nil {
+		return nil
+	}
+
+	return &host.InfoStat{
+		Hostname:             s.hostInfo.Hostname,
+		Uptime:               uint64(time.Now().Unix()) - s.hostInfo.BootTime,
+		BootTime:             s.hostInfo.BootTime,
+		OS:                   s.hostInfo.OS,
+		Platform:             s.hostInfo.Platform,
+		PlatformFamily:       s.hostInfo.PlatformFamily,
+		PlatformVersion:      s.hostInfo.PlatformVersion,
+		KernelVersion:        s.hostInfo.KernelVersion,
+		KernelArch:           s.hostInfo.KernelArch,
+		VirtualizationSystem: s.hostInfo.VirtualizationSystem,
+		VirtualizationRole:   s.hostInfo.VirtualizationRole,
+		HostID:               s.hostInfo.HostID,
+	}
+}
+
+// GetHostInfo attempts to make a unique machine identifier...
+func (s *Server) GetHostInfo() (*host.InfoStat, error) { //nolint:cyclop
+	if s.hostInfo != nil {
+		return s.hostInfoNoError(), nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second) //nolint:gomnd
+	defer cancel()
+
+	hostInfo, err := host.InfoWithContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting host info: %w", err)
+	}
+
+	syn, err := snapshot.GetSynology()
+	if err == nil {
+		// This method writes synology data into hostInfo.
+		syn.SetInfo(hostInfo)
+	}
+
+	if hostInfo.Platform == "" &&
+		(hostInfo.VirtualizationSystem == "docker" || mnd.IsDocker) {
+		hostInfo.Platform = "Docker " + hostInfo.KernelVersion
+		hostInfo.PlatformFamily = "Docker"
+	}
+
+	const (
+		trueNasJunkLen   = 17
+		trueNasJunkParts = 2
+	)
+	// TrueNAS adds junk to the hostname.
+	if mnd.IsDocker && strings.HasSuffix(hostInfo.KernelVersion, "truenas") && len(hostInfo.Hostname) > trueNasJunkLen {
+		if splitHost := strings.Split(hostInfo.Hostname, "-"); len(splitHost) > trueNasJunkParts {
+			hostInfo.Hostname = strings.Join(splitHost[:len(splitHost)-trueNasJunkParts], "-")
+		}
+	}
+
+	if s.config.HostID != "" {
+		hostInfo.HostID = s.config.HostID
+	}
+
+	// This only happens once.
+	s.hostInfo = hostInfo
+
+	return s.hostInfoNoError(), nil // return a copy.
+}


### PR DESCRIPTION
- Converts starrqueue module to caching. 
- Reverts stuck items to all sending in the same payload.
- Splits `-v` and `--version` into short and long version output.
- Changes how client info app configs from website are handled.
- Adds `Enabled()` to starr apps methods.
- Fixes lock when triggering any service check manually.
- Fixes broken service check for NZBGet when auth is enabled.
- Due to changes in client info, this could have adverse affects on backup and corruption checks.
- Also fixes a bug that broke corruption checks. 

Only draw back is now queue collection and stuck items sending are detached. One cannot manually trigger queue updates now. The cache updates at a hard coded 5 minute interval.