### PR TITLE
Fix crash when collecting apps for service checks.

### DIFF
--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -299,7 +299,7 @@ func (c *Client) reloadConfiguration(event website.EventType, source string) err
 	c.Logger.SetupLogging(c.Config.LogConfig)
 	clientInfo := c.configureServices()
 	c.setupMenus(clientInfo)
-	c.Print(" 🔄 Configuration Reloaded! Config File:", c.Flags.ConfigFile)
+	c.Print(" 🌀 Configuration Reloaded! Config File:", c.Flags.ConfigFile)
 
 	if err = ui.Notify("Configuration Reloaded! Config File: %s", c.Flags.ConfigFile); err != nil {
 		c.Errorf("Creating Toast Notification: %v", err)

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -20,6 +20,7 @@ import (
 	homedir "github.com/mitchellh/go-homedir"
 	"golift.io/rotatorr"
 	"golift.io/rotatorr/timerotator"
+	"golift.io/version"
 )
 
 // Logger provides some methods with baked in assumptions.
@@ -165,7 +166,8 @@ func (l *Logger) CapturePanic() {
 	if r := recover(); r != nil {
 		ui.ShowConsoleWindow()
 		l.ErrorLog.Output(callDepth, //nolint:errcheck
-			fmt.Sprintf("Go Panic! %s\n%v\n%s", mnd.BugIssue, r, string(debug.Stack())))
+			fmt.Sprintf("Go Panic! %s\n%s-%s %s %v\n%s", mnd.BugIssue,
+				version.Version, version.Revision, version.Branch, r, string(debug.Stack())))
 		panic(r)
 	}
 }

--- a/pkg/services/interface.go
+++ b/pkg/services/interface.go
@@ -83,7 +83,7 @@ func (c *Config) runChecks(forceAll bool) bool {
 }
 
 func (c *Config) updateStatesOnSite(force bool) {
-	if !force && time.Since(c.lastUpdate) < time.Hour {
+	if !force && time.Since(c.lastUpdate) < time.Hour || len(c.services) == 0 {
 		return
 	}
 
@@ -104,7 +104,6 @@ func (c *Config) updateStatesOnSite(force bool) {
 	}
 
 	if len(values) == 0 {
-		c.Printf("No service states to send updates to website? Weird.")
 		return
 	}
 


### PR DESCRIPTION
Closes #287 by fixing a crash when collecting apps for service checks.

This also adds a limiter to the file watcher, so it won't kill itself when the file it's watching becomes unruly.