### PR TITLE
Add config file backup cleanup and put them in sub folder

### DIFF
--- a/pkg/client/handlers_websocket.go
+++ b/pkg/client/handlers_websocket.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path/filepath"
 	"time"
 
 	"github.com/Notifiarr/notifiarr/pkg/logs"
@@ -33,11 +34,13 @@ func (c *Client) handleWebSockets(response http.ResponseWriter, request *http.Re
 
 	var fileInfos *logs.LogFileInfos
 
+	backupPath := filepath.Join(filepath.Dir(c.Flags.ConfigFile), "backups", filepath.Base(c.Flags.ConfigFile))
+
 	switch src := mux.Vars(request)["source"]; src {
 	case fileSourceLogs:
 		fileInfos = c.Logger.GetAllLogFilePaths()
 	case fileSourceConfig:
-		fileInfos = logs.GetFilePaths(c.Flags.ConfigFile)
+		fileInfos = logs.GetFilePaths(c.Flags.ConfigFile, backupPath)
 	default:
 		http.Error(response, "invalid source: "+src, http.StatusBadRequest)
 		c.socketLog(http.StatusBadRequest, request)

--- a/pkg/client/html_templates.go
+++ b/pkg/client/html_templates.go
@@ -436,6 +436,7 @@ func (c *Client) renderTemplate(
 	binary, _ := os.Executable()
 	userName, dynamic := c.getUserName(req)
 	hostInfo, _ := c.website.GetHostInfo(ctx)
+	backupPath := filepath.Join(filepath.Dir(c.Flags.ConfigFile), "backups", filepath.Base(c.Flags.ConfigFile))
 
 	err := c.templat.ExecuteTemplate(response, templateName, &templateData{
 		Config:      c.Config,
@@ -445,7 +446,7 @@ func (c *Client) renderTemplate(
 		Webauth:     c.webauth,
 		Msg:         msg,
 		LogFiles:    c.Logger.GetAllLogFilePaths(),
-		ConfigFiles: logs.GetFilePaths(c.Flags.ConfigFile),
+		ConfigFiles: logs.GetFilePaths(c.Flags.ConfigFile, backupPath),
 		ClientInfo:  clientInfo,
 		Disks:       c.getDisks(ctx),
 		Cache: map[string]*cache.Item{


### PR DESCRIPTION
Closes #270.

Keeps 10 config file backups, deletes oldest first.  Stores them in a `backup/` folder.