### PR TITLE
Crash fix

### DIFF
--- a/init/docker/Dockerfile
+++ b/init/docker/Dockerfile
@@ -12,14 +12,9 @@ COPY go.mod go.sum .
 RUN go mod download
 COPY . .
 
-ARG BINARY=application-builder
-ARG BUILD_DATE=0
-ARG COMMIT=0
-ARG VERSION=unknown
 ARG TARGETOS
 ARG BINARY
 ARG TARGETARCH
-ARG BUILD_FLAGS
 
 # For megacli. All the *'s are to deal with multiarch. :(
 RUN apt update && apt install -y libncurses5 libstdc++6 libtinfo5 apt-utils && \

--- a/init/docker/build
+++ b/init/docker/build
@@ -5,6 +5,7 @@ pushd ../..
 
 source settings.sh
 
+docker buildx create --use
 
 if [ "v$VERSION" = "$SOURCE_BRANCH" ]; then
   TAGS="--tag ${DOCKER_REPO}:$VERSION"

--- a/pkg/bindata/templates/landing.html
+++ b/pkg/bindata/templates/landing.html
@@ -11,7 +11,7 @@
                                                 If you have more ideas for this interface, or find any bugs,
                                                 <a href="https://github.com/Notifiarr/notifiarr/issues/new">please let us know!</a>
                                             </p>
-                                            <p><b>{{.ClientInfo.String}}</b></p>
+                                            <p>{{todaysemoji}} <b>{{.ClientInfo.String}}</b></p>
                                             <p class="text-center"><img src="{{files}}/images/golift.png" style="height:150px;"></p>
                                         </div>
                                         <div class="col-md-1">

--- a/pkg/bindata/templates/system.html
+++ b/pkg/bindata/templates/system.html
@@ -67,7 +67,7 @@
                                              </tr>
                                              <tr>
                                                  <td>Version</td>
-                                                 <td>{{.Version.version}}.{{.Version.revision}}</td>
+                                                 <td>{{.Version.version}}-{{.Version.revision}}</td>
                                                  <td style="display:none;"></td>
                                              </tr>
                                              <tr>

--- a/pkg/client/html_templates.go
+++ b/pkg/client/html_templates.go
@@ -111,7 +111,8 @@ func (c *Client) getFuncMap() template.FuncMap {
 
 			return date.String()
 		},
-		"fortune": Fortune,
+		"todaysemoji": mnd.TodaysEmoji,
+		"fortune":     Fortune,
 		// returns the current time.
 		"now": time.Now,
 		// returns an integer divided by a million.

--- a/pkg/client/html_templates.go
+++ b/pkg/client/html_templates.go
@@ -143,7 +143,7 @@ func (c *Client) getFuncMap() template.FuncMap {
 			}
 			return "0"
 		},
-		"one259": func() (num []float64) {
+		"one259": func() (num []float64) { // 1 to 59
 			for i := float64(1); i < 60; i++ {
 				num = append(num, i)
 			}

--- a/pkg/client/tray.go
+++ b/pkg/client/tray.go
@@ -48,7 +48,7 @@ func (c *Client) startTray(clientInfo *website.ClientInfo) {
 		}
 	}, func() {
 		// This code only fires from menu->quit.
-		if err := c.exit(); err != nil {
+		if err := c.stop(website.EventUser); err != nil {
 			c.Errorf("Server: %v", err)
 			os.Exit(1) // web server problem
 		}

--- a/pkg/client/webserver.go
+++ b/pkg/client/webserver.go
@@ -16,9 +16,6 @@ import (
 	apachelog "github.com/lestrrat-go/apache-logformat"
 )
 
-// ErrNoServer returns when the server is already stopped and a stop req occurs.
-var ErrNoServer = fmt.Errorf("the web server is not running, cannot stop it")
-
 // StartWebServer starts the web server.
 func (c *Client) StartWebServer() {
 	c.Lock()
@@ -81,6 +78,8 @@ func (c *Client) runWebServer() {
 
 // StopWebServer stops the web servers. Panics if that causes an error or timeout.
 func (c *Client) StopWebServer() error {
+	c.Print("==> Stopping Web Server!")
+
 	ctx, cancel := context.WithTimeout(context.Background(), c.Config.Timeout.Duration)
 	defer cancel()
 
@@ -125,7 +124,7 @@ func (r *responseWrapper) Write(b []byte) (int, error) {
 func (r *responseWrapper) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	hijack, ok := r.ResponseWriter.(http.Hijacker)
 	if !ok {
-		return nil, nil, ErrNoServer
+		panic("cannot hijack connection!")
 	}
 
 	conn, buf, err := hijack.Hijack()

--- a/pkg/mnd/constants.go
+++ b/pkg/mnd/constants.go
@@ -21,7 +21,7 @@ const (
 	Bits32    = 32
 	Windows   = "windows"
 	Disabled  = "disabled"
-	HelpLink  = "GoLift Discord: https://golift.io/discord"
+	HelpLink  = "Notifiarr Discord: https://notifiarr.com/discord"
 	UserRepo  = "Notifiarr/notifiarr"
 	BugIssue  = "This is a bug please report it on github: https://github.com/" + UserRepo + "/issues/new"
 	DockerV   = "NOTIFIARR_IN_DOCKER"

--- a/pkg/mnd/emoji.go
+++ b/pkg/mnd/emoji.go
@@ -15,12 +15,13 @@ const (
 func TodaysEmoji() string {
 	today := version.Started.YearDay()
 
-	if leapYear(version.Started.Year()) {
-		if today == leapDay {
-			today = altLeapDay
-		} else {
-			today--
-		}
+	switch year := version.Started.Year(); {
+	case !leapYear(year), today < leapDay:
+		break
+	case today == leapDay:
+		today = altLeapDay
+	default:
+		today--
 	}
 
 	if emoji, ok := specialDays[today]; ok {
@@ -59,5 +60,4 @@ var specialDays = map[int]string{ //nolint:gochecknoglobals
 	328:        "🦃", // November 24
 	359:        "🎄", // December 25
 	altLeapDay: "🤹", // February 29 (Leap Day)
-
 }

--- a/pkg/mnd/emoji.go
+++ b/pkg/mnd/emoji.go
@@ -7,57 +7,58 @@ import (
 )
 
 const (
-	leapDay    = 60
+	leapDay    = 60 // day of year leap day falls on.
 	altLeapDay = 366
 )
 
-// TodaysEmoji returns an emoji specific to the month (or perhaps date).
-func TodaysEmoji() string {
-	today := version.Started.YearDay()
-
-	switch year := version.Started.Year(); {
-	case !leapYear(year), today < leapDay:
-		break
+func today(when time.Time) int {
+	switch today := when.YearDay(); {
+	case !leapYear(when.Year()), today < leapDay:
+		return today
 	case today == leapDay:
-		today = altLeapDay
+		return altLeapDay
 	default:
-		today--
+		return today - 1
 	}
-
-	if emoji, ok := specialDays[today]; ok {
-		return emoji
-	}
-
-	return monthEmojis[version.Started.Month()]
 }
 
 func leapYear(year int) bool {
 	return year%400 == 0 || (year%4 == 0 && year%100 != 0)
 }
 
-var monthEmojis = map[time.Month]string{ //nolint:gochecknoglobals
-	time.January:   "🤖", //
-	time.February:  "😻", //
-	time.March:     "🗼", //
-	time.April:     "🌦", //
-	time.May:       "🌸", //
-	time.June:      "🍀", //
-	time.July:      "🌵", //
-	time.August:    "🔥", //
-	time.September: "🍁", //
-	time.October:   "🍉", //
-	time.November:  "🍗", //
-	time.December:  "⛄", //
+func emojiMonth(when time.Time) string {
+	return map[time.Month]string{
+		time.January:   "🤖", //
+		time.February:  "😻", //
+		time.March:     "🗼", //
+		time.April:     "🌧", //
+		time.May:       "🌸", //
+		time.June:      "🍄", //
+		time.July:      "🌵", //
+		time.August:    "🔥", //
+		time.September: "🐸", //
+		time.October:   "🍁", //
+		time.November:  "👽", //
+		time.December:  "⛄", //
+	}[when.Month()]
 }
 
-var specialDays = map[int]string{ //nolint:gochecknoglobals
-	1:          "🎉", // January 1
-	45:         "💝", // February 14
-	185:        "🧨", // July 4
-	229:        "🏄", // August 17
-	304:        "🎃", // October 31
-	315:        "🪖", // November 11
-	328:        "🦃", // November 24
-	359:        "🎄", // December 25
-	altLeapDay: "🤹", // February 29 (Leap Day)
+// TodaysEmoji returns an emoji specific to the month (or perhaps date).
+func TodaysEmoji() string {
+	if emoji, ok := map[int]string{
+		1:          "🎉", // January 1
+		45:         "💝", // February 14
+		185:        "🧨", // July 4
+		229:        "🏄", // August 17
+		254:        "⛑", // September 11
+		304:        "🎃", // October 31
+		315:        "🪖", // November 11
+		328:        "🦃", // November 24
+		359:        "🎄", // December 25
+		altLeapDay: "🤹", // February 29 (Leap Day)
+	}[today(version.Started)]; ok {
+		return emoji
+	}
+
+	return emojiMonth(version.Started)
 }

--- a/pkg/mnd/emoji.go
+++ b/pkg/mnd/emoji.go
@@ -1,0 +1,63 @@
+package mnd
+
+import (
+	"time"
+
+	"golift.io/version"
+)
+
+const (
+	leapDay    = 60
+	altLeapDay = 366
+)
+
+// TodaysEmoji returns an emoji specific to the month (or perhaps date).
+func TodaysEmoji() string {
+	today := version.Started.YearDay()
+
+	if leapYear(version.Started.Year()) {
+		if today == leapDay {
+			today = altLeapDay
+		} else {
+			today--
+		}
+	}
+
+	if emoji, ok := specialDays[today]; ok {
+		return emoji
+	}
+
+	return monthEmojis[version.Started.Month()]
+}
+
+func leapYear(year int) bool {
+	return year%400 == 0 || (year%4 == 0 && year%100 != 0)
+}
+
+var monthEmojis = map[time.Month]string{ //nolint:gochecknoglobals
+	time.January:   "🤖", //
+	time.February:  "😻", //
+	time.March:     "🗼", //
+	time.April:     "🌦", //
+	time.May:       "🌸", //
+	time.June:      "🍀", //
+	time.July:      "🌵", //
+	time.August:    "🔥", //
+	time.September: "🍁", //
+	time.October:   "🍉", //
+	time.November:  "🍗", //
+	time.December:  "⛄", //
+}
+
+var specialDays = map[int]string{ //nolint:gochecknoglobals
+	1:          "🎉", // January 1
+	45:         "💝", // February 14
+	185:        "🧨", // July 4
+	229:        "🏄", // August 17
+	304:        "🎃", // October 31
+	315:        "🪖", // November 11
+	328:        "🦃", // November 24
+	359:        "🎄", // December 25
+	altLeapDay: "🤹", // February 29 (Leap Day)
+
+}

--- a/pkg/services/apps.go
+++ b/pkg/services/apps.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"net/url"
 	"strings"
 
 	"golift.io/cnfg"
@@ -194,9 +195,10 @@ func (c *Config) collectDownloadApps(svcs []*Service) []*Service { //nolint:funl
 
 		prefix := "" // add auth to the url here. woo, hacky, but it works!
 		if !strings.Contains(app.Config.URL, "@") {
-			prefix = "http://" + app.User + ":" + app.Pass + "@"
+			user := url.PathEscape(app.User) + ":" + url.PathEscape(app.Pass) + "@"
+			prefix = "http://" + user
 			if strings.HasPrefix(app.Config.URL, "https://") {
-				prefix = "https://" + app.User + ":" + app.Pass + "@"
+				prefix = "https://" + user
 			}
 		}
 

--- a/pkg/services/apps.go
+++ b/pkg/services/apps.go
@@ -194,10 +194,10 @@ func (c *Config) collectDownloadApps(svcs []*Service) []*Service { //nolint:funl
 		}
 
 		prefix := "" // add auth to the url here. woo, hacky, but it works!
+
 		if !strings.Contains(app.Config.URL, "@") {
 			user := url.PathEscape(app.User) + ":" + url.PathEscape(app.Pass) + "@"
-			prefix = "http://" + user
-			if strings.HasPrefix(app.Config.URL, "https://") {
+			if prefix = "http://" + user; strings.HasPrefix(app.Config.URL, "https://") {
 				prefix = "https://" + user
 			}
 		}

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	triggerChan  chan website.EventType
 	checkChan    chan triggerCheck
 	stopLock     sync.Mutex
+	lastUpdate   time.Time // last time we sent service states to website.
 }
 
 // CheckType locks us into a few specific types of checks.

--- a/pkg/website/website.go
+++ b/pkg/website/website.go
@@ -192,6 +192,11 @@ func readBodyForLog(body io.Reader, max int64) string {
 }
 
 func (s *Server) watchSendDataChan() {
+	defer func() {
+		defer s.config.CapturePanic()
+		s.config.Printf("==> Website notifier shutting down. No more ->website requests may be sent!")
+	}()
+
 	for data := range s.sendData {
 		switch resp, elapsed, err := s.sendRequest(data); {
 		case data.LogMsg == "":


### PR DESCRIPTION
- This closes #269 by re-ordering the reload (and shut down) procedure to kill the web server before killing the triggers.
- Fixes a bug with monitoring NZBGet using a special character in the password.
- Fixes the version display on Docker (which may have been broken in a previous non-release commit).
- Finally fixes services states being reset after many hours + reload.
- Runs full shut down procedure when exiting now. This was probably a miss.
- Adds log flair.