### PR TITLE
TRaSH sync updated

### DIFF
--- a/pkg/apps/apppkg/tautulli/tautulli.go
+++ b/pkg/apps/apppkg/tautulli/tautulli.go
@@ -45,7 +45,7 @@ func (c *Config) GetURLInto(ctx context.Context, params url.Values, into interfa
 
 // GetUsers returns the Tautulli users.
 func (c *Config) GetUsers(ctx context.Context) (*Users, error) {
-	if c == nil || c.URL == "" {
+	if c == nil || c.Client == nil {
 		return &Users{}, nil
 	}
 

--- a/pkg/apps/radarr.go
+++ b/pkg/apps/radarr.go
@@ -25,6 +25,7 @@ func (a *Apps) radarrHandlers() {
 	a.HandleAPIpath(starr.Radarr, "/qualityProfile", radarrAddQualityProfile, "POST")
 	a.HandleAPIpath(starr.Radarr, "/qualityProfile/{profileID:[0-9]+}", radarrUpdateQualityProfile, "PUT")
 	a.HandleAPIpath(starr.Radarr, "/qualityProfile/{profileID:[0-9]+}", radarrDeleteQualityProfile, "DELETE")
+	a.HandleAPIpath(starr.Radarr, "/qualityProfile/all", radarrDeleteAllQualityProfile, "DELETE")
 	a.HandleAPIpath(starr.Radarr, "/rootFolder", radarrRootFolders, "GET")
 	a.HandleAPIpath(starr.Radarr, "/search/{query}", radarrSearchMovie, "GET")
 	a.HandleAPIpath(starr.Radarr, "/tag", radarrGetTags, "GET")
@@ -40,6 +41,7 @@ func (a *Apps) radarrHandlers() {
 	a.HandleAPIpath(starr.Radarr, "/qualitydefinitions", radarrGetQualityDefinitions, "GET")
 	a.HandleAPIpath(starr.Radarr, "/qualitydefinition", radarrUpdateQualityDefinition, "PUT")
 	a.HandleAPIpath(starr.Radarr, "/customformats/{cfid:[0-9]+}", radarrDeleteCustomFormat, "DELETE")
+	a.HandleAPIpath(starr.Radarr, "/customformats/all", radarrDeleteAllCustomFormat, "DELETE")
 	a.HandleAPIpath(starr.Radarr, "/importlist", radarrGetImportLists, "GET")
 	a.HandleAPIpath(starr.Radarr, "/importlist", radarrAddImportList, "POST")
 	a.HandleAPIpath(starr.Radarr, "/importlist/{ilid:[0-9]+}", radarrUpdateImportList, "PUT")
@@ -259,6 +261,35 @@ func radarrDeleteQualityProfile(req *http.Request) (int, interface{}) {
 	return http.StatusOK, "OK"
 }
 
+func radarrDeleteAllQualityProfile(req *http.Request) (int, interface{}) {
+	// Get all the profiles from radarr.
+	profiles, err := getRadarr(req).GetQualityProfilesContext(req.Context())
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("getting profiles: %w", err)
+	}
+
+	var (
+		deleted int
+		errs    []string
+	)
+
+	// Delete each profile from radarr.
+	for _, profile := range profiles {
+		if err := getRadarr(req).DeleteQualityProfileContext(req.Context(), profile.ID); err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+
+		deleted++
+	}
+
+	return http.StatusOK, map[string]any{
+		"found":   len(profiles),
+		"deleted": deleted,
+		"errors":  errs,
+	}
+}
+
 func radarrRootFolders(req *http.Request) (int, interface{}) {
 	// Get folder list from Radarr.
 	folders, err := getRadarr(req).GetRootFoldersContext(req.Context())
@@ -465,6 +496,34 @@ func radarrDeleteCustomFormat(req *http.Request) (int, interface{}) {
 	}
 
 	return http.StatusOK, "OK"
+}
+
+func radarrDeleteAllCustomFormat(req *http.Request) (int, interface{}) {
+	formats, err := getRadarr(req).GetCustomFormatsContext(req.Context())
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("getting custom formats: %w", err)
+	}
+
+	var (
+		deleted int
+		errs    []string
+	)
+
+	for _, format := range formats {
+		err := getRadarr(req).DeleteCustomFormatContext(req.Context(), format.ID)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+
+		deleted++
+	}
+
+	return http.StatusOK, map[string]any{
+		"found":   len(formats),
+		"deleted": deleted,
+		"errors":  errs,
+	}
 }
 
 func radarrGetImportLists(req *http.Request) (int, interface{}) {

--- a/pkg/apps/radarr.go
+++ b/pkg/apps/radarr.go
@@ -25,7 +25,7 @@ func (a *Apps) radarrHandlers() {
 	a.HandleAPIpath(starr.Radarr, "/qualityProfile", radarrAddQualityProfile, "POST")
 	a.HandleAPIpath(starr.Radarr, "/qualityProfile/{profileID:[0-9]+}", radarrUpdateQualityProfile, "PUT")
 	a.HandleAPIpath(starr.Radarr, "/qualityProfile/{profileID:[0-9]+}", radarrDeleteQualityProfile, "DELETE")
-	a.HandleAPIpath(starr.Radarr, "/qualityProfile/all", radarrDeleteAllQualityProfile, "DELETE")
+	a.HandleAPIpath(starr.Radarr, "/qualityProfiles/all", radarrDeleteAllQualityProfiles, "DELETE")
 	a.HandleAPIpath(starr.Radarr, "/rootFolder", radarrRootFolders, "GET")
 	a.HandleAPIpath(starr.Radarr, "/search/{query}", radarrSearchMovie, "GET")
 	a.HandleAPIpath(starr.Radarr, "/tag", radarrGetTags, "GET")
@@ -41,7 +41,7 @@ func (a *Apps) radarrHandlers() {
 	a.HandleAPIpath(starr.Radarr, "/qualitydefinitions", radarrGetQualityDefinitions, "GET")
 	a.HandleAPIpath(starr.Radarr, "/qualitydefinition", radarrUpdateQualityDefinition, "PUT")
 	a.HandleAPIpath(starr.Radarr, "/customformats/{cfid:[0-9]+}", radarrDeleteCustomFormat, "DELETE")
-	a.HandleAPIpath(starr.Radarr, "/customformats/all", radarrDeleteAllCustomFormat, "DELETE")
+	a.HandleAPIpath(starr.Radarr, "/customformats/all", radarrDeleteAllCustomFormats, "DELETE")
 	a.HandleAPIpath(starr.Radarr, "/importlist", radarrGetImportLists, "GET")
 	a.HandleAPIpath(starr.Radarr, "/importlist", radarrAddImportList, "POST")
 	a.HandleAPIpath(starr.Radarr, "/importlist/{ilid:[0-9]+}", radarrUpdateImportList, "PUT")
@@ -261,7 +261,7 @@ func radarrDeleteQualityProfile(req *http.Request) (int, interface{}) {
 	return http.StatusOK, "OK"
 }
 
-func radarrDeleteAllQualityProfile(req *http.Request) (int, interface{}) {
+func radarrDeleteAllQualityProfiles(req *http.Request) (int, interface{}) {
 	// Get all the profiles from radarr.
 	profiles, err := getRadarr(req).GetQualityProfilesContext(req.Context())
 	if err != nil {
@@ -498,7 +498,7 @@ func radarrDeleteCustomFormat(req *http.Request) (int, interface{}) {
 	return http.StatusOK, "OK"
 }
 
-func radarrDeleteAllCustomFormat(req *http.Request) (int, interface{}) {
+func radarrDeleteAllCustomFormats(req *http.Request) (int, interface{}) {
 	formats, err := getRadarr(req).GetCustomFormatsContext(req.Context())
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("getting custom formats: %w", err)

--- a/pkg/apps/sonarr.go
+++ b/pkg/apps/sonarr.go
@@ -28,17 +28,17 @@ func (a *Apps) sonarrHandlers() {
 	a.HandleAPIpath(starr.Sonarr, "/qualityProfile", sonarrAddQualityProfile, "POST")
 	a.HandleAPIpath(starr.Sonarr, "/qualityProfile/{profileID:[0-9]+}", sonarrUpdateQualityProfile, "PUT")
 	a.HandleAPIpath(starr.Sonarr, "/qualityProfile/{profileID:[0-9]+}", sonarrDeleteQualityProfile, "DELETE")
-	a.HandleAPIpath(starr.Sonarr, "/qualityProfile/all", sonarrDeleteAllQualityProfile, "DELETE")
+	a.HandleAPIpath(starr.Sonarr, "/qualityProfiles/all", sonarrDeleteAllQualityProfiles, "DELETE")
 	a.HandleAPIpath(starr.Sonarr, "/releaseProfiles", sonarrGetReleaseProfiles, "GET")
 	a.HandleAPIpath(starr.Sonarr, "/releaseProfile", sonarrAddReleaseProfile, "POST")
 	a.HandleAPIpath(starr.Sonarr, "/releaseProfile/{profileID:[0-9]+}", sonarrUpdateReleaseProfile, "PUT")
 	a.HandleAPIpath(starr.Sonarr, "/releaseProfile/{profileID:[0-9]+}", sonarrDeleteReleaseProfile, "DELETE")
-	a.HandleAPIpath(starr.Sonarr, "/releaseProfile/all", sonarrDeleteAllReleaseProfile, "DELETE")
+	a.HandleAPIpath(starr.Sonarr, "/releaseProfiles/all", sonarrDeleteAllReleaseProfiles, "DELETE")
 	a.HandleAPIpath(starr.Sonarr, "/customformats", sonarrGetCustomFormats, "GET")
 	a.HandleAPIpath(starr.Sonarr, "/customformats", sonarrAddCustomFormat, "POST")
 	a.HandleAPIpath(starr.Sonarr, "/customformats/{cfid:[0-9]+}", sonarrUpdateCustomFormat, "PUT")
 	a.HandleAPIpath(starr.Sonarr, "/customformats/{cfid:[0-9]+}", sonarrDeleteCustomFormat, "DELETE")
-	a.HandleAPIpath(starr.Sonarr, "/customformats/all", sonarrDeleteAllCustomFormat, "DELETE")
+	a.HandleAPIpath(starr.Sonarr, "/customformats/all", sonarrDeleteAllCustomFormats, "DELETE")
 	a.HandleAPIpath(starr.Sonarr, "/qualitydefinitions", sonarrGetQualityDefinitions, "GET")
 	a.HandleAPIpath(starr.Sonarr, "/qualitydefinition", sonarrUpdateQualityDefinition, "PUT")
 	a.HandleAPIpath(starr.Sonarr, "/rootFolder", sonarrRootFolders, "GET")
@@ -321,7 +321,7 @@ func sonarrDeleteQualityProfile(req *http.Request) (int, interface{}) {
 	return http.StatusOK, "OK"
 }
 
-func sonarrDeleteAllQualityProfile(req *http.Request) (int, interface{}) {
+func sonarrDeleteAllQualityProfiles(req *http.Request) (int, interface{}) {
 	// Get all the profiles from sonarr.
 	profiles, err := getSonarr(req).GetQualityProfilesContext(req.Context())
 	if err != nil {
@@ -416,7 +416,7 @@ func sonarrDeleteReleaseProfile(req *http.Request) (int, interface{}) {
 	return http.StatusOK, "OK"
 }
 
-func sonarrDeleteAllReleaseProfile(req *http.Request) (int, interface{}) {
+func sonarrDeleteAllReleaseProfiles(req *http.Request) (int, interface{}) {
 	profiles, err := getSonarr(req).GetReleaseProfilesContext(req.Context())
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("getting profiles: %w", err)
@@ -624,7 +624,7 @@ func sonarrDeleteCustomFormat(req *http.Request) (int, interface{}) {
 	return http.StatusOK, "OK"
 }
 
-func sonarrDeleteAllCustomFormat(req *http.Request) (int, interface{}) {
+func sonarrDeleteAllCustomFormats(req *http.Request) (int, interface{}) {
 	formats, err := getSonarr(req).GetCustomFormatsContext(req.Context())
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("getting custom formats: %w", err)

--- a/pkg/client/handlers.go
+++ b/pkg/client/handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -246,11 +247,29 @@ func (c *Client) runTrigger(source website.EventType, trigger, content string) (
 
 		return http.StatusOK, "Command triggered: " + cmd.Name
 	case "cfsync":
-		c.triggers.CFSync.SyncRadarrCF(source)
-		return http.StatusOK, "TRaSH Custom Formats Radarr Sync initiated."
+		if content == "" {
+			c.triggers.CFSync.SyncRadarrCF(source)
+			return http.StatusOK, "TRaSH Custom Formats Radarr Sync initiated."
+		}
+
+		instance, _ := strconv.Atoi(content)
+		if err := c.triggers.CFSync.SyncRadarrInstanceCF(source, instance); err != nil {
+			return http.StatusBadRequest, "TRaSH Custom Formats Radarr Sync failed for instance " + content + ": " + err.Error()
+		}
+
+		return http.StatusOK, "TRaSH Custom Formats Radarr Sync initiated for instance " + content
 	case "rpsync":
-		c.triggers.CFSync.SyncSonarrRP(source)
-		return http.StatusOK, "TRaSH Release Profile Sonarr Sync initiated."
+		if content == "" {
+			c.triggers.CFSync.SyncSonarrRP(source)
+			return http.StatusOK, "TRaSH Release Profile Sonarr Sync initiated."
+		}
+
+		instance, _ := strconv.Atoi(content)
+		if err := c.triggers.CFSync.SyncSonarrInstanceRP(source, instance); err != nil {
+			return http.StatusBadRequest, "TRaSH Release Profile Sonarr Sync failed for instance " + content + ": " + err.Error()
+		}
+
+		return http.StatusOK, "TRaSH Release Profile Sonarr Sync initiated for instance " + content
 	case "services":
 		c.Config.Services.RunChecks(source)
 		return http.StatusOK, "All service checks rescheduled for immediate exeution."

--- a/pkg/client/handlers_gui.go
+++ b/pkg/client/handlers_gui.go
@@ -433,7 +433,7 @@ func (c *Client) handleFileBrowser(response http.ResponseWriter, request *http.R
 }
 
 func (c *Client) handleGUITrigger(response http.ResponseWriter, request *http.Request) {
-	code, data := c.runTrigger(website.EventGUI, mux.Vars(request)["action"], mux.Vars(request)["content"])
+	code, data := c.triggers.RunTrigger(website.EventGUI, mux.Vars(request)["action"], mux.Vars(request)["content"])
 	http.Error(response, data, code)
 }
 

--- a/pkg/configfile/config.go
+++ b/pkg/configfile/config.go
@@ -198,6 +198,7 @@ func (c *Config) setup() *triggers.Actions {
 		Snapshot:   c.Snapshot,
 		WatchFiles: c.WatchFiles,
 		Commands:   c.Commands,
+		Services:   c.Services,
 	})
 }
 

--- a/pkg/triggers/cfsync/common.go
+++ b/pkg/triggers/cfsync/common.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/Notifiarr/notifiarr/pkg/apps"
 	"github.com/Notifiarr/notifiarr/pkg/triggers/common"
 	"github.com/Notifiarr/notifiarr/pkg/website"
 )
@@ -42,6 +43,8 @@ func (a *Action) Create() {
 
 func (c *cmd) create() {
 	ci := website.GetClientInfo()
+	c.setupRadarr(ci)
+	c.setupSonarr(ci)
 
 	var (
 		radarrTicker *time.Ticker
@@ -77,4 +80,72 @@ func (c *cmd) create() {
 		C:    make(chan website.EventType, 1),
 		T:    sonarrTicker,
 	})
+}
+
+type radarrApp struct {
+	app *apps.RadarrConfig
+	cmd *cmd
+	idx int
+}
+
+func (c *cmd) setupRadarr(ci *website.ClientInfo) {
+	if ci == nil {
+		return
+	}
+
+	for idx, app := range c.Apps.Radarr {
+		instance := idx + 1
+		if !app.Enabled() || !ci.Actions.Sync.RadarrInstances.Has(instance) {
+			continue
+		}
+
+		var ticker *time.Ticker
+		//nolint:gosec
+		if ci != nil && ci.Actions.Sync.Interval.Duration > 0 {
+			randomTime := time.Duration(rand.Intn(randomMilliseconds)) * time.Millisecond
+			ticker = time.NewTicker(ci.Actions.Sync.Interval.Duration + randomTime)
+		}
+
+		c.Add(&common.Action{
+			Hide: true,
+			Name: TrigCFSyncRadarrInt.WithInstance(instance),
+			Fn:   (&radarrApp{app: app, cmd: c, idx: idx}).syncRadarr,
+			C:    make(chan website.EventType, 1),
+			T:    ticker,
+		})
+	}
+}
+
+type sonarrApp struct {
+	app *apps.SonarrConfig
+	cmd *cmd
+	idx int
+}
+
+func (c *cmd) setupSonarr(ci *website.ClientInfo) {
+	if ci == nil {
+		return
+	}
+
+	for idx, app := range c.Apps.Sonarr {
+		instance := idx + 1
+		if !app.Enabled() || !ci.Actions.Sync.SonarrInstances.Has(instance) {
+			continue
+		}
+
+		var ticker *time.Ticker
+		//nolint:gosec
+		if ci != nil && ci.Actions.Sync.Interval.Duration > 0 {
+			randomTime := time.Duration(rand.Intn(randomMilliseconds)) * time.Millisecond
+			ticker = time.NewTicker(ci.Actions.Sync.Interval.Duration + randomTime)
+		}
+
+		c.Add(&common.Action{
+			Hide: true,
+			Name: TrigRPSyncSonarrInt.WithInstance(instance),
+			Fn:   (&sonarrApp{app: app, cmd: c, idx: idx}).syncSonarr,
+			C:    make(chan website.EventType, 1),
+			T:    ticker,
+		})
+	}
 }

--- a/pkg/triggers/common/triggers.go
+++ b/pkg/triggers/common/triggers.go
@@ -24,8 +24,9 @@ type Config struct {
 	Snapshot        *snapshot.Config
 	Apps            *apps.Apps
 	mnd.Logger
-	stop *Action   // Triggered by calling Stop()
-	list []*Action // List of action triggers
+	stop     *Action   // Triggered by calling Stop()
+	list     []*Action // List of action triggers
+	Services           // for running service checks.
 }
 
 // TriggerName makes sure triggers have a known name.
@@ -38,6 +39,11 @@ type Action struct {
 	C    chan website.EventType                   // if provided, T is optional.
 	T    *time.Ticker                             // if provided, C is optional.
 	Hide bool                                     // prevent logging.
+}
+
+// Services is the input interface to do things with services via triggers.
+type Services interface {
+	RunChecks(website.EventType)
 }
 
 // Exec runs a trigger. This is abastraction method used in a bunch of places.

--- a/pkg/triggers/data/store.go
+++ b/pkg/triggers/data/store.go
@@ -1,7 +1,7 @@
 package data
 
 import (
-	"strconv"
+	"fmt"
 
 	"golift.io/cache"
 )
@@ -22,10 +22,10 @@ func Get(key string) *cache.Item {
 
 // SaveWithID saves data to the cache, and appends the key to an id.
 func SaveWithID(key string, id int, data interface{}) {
-	store.Save(key+strconv.Itoa(id), data, cache.Options{})
+	store.Save(key+fmt.Sprint(id), data, cache.Options{})
 }
 
 // GetWithID returns data from the cache using a kay appended to an id.
 func GetWithID(key string, id int) *cache.Item {
-	return store.Get(key + strconv.Itoa(id))
+	return store.Get(key + fmt.Sprint(id))
 }

--- a/pkg/triggers/handler.go
+++ b/pkg/triggers/handler.go
@@ -1,0 +1,182 @@
+package triggers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/Notifiarr/notifiarr/pkg/logs/share"
+	"github.com/Notifiarr/notifiarr/pkg/ui"
+	"github.com/Notifiarr/notifiarr/pkg/website"
+	"github.com/gorilla/mux"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	"golift.io/starr"
+)
+
+func (a *Actions) Handler(r *http.Request) (int, interface{}) {
+	return a.runTrigger(website.EventAPI, mux.Vars(r)["trigger"], mux.Vars(r)["content"])
+}
+
+func (a *Actions) RunTrigger(source website.EventType, trigger, content string) (int, string) {
+	return a.runTrigger(source, trigger, content)
+}
+
+func (a *Actions) runTrigger(source website.EventType, trigger, content string) (int, string) { //nolint:cyclop
+	if content != "" {
+		a.timers.Debugf("Incoming API Trigger: %s (%s)", trigger, content)
+	} else {
+		a.timers.Debugf("Incoming API Trigger: %s", trigger)
+	}
+
+	switch trigger {
+	case "clientlogs":
+		return a.clientLogs(content)
+	case "command":
+		return a.command(source, content)
+	case "cfsync":
+		return a.cfsync(source, content)
+	case "rpsync":
+		return a.rpsync(source, content)
+	case "services":
+		return a.services(source)
+	case "sessions":
+		return a.sessions(source)
+	case "stuckitems":
+		return a.stuckitems(source)
+	case "dashboard":
+		return a.dashboard(source)
+	case "snapshot":
+		return a.snapshot(source)
+	case "gaps":
+		return a.gaps(source)
+	case "corrupt":
+		return a.corrupt(source, content)
+	case "backup":
+		return a.backup(source, content)
+	case "reload":
+		// reload is handled in another package and never gets triggered here.
+		return http.StatusExpectationFailed, "Impossible Code Path Reached"
+	case "notification":
+		return a.notification(content)
+	default:
+		return http.StatusBadRequest, "Unknown trigger provided:'" + trigger + "'"
+	}
+}
+
+func (a *Actions) clientLogs(content string) (int, string) {
+	if content == "true" || content == "on" || content == "enable" {
+		share.Setup(a.timers.Server)
+		return http.StatusBadRequest, "Client log notifications enabled."
+	}
+
+	share.StopLogs()
+
+	return http.StatusBadRequest, "Client log notifications disabled."
+}
+
+func (a *Actions) command(source website.EventType, content string) (int, string) {
+	cmd := a.Commands.GetByHash(content)
+	if cmd == nil {
+		return http.StatusBadRequest, "No command hash provided."
+	}
+
+	cmd.Run(source)
+
+	return http.StatusOK, "Command triggered: " + cmd.Name
+}
+
+func (a *Actions) cfsync(source website.EventType, content string) (int, string) {
+	if content == "" {
+		a.CFSync.SyncRadarrCF(source)
+		return http.StatusOK, "TRaSH Custom Formats Radarr Sync initiated."
+	}
+
+	instance, _ := strconv.Atoi(content)
+	if err := a.CFSync.SyncRadarrInstanceCF(source, instance); err != nil {
+		return http.StatusBadRequest, "TRaSH Custom Formats Radarr Sync failed for instance " + content + ": " + err.Error()
+	}
+
+	return http.StatusOK, "TRaSH Custom Formats Radarr Sync initiated for instance " + content
+}
+
+func (a *Actions) rpsync(source website.EventType, content string) (int, string) {
+	if content == "" {
+		a.CFSync.SyncSonarrRP(source)
+		return http.StatusOK, "TRaSH Release Profile Sonarr Sync initiated."
+	}
+
+	instance, _ := strconv.Atoi(content)
+	if err := a.CFSync.SyncSonarrInstanceRP(source, instance); err != nil {
+		return http.StatusBadRequest, "TRaSH Release Profile Sonarr Sync failed for instance " + content + ": " + err.Error()
+	}
+
+	return http.StatusOK, "TRaSH Release Profile Sonarr Sync initiated for instance " + content
+}
+
+func (a *Actions) services(source website.EventType) (int, string) {
+	a.timers.RunChecks(source)
+	return http.StatusOK, "All service checks rescheduled for immediate exeution."
+}
+
+func (a *Actions) sessions(source website.EventType) (int, string) {
+	if !a.timers.Apps.Plex.Enabled() {
+		return http.StatusNotImplemented, "Plex Sessions are not enabled."
+	}
+
+	a.PlexCron.Send(source)
+
+	return http.StatusOK, "Plex sessions triggered."
+}
+
+func (a *Actions) stuckitems(source website.EventType) (int, string) {
+	a.StarrQueue.StuckItems(source)
+	return http.StatusOK, "Stuck Queue Items triggered."
+}
+
+func (a *Actions) dashboard(source website.EventType) (int, string) {
+	a.Dashboard.Send(source)
+	return http.StatusOK, "Dashboard states triggered."
+}
+
+func (a *Actions) snapshot(source website.EventType) (int, string) {
+	a.SnapCron.Send(source)
+	return http.StatusOK, "System Snapshot triggered."
+}
+
+func (a *Actions) gaps(source website.EventType) (int, string) {
+	a.Gaps.Send(source)
+	return http.StatusOK, "Radarr Collections Gaps initiated."
+}
+
+func (a *Actions) corrupt(source website.EventType, content string) (int, string) {
+	title := cases.Title(language.AmericanEnglish)
+
+	err := a.Backups.Corruption(source, starr.App(title.String(content)))
+	if err != nil {
+		return http.StatusBadRequest, "Corruption trigger failed: " + err.Error()
+	}
+
+	return http.StatusOK, title.String(content) + " corruption checks initiated."
+}
+
+func (a *Actions) backup(source website.EventType, content string) (int, string) {
+	title := cases.Title(language.AmericanEnglish)
+
+	err := a.Backups.Backup(source, starr.App(title.String(content)))
+	if err != nil {
+		return http.StatusBadRequest, "Backup trigger failed: " + err.Error()
+	}
+
+	return http.StatusOK, title.String(content) + " backups check initiated."
+}
+
+func (a *Actions) notification(content string) (int, string) {
+	if content != "" {
+		ui.Notify("Notification: %s", content) //nolint:errcheck
+		a.timers.Printf("NOTIFICATION: %s", content)
+
+		return http.StatusOK, "Local Nntification sent."
+	}
+
+	return http.StatusBadRequest, "Missing notification content."
+}

--- a/pkg/triggers/handler.go
+++ b/pkg/triggers/handler.go
@@ -13,10 +13,12 @@ import (
 	"golift.io/starr"
 )
 
+// Handler is passed into the webserver so triggers can be executed from the API.
 func (a *Actions) Handler(r *http.Request) (int, interface{}) {
 	return a.runTrigger(website.EventAPI, mux.Vars(r)["trigger"], mux.Vars(r)["content"])
 }
 
+// RunTrigger is fired by GUI web requests and possibly other places.
 func (a *Actions) RunTrigger(source website.EventType, trigger, content string) (int, string) {
 	return a.runTrigger(source, trigger, content)
 }

--- a/pkg/triggers/triggers.go
+++ b/pkg/triggers/triggers.go
@@ -30,6 +30,7 @@ type Config struct {
 	Snapshot   *snapshot.Config
 	WatchFiles []*filewatch.WatchFile
 	Commands   []*commands.Command
+	common.Services
 	mnd.Logger
 }
 


### PR DESCRIPTION
Closes #309.

- Adds five delete methods to clear out all custom formats, quality profiles and release profiles in sonarr and radarr.
  - `/api/sonarr/1/customFormats/all`
  - `/api/sonarr/1/qualityProfiles/all`
  - `/api/sonarr/1/releaseProfiles/all`
  - `/api/radarr/1/customFormats/all`
  - `/api/radarr/1/qualityProfiles/all`
- Adds per-instance trash sync triggers:
  - `/api/triggers/cfsync/1`
  - `/api/triggers/rpsync/1`