### PR TITLE
Unstable

### DIFF
--- a/pkg/apps/api.go
+++ b/pkg/apps/api.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/Notifiarr/notifiarr/pkg/exp"
+	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/gorilla/mux"
 	"golift.io/datacounter"
 	"golift.io/starr"
@@ -102,10 +102,10 @@ func (a *Apps) handleAPI(app starr.App, api APIHandler) http.HandlerFunc { //nol
 		}
 
 		wrote := a.Respond(w, code, msg)
-		exp.APIHits.Add(appName+" Bytes Sent", wrote)
-		exp.APIHits.Add(appName+" Bytes Received", int64(len(post)))
-		exp.APIHits.Add(appName+" Requests", 1)
-		exp.APIHits.Add("Total", 1)
+		mnd.APIHits.Add(appName+" Bytes Sent", wrote)
+		mnd.APIHits.Add(appName+" Bytes Received", int64(len(post)))
+		mnd.APIHits.Add(appName+" Requests", 1)
+		mnd.APIHits.Add("Total", 1)
 		r.Header.Set("X-Request-Time", fmt.Sprintf("%dms", time.Since(start).Milliseconds()))
 	}
 }
@@ -131,7 +131,7 @@ func (a *Apps) Respond(w http.ResponseWriter, stat int, msg interface{}) int64 {
 		m, _ := msg.(string)
 		w.Header().Set("Location", m)
 		w.WriteHeader(stat)
-		exp.APIHits.Add(statusTxt, 1)
+		mnd.APIHits.Add(statusTxt, 1)
 
 		return 0
 	}
@@ -141,7 +141,7 @@ func (a *Apps) Respond(w http.ResponseWriter, stat int, msg interface{}) int64 {
 		msg = m.Error()
 	}
 
-	exp.APIHits.Add(statusTxt, 1)
+	mnd.APIHits.Add(statusTxt, 1)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(stat)
 	counter := datacounter.NewResponseWriterCounter(w)

--- a/pkg/apps/apppkg/plex/plex.go
+++ b/pkg/apps/apppkg/plex/plex.go
@@ -14,8 +14,6 @@ import (
 	"net/http"
 	"net/url"
 	"time"
-
-	"github.com/Notifiarr/notifiarr/pkg/exp"
 )
 
 // Server is the Plex configuration from a config file.
@@ -93,12 +91,10 @@ func (s *Server) reqPlexURL(
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		exp.Apps.Add("Plex&&"+method+" Errors", 1)
 		return nil, fmt.Errorf("reading http response: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		exp.Apps.Add("Plex&&"+method+" Errors", 1)
 		return body, ErrBadStatus
 	}
 

--- a/pkg/apps/integrations.go
+++ b/pkg/apps/integrations.go
@@ -69,7 +69,7 @@ type DelugeConfig struct {
 
 func (a *Apps) setupDeluge() error {
 	for idx, app := range a.Deluge {
-		if !a.Deluge[idx].Enabled() {
+		if app == nil || app.Config == nil || app.URL == "" || app.Password == "" {
 			return fmt.Errorf("%w: missing url or password: Deluge config %d", ErrInvalidApp, idx+1)
 		} else if !strings.HasPrefix(app.Config.URL, "http://") && !strings.HasPrefix(app.Config.URL, "https://") {
 			return fmt.Errorf("%w: URL must begin with http:// or https://: Deluge config %d", ErrInvalidApp, idx+1)
@@ -112,7 +112,7 @@ type SabNZBConfig struct {
 
 func (a *Apps) setupSabNZBd() error {
 	for idx, app := range a.SabNZB {
-		if !a.SabNZB[idx].Enabled() {
+		if app == nil || app.Config == nil || app.URL == "" || app.APIKey == "" {
 			return fmt.Errorf("%w: missing url or api key: SABnzbd config %d", ErrInvalidApp, idx+1)
 		} else if !strings.HasPrefix(app.Config.URL, "http://") && !strings.HasPrefix(app.Config.URL, "https://") {
 			return fmt.Errorf("%w: URL must begin with http:// or https://: SABnzbd config %d", ErrInvalidApp, idx+1)
@@ -151,7 +151,7 @@ type QbitConfig struct {
 
 func (a *Apps) setupQbit() error {
 	for idx, app := range a.Qbit {
-		if !a.Qbit[idx].Enabled() {
+		if app == nil || app.Config == nil || app.URL == "" {
 			return fmt.Errorf("%w: missing url: Qbit config %d", ErrInvalidApp, idx+1)
 		} else if !strings.HasPrefix(app.Config.URL, "http://") && !strings.HasPrefix(app.Config.URL, "https://") {
 			return fmt.Errorf("%w: URL must begin with http:// or https://: Qbit config %d", ErrInvalidApp, idx+1)
@@ -196,7 +196,7 @@ type RtorrentConfig struct {
 
 func (a *Apps) setupRtorrent() error {
 	for idx, app := range a.Rtorrent {
-		if !a.Rtorrent[idx].Enabled() {
+		if app == nil || app.URL == "" {
 			return fmt.Errorf("%w: missing url: rTorrent config %d", ErrInvalidApp, idx+1)
 		} else if !strings.HasPrefix(app.URL, "http://") && !strings.HasPrefix(app.URL, "https://") {
 			return fmt.Errorf("%w: URL must begin with http:// or https://: rTorrent config %d", ErrInvalidApp, idx+1)
@@ -241,14 +241,14 @@ type NZBGetConfig struct {
 }
 
 func (a *Apps) setupNZBGet() error {
-	for idx, nzb := range a.NZBGet {
-		if !nzb.Enabled() {
+	for idx, app := range a.NZBGet {
+		if app == nil || app.Config == nil || app.URL == "" {
 			return fmt.Errorf("%w: missing url: NZBGet config %d", ErrInvalidApp, idx+1)
-		} else if !strings.HasPrefix(nzb.Config.URL, "http://") && !strings.HasPrefix(nzb.Config.URL, "https://") {
+		} else if !strings.HasPrefix(app.Config.URL, "http://") && !strings.HasPrefix(app.Config.URL, "https://") {
 			return fmt.Errorf("%w: URL must begin with http:// or https://: NZBGet config %d", ErrInvalidApp, idx+1)
 		}
 
-		nzb.Client = starr.ClientWithDebug(nzb.Timeout.Duration, nzb.ValidSSL, debuglog.Config{
+		app.Client = starr.ClientWithDebug(app.Timeout.Duration, app.ValidSSL, debuglog.Config{
 			MaxBody: a.MaxBody,
 			Debugf:  a.Debugf,
 			Caller:  metricMaker("NZBGet"),

--- a/pkg/apps/prowlarr.go
+++ b/pkg/apps/prowlarr.go
@@ -40,11 +40,16 @@ func (a *Apps) setupProwlarr() error {
 			return fmt.Errorf("%w: URL must begin with http:// or https://: Prowlarr config %d", ErrInvalidApp, idx+1)
 		}
 
-		app.Config.Client = starr.ClientWithDebug(app.Timeout.Duration, app.ValidSSL, debuglog.Config{
-			MaxBody: a.MaxBody,
-			Debugf:  a.Debugf,
-			Caller:  metricMaker(string(starr.Prowlarr)),
-		})
+		if a.Logger.DebugEnabled() {
+			app.Config.Client = starr.ClientWithDebug(app.Timeout.Duration, app.ValidSSL, debuglog.Config{
+				MaxBody: a.MaxBody,
+				Debugf:  a.Debugf,
+				Caller:  metricMakerCallback(string(starr.Prowlarr)),
+			})
+		} else {
+			app.Config.Client = starr.Client(app.Timeout.Duration, app.ValidSSL)
+			app.Config.Client.Transport = NewMetricsRoundTripper(starr.Prowlarr.String(), nil)
+		}
 
 		app.errorf = a.Errorf
 		app.URL = strings.TrimRight(app.URL, "/")

--- a/pkg/apps/setup.go
+++ b/pkg/apps/setup.go
@@ -120,8 +120,8 @@ func (a *Apps) Setup() error { //nolint:cyclop
 		a.Plex = &PlexConfig{Config: &plex.Config{}}
 	}
 
-	a.Tautulli.Setup(a.MaxBody, a.Debugf)
-	a.Plex.Setup(a.MaxBody, a.Debugf)
+	a.Tautulli.Setup(a.MaxBody, a.Logger)
+	a.Plex.Setup(a.MaxBody, a.Logger)
 
 	return nil
 }

--- a/pkg/apps/setup.go
+++ b/pkg/apps/setup.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Notifiarr/notifiarr/pkg/apps/apppkg/plex"
 	"github.com/Notifiarr/notifiarr/pkg/apps/apppkg/tautulli"
-	"github.com/Notifiarr/notifiarr/pkg/exp"
 	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/gorilla/mux"
 	"golift.io/cnfg"
@@ -140,21 +139,4 @@ func (a *Apps) InitHandlers() {
 	a.radarrHandlers()
 	a.readarrHandlers()
 	a.sonarrHandlers()
-}
-
-func metricMaker(app string) func(string, string, int, int, error) {
-	return func(status, method string, sent, rcvd int, err error) {
-		exp.Apps.Add(app+"&&"+method+" Bytes Received", int64(rcvd))
-		exp.Apps.Add(app+"&&"+method+" Requests", 1)
-
-		if method != "GET" || sent > 0 {
-			exp.Apps.Add(app+"&&"+method+" Bytes Sent", int64(sent))
-		}
-
-		if err != nil {
-			exp.Apps.Add(app+"&&"+method+" Request Errors", 1)
-		} else {
-			exp.Apps.Add(app+"&&"+method+" Response: "+status, 1)
-		}
-	}
 }

--- a/pkg/bindata/templates/index.html
+++ b/pkg/bindata/templates/index.html
@@ -86,8 +86,8 @@
                                 </a>
                                 <ul style="width:95%;" class="dropdown-menu bk-dark" aria-labelledby="triggers menu">
                                     <li><a class="nav-link text-grey" href="#triggers" onClick="swapNavigationTemplate('triggers')">- Open Triggers Page -</a></li>
-                                    <li><a class="nav-link text-grey" onClick="triggerAction('cfsync')">Custom Formats</a></li>
-                                    <li><a class="nav-link text-grey" onClick="triggerAction('rpsync')">Release Profiles</a></li>
+                                    <li><a class="nav-link text-grey" onClick="triggerAction('cfsync')">Radarr TRaSH Sync</a></li>
+                                    <li><a class="nav-link text-grey" onClick="triggerAction('rpsync')">Sonarr TRaSH Sync</a></li>
                                     <li><a class="nav-link text-grey" onClick="triggerAction('snapshot')">System Snapshot</a></li>
                                     <li><a class="nav-link text-grey" onClick="triggerAction('dashboard')">Dashboard States</a></li>
                                     <li><a class="nav-link text-grey" onClick="triggerAction('sessions')">Plex Sessions</a></li>

--- a/pkg/bindata/templates/media/plex.html
+++ b/pkg/bindata/templates/media/plex.html
@@ -86,7 +86,7 @@
                                                                 </div>
                                                                 {{- end}}
                                                                 <input type="password" autocomplete="off" id="Apps.Plex.Token" name="Apps.Plex.Token" data-app="Plex" class="client-parameter form-control input-sm" data-group="media" data-label="Plex Token" data-original="{{.Config.Apps.Plex.Token}}" value="{{.Config.Apps.Plex.Token}}">
-                                                                <div style="width:35px; max-width:35px;" class="input-group-addon input-sm" onClick="togglePassword('Plex.Token', $(this).find('i'));"><i class="fas fa-low-vision secret-input"></i></div>
+                                                                <div style="width:35px; max-width:35px;" class="input-group-addon input-sm" onClick="togglePassword('Apps.Plex.Token', $(this).find('i'));"><i class="fas fa-low-vision secret-input"></i></div>
                                                             </div>
                                                         </div>
                                                     </form>

--- a/pkg/bindata/templates/triggers.html
+++ b/pkg/bindata/templates/triggers.html
@@ -6,13 +6,13 @@
                                         <tr>
                                             <td>{{index .Expvar.TimerCounts "Starting Radarr Custom Format TRaSH sync."}}</td>
                                             <td>
-                                                <a href="#triggers" onClick="triggerAction('cfsync')">Sync Custom Formats</a></td><td>Syncs TRaSH custom formats to Radarr.
+                                                <a href="#triggers" onClick="triggerAction('cfsync')">Radarr TRaSH Sync</a></td><td>Syncs TRaSH custom formats to Radarr.
                                             </td>
                                         </tr>
                                         <tr>
                                             <td>{{index .Expvar.TimerCounts "Starting Sonarr Release Profile TRaSH sync."}}</td>
                                             <td>
-                                                <a href="#triggers" onClick="triggerAction('rpsync')">Sync Release Profiles</a></td><td>Syncs TRaSH release profiles to Sonarr.
+                                                <a href="#triggers" onClick="triggerAction('rpsync')">Sonarr TRaSH Sync</a></td><td>Syncs TRaSH release profiles and custom formats to Sonarr.
                                             </td>
                                         </tr>
                                         <tr>

--- a/pkg/client/handlers.go
+++ b/pkg/client/handlers.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/Notifiarr/notifiarr/pkg/bindata"
-	"github.com/Notifiarr/notifiarr/pkg/exp"
+	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"golift.io/starr"
 )
 
@@ -175,20 +175,20 @@ func (c *Client) addUsernameHeader(next http.Handler) http.Handler {
 
 func (c *Client) countRequest(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(response http.ResponseWriter, req *http.Request) {
-		exp.HTTPRequests.Add("Total Requests", 1)
+		mnd.HTTPRequests.Add("Total Requests", 1)
 
 		switch {
 		case strings.HasPrefix(req.RequestURI, path.Join(c.Config.URLBase, "api")):
-			exp.HTTPRequests.Add("/api Requests", 1)
+			mnd.HTTPRequests.Add("/api Requests", 1)
 		case strings.HasPrefix(req.RequestURI, path.Join(c.Config.URLBase, "ws")):
-			exp.HTTPRequests.Add("Websocket Requests", 1)
+			mnd.HTTPRequests.Add("Websocket Requests", 1)
 		default:
-			exp.HTTPRequests.Add("Non-/api Requests", 1)
+			mnd.HTTPRequests.Add("Non-/api Requests", 1)
 		}
 
 		wrap := &responseWrapper{ResponseWriter: response, statusCode: http.StatusOK}
 		next.ServeHTTP(wrap, req)
-		exp.HTTPRequests.Add(fmt.Sprintf("Response %d %s", wrap.statusCode, http.StatusText(wrap.statusCode)), 1)
+		mnd.HTTPRequests.Add(fmt.Sprintf("Response %d %s", wrap.statusCode, http.StatusText(wrap.statusCode)), 1)
 	})
 }
 

--- a/pkg/client/handlers_gui.go
+++ b/pkg/client/handlers_gui.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/Notifiarr/notifiarr/pkg/bindata"
 	"github.com/Notifiarr/notifiarr/pkg/configfile"
-	"github.com/Notifiarr/notifiarr/pkg/exp"
 	"github.com/Notifiarr/notifiarr/pkg/logs"
 	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/Notifiarr/notifiarr/pkg/services"
@@ -119,7 +118,7 @@ func (c *Client) loginHandler(response http.ResponseWriter, request *http.Reques
 		c.indexPage(request.Context(), response, request, "Invalid Password Length")
 	case c.checkUserPass(providedUsername, request.FormValue("password")):
 		c.setSession(providedUsername, response)
-		exp.HTTPRequests.Add("GUI Logins", 1)
+		mnd.HTTPRequests.Add("GUI Logins", 1)
 		http.Redirect(response, request, c.Config.URLBase, http.StatusFound)
 	default: // Start over.
 		c.indexPage(request.Context(), response, request, "Invalid Password")

--- a/pkg/client/handlers_gui.go
+++ b/pkg/client/handlers_gui.go
@@ -433,11 +433,6 @@ func (c *Client) handleFileBrowser(response http.ResponseWriter, request *http.R
 	}
 }
 
-func (c *Client) handleGUITrigger(response http.ResponseWriter, request *http.Request) {
-	code, data := c.triggers.RunTrigger(website.EventGUI, mux.Vars(request)["action"], mux.Vars(request)["content"])
-	http.Error(response, data, code)
-}
-
 func (c *Client) handleCommandStats(response http.ResponseWriter, request *http.Request) {
 	cID, _ := strconv.Atoi(mux.Vars(request)["command"])
 	if cID < 0 || cID >= len(c.triggers.Commands.List()) {

--- a/pkg/client/handlers_plex.go
+++ b/pkg/client/handlers_plex.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Notifiarr/notifiarr/pkg/apps"
 	"github.com/Notifiarr/notifiarr/pkg/apps/apppkg/plex"
-	"github.com/Notifiarr/notifiarr/pkg/exp"
 	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/Notifiarr/notifiarr/pkg/website"
 )
@@ -36,16 +36,16 @@ func (t *Timer) Active(d time.Duration) bool {
 
 // PlexHandler handles an incoming webhook from Plex.
 func (c *Client) PlexHandler(w http.ResponseWriter, r *http.Request) { //nolint:cyclop,varnamelen,funlen
-	exp.Apps.Add("Plex&&Incoming Webhooks", 1)
+	mnd.Apps.Add("Plex&&Incoming Webhooks", 1)
 
 	start := time.Now()
 
-	r.Body = exp.NewFakeCloser("Plex", "Webhook", r.Body)
+	r.Body = apps.NewFakeCloser("Plex", "Webhook", r.Body)
 	defer r.Body.Close()
 
 	if err := r.ParseMultipartForm(mnd.Megabyte); err != nil {
 		c.Errorf("Parsing Multipart Form (plex): %v", err)
-		exp.Apps.Add("Plex&&Webhook Errors", 1)
+		mnd.Apps.Add("Plex&&Webhook Errors", 1)
 		http.Error(w, "form parse error", http.StatusBadRequest)
 
 		return
@@ -59,7 +59,7 @@ func (c *Client) PlexHandler(w http.ResponseWriter, r *http.Request) { //nolint:
 
 	switch err := json.Unmarshal([]byte(payload), &v); {
 	case err != nil:
-		exp.Apps.Add("Plex&&Webhook Errors", 1)
+		mnd.Apps.Add("Plex&&Webhook Errors", 1)
 		http.Error(w, "payload error", http.StatusBadRequest)
 		c.Errorf("Unmarshalling Plex payload: %v", err)
 	case strings.EqualFold(v.Event, "admin.database.backup"):

--- a/pkg/client/html_templates.go
+++ b/pkg/client/html_templates.go
@@ -18,7 +18,6 @@ import (
 	"github.com/Notifiarr/notifiarr/pkg/apps/apppkg/plex"
 	"github.com/Notifiarr/notifiarr/pkg/bindata"
 	"github.com/Notifiarr/notifiarr/pkg/configfile"
-	"github.com/Notifiarr/notifiarr/pkg/exp"
 	"github.com/Notifiarr/notifiarr/pkg/logs"
 	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/Notifiarr/notifiarr/pkg/snapshot"
@@ -416,7 +415,7 @@ type templateData struct {
 	LogFiles    *logs.LogFileInfos             `json:"logFileInfo"`
 	ConfigFiles *logs.LogFileInfos             `json:"configFileInfo"`
 	ClientInfo  *website.ClientInfo            `json:"clientInfo"`
-	Expvar      exp.AllData                    `json:"expvar"`
+	Expvar      mnd.AllData                    `json:"expvar"`
 	HostInfo    *host.InfoStat                 `json:"hostInfo"`
 	Disks       map[string]*snapshot.Partition `json:"disks"`
 }
@@ -475,7 +474,7 @@ func (c *Client) renderTemplate(
 			"uid":       os.Getuid(),
 			"gid":       os.Getgid(),
 		},
-		Expvar:   exp.GetAllData(),
+		Expvar:   mnd.GetAllData(),
 		HostInfo: hostInfo,
 	})
 	if err != nil {

--- a/pkg/client/instance_tests.go
+++ b/pkg/client/instance_tests.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Notifiarr/notifiarr/pkg/services"
 	"github.com/Notifiarr/notifiarr/pkg/snapshot"
 	"github.com/Notifiarr/notifiarr/pkg/triggers/commands"
+	"github.com/Notifiarr/notifiarr/pkg/triggers/common"
 	"github.com/Notifiarr/notifiarr/pkg/website"
 	"github.com/gorilla/mux"
 	"golift.io/deluge"
@@ -41,9 +42,9 @@ func (c *Client) testInstance(response http.ResponseWriter, request *http.Reques
 	switch mux.Vars(request)["type"] {
 	case "Commands":
 		if len(c.Config.Commands) > index {
-			c.Config.Commands[index].Run(website.EventGUI)
+			c.Config.Commands[index].Run(&common.ActionInput{Type: website.EventGUI})
 			reply, code = fmt.Sprintf("Command Triggered: %s", c.Config.Commands[index].Name), http.StatusOK
-		} else if len(config.Commands) > index {
+		} else if len(config.Commands) > index { // check POST input for "new" command.
 			config.Commands[index].Setup(c.Logger, c.website)
 			reply, code = testCustomCommand(request.Context(), config.Commands[index])
 		}
@@ -144,7 +145,7 @@ func testCustomCommand(ctx context.Context, cmd *commands.Command) (string, int)
 	ctx, cancel := context.WithTimeout(ctx, cmd.Timeout.Duration)
 	defer cancel()
 
-	output, err := cmd.RunNow(ctx, website.EventGUI)
+	output, err := cmd.RunNow(ctx, &common.ActionInput{Type: website.EventGUI})
 	if err != nil {
 		return fmt.Sprintf("Command Failed! Error: %v", err), http.StatusInternalServerError
 	}

--- a/pkg/client/instance_tests.go
+++ b/pkg/client/instance_tests.go
@@ -164,7 +164,7 @@ func testQbit(ctx context.Context, config *qbit.Config) (string, int) {
 }
 
 func testRtorrent(config *apps.RtorrentConfig) (string, int) {
-	config.Setup(0, func(string, ...interface{}) {})
+	config.Setup(0, nil)
 
 	result, err := config.Client.Call("system.hostname")
 	if err != nil {
@@ -183,7 +183,7 @@ func testRtorrent(config *apps.RtorrentConfig) (string, int) {
 }
 
 func testSabNZB(ctx context.Context, app *apps.SabNZBConfig) (string, int) {
-	app.Setup(0, func(string, ...interface{}) {})
+	app.Setup(0, nil)
 
 	sab, err := app.GetQueue(ctx)
 	if err != nil {
@@ -329,7 +329,7 @@ func testProcess(ctx context.Context, svc *services.Service) (string, int) {
 }
 
 func testPlex(ctx context.Context, app *apps.PlexConfig) (string, int) {
-	app.Setup(0, func(string, ...interface{}) {})
+	app.Setup(0, nil)
 
 	info, err := app.GetInfo(ctx)
 	if err != nil {
@@ -340,7 +340,7 @@ func testPlex(ctx context.Context, app *apps.PlexConfig) (string, int) {
 }
 
 func testTautulli(ctx context.Context, app *apps.TautulliConfig) (string, int) {
-	app.Setup(0, func(string, ...interface{}) {})
+	app.Setup(0, nil)
 
 	users, err := app.GetUsers(ctx)
 	if err != nil {

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -243,10 +243,9 @@ func (c *Client) configureServices(ctx context.Context) *website.ClientInfo {
 	}
 
 	c.configureServicesPlex(ctx)
-	c.website.ReloadCh(c.sighup)
 	c.Config.Snapshot.Validate()
 	c.PrintStartupInfo(ctx, clientInfo)
-	c.triggers.Start(ctx)
+	c.triggers.Start(ctx, c.sighup)
 	c.Config.Services.Start(ctx)
 
 	return clientInfo

--- a/pkg/client/tray.go
+++ b/pkg/client/tray.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Notifiarr/notifiarr/pkg/bindata"
 	"github.com/Notifiarr/notifiarr/pkg/mnd"
+	"github.com/Notifiarr/notifiarr/pkg/triggers/common"
 	"github.com/Notifiarr/notifiarr/pkg/ui"
 	"github.com/Notifiarr/notifiarr/pkg/website"
 	"github.com/getlantern/systray"
@@ -264,7 +265,7 @@ func (c *Client) buildDynamicTimerMenus() {
 
 	for {
 		if idx, _, ok := reflect.Select(cases); ok {
-			timers[idx].Run(website.EventUser)
+			timers[idx].Run(&common.ActionInput{Type: website.EventUser})
 		} else if cases = append(cases[:idx], cases[idx+1:]...); len(cases) < 1 {
 			// Channel cases[idx] has been closed, remove it.
 			return // no menus left to watch, exit.
@@ -403,25 +404,25 @@ func (c *Client) watchNotifiarrMenu(ctx context.Context) {
 		case <-menu["send_dash"].ClickedCh:
 			c.triggers.Dashboard.Send(website.EventUser)
 		case <-menu["corrLidarr"].ClickedCh:
-			_ = c.triggers.Backups.Corruption(website.EventUser, starr.Lidarr)
+			_ = c.triggers.Backups.Corruption(&common.ActionInput{Type: website.EventUser}, starr.Lidarr)
 		case <-menu["corrProwlarr"].ClickedCh:
-			_ = c.triggers.Backups.Corruption(website.EventUser, starr.Prowlarr)
+			_ = c.triggers.Backups.Corruption(&common.ActionInput{Type: website.EventUser}, starr.Prowlarr)
 		case <-menu["corrRadarr"].ClickedCh:
-			_ = c.triggers.Backups.Corruption(website.EventUser, starr.Radarr)
+			_ = c.triggers.Backups.Corruption(&common.ActionInput{Type: website.EventUser}, starr.Radarr)
 		case <-menu["corrReadarr"].ClickedCh:
-			_ = c.triggers.Backups.Corruption(website.EventUser, starr.Readarr)
+			_ = c.triggers.Backups.Corruption(&common.ActionInput{Type: website.EventUser}, starr.Readarr)
 		case <-menu["corrSonarr"].ClickedCh:
-			_ = c.triggers.Backups.Corruption(website.EventUser, starr.Sonarr)
+			_ = c.triggers.Backups.Corruption(&common.ActionInput{Type: website.EventUser}, starr.Sonarr)
 		case <-menu["backLidarr"].ClickedCh:
-			_ = c.triggers.Backups.Backup(website.EventUser, starr.Lidarr)
+			_ = c.triggers.Backups.Backup(&common.ActionInput{Type: website.EventUser}, starr.Lidarr)
 		case <-menu["backProwlarr"].ClickedCh:
-			_ = c.triggers.Backups.Backup(website.EventUser, starr.Prowlarr)
+			_ = c.triggers.Backups.Backup(&common.ActionInput{Type: website.EventUser}, starr.Prowlarr)
 		case <-menu["backRadarr"].ClickedCh:
-			_ = c.triggers.Backups.Backup(website.EventUser, starr.Radarr)
+			_ = c.triggers.Backups.Backup(&common.ActionInput{Type: website.EventUser}, starr.Radarr)
 		case <-menu["backReadarr"].ClickedCh:
-			_ = c.triggers.Backups.Backup(website.EventUser, starr.Readarr)
+			_ = c.triggers.Backups.Backup(&common.ActionInput{Type: website.EventUser}, starr.Readarr)
 		case <-menu["backSonarr"].ClickedCh:
-			_ = c.triggers.Backups.Backup(website.EventUser, starr.Sonarr)
+			_ = c.triggers.Backups.Backup(&common.ActionInput{Type: website.EventUser}, starr.Sonarr)
 		}
 	}
 }

--- a/pkg/client/webserver.go
+++ b/pkg/client/webserver.go
@@ -11,7 +11,7 @@ import (
 	"path"
 	"time"
 
-	"github.com/Notifiarr/notifiarr/pkg/exp"
+	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/gorilla/mux"
 	apachelog "github.com/lestrrat-go/apache-logformat"
 )
@@ -117,7 +117,7 @@ func (r *responseWrapper) WriteHeader(statusCode int) {
 }
 
 func (r *responseWrapper) Write(b []byte) (int, error) {
-	exp.HTTPRequests.Add("Response Bytes", int64(len(b)))
+	mnd.HTTPRequests.Add("Response Bytes", int64(len(b)))
 	return r.ResponseWriter.Write(b) //nolint:wrapcheck
 }
 
@@ -136,6 +136,6 @@ func (r *responseWrapper) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 }
 
 func (n *netConnWrapper) Write(b []byte) (int, error) {
-	exp.HTTPRequests.Add("Response Bytes", int64(len(b)))
+	mnd.HTTPRequests.Add("Response Bytes", int64(len(b)))
 	return n.Conn.Write(b) //nolint:wrapcheck
 }

--- a/pkg/logs/logfiles.go
+++ b/pkg/logs/logfiles.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Notifiarr/notifiarr/pkg/exp"
 	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	homedir "github.com/mitchellh/go-homedir"
 	"golift.io/datacounter"
@@ -299,11 +298,11 @@ func map2list(input map[string]struct{}) []string {
 func logCounter(filename string, writer io.Writer) io.Writer {
 	counter := datacounter.NewWriterCounter(writer)
 
-	exp.LogFiles.Set("Lines Written: "+filename, expvar.Func(
+	mnd.LogFiles.Set("Lines Written: "+filename, expvar.Func(
 		func() interface{} { return int64(counter.Writes()) },
 	))
 
-	exp.LogFiles.Set("Bytes Written: "+filename, expvar.Func(
+	mnd.LogFiles.Set("Bytes Written: "+filename, expvar.Func(
 		func() interface{} { return int64(counter.Count()) },
 	))
 

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -14,7 +14,6 @@ import (
 	"runtime/debug"
 	"sync"
 
-	"github.com/Notifiarr/notifiarr/pkg/exp"
 	"github.com/Notifiarr/notifiarr/pkg/logs/share"
 	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/Notifiarr/notifiarr/pkg/ui"
@@ -175,43 +174,43 @@ func (l *Logger) CapturePanic() {
 
 // Debug writes log lines... to stdout and/or a file.
 func (l *Logger) Debug(v ...interface{}) {
-	exp.LogFiles.Add("Debug Lines", 1)
+	mnd.LogFiles.Add("Debug Lines", 1)
 	l.writeMsg(fmt.Sprintln(v...), l.DebugLog, false)
 }
 
 // Debugf writes log lines... to stdout and/or a file.
 func (l *Logger) Debugf(msg string, v ...interface{}) {
-	exp.LogFiles.Add("Debug Lines", 1)
+	mnd.LogFiles.Add("Debug Lines", 1)
 	l.writeMsg(fmt.Sprintf(msg, v...), l.DebugLog, false)
 }
 
 // Print writes log lines... to stdout and/or a file.
 func (l *Logger) Print(v ...interface{}) {
-	exp.LogFiles.Add("Info Lines", 1)
+	mnd.LogFiles.Add("Info Lines", 1)
 	l.writeMsg(fmt.Sprintln(v...), l.InfoLog, false)
 }
 
 // Printf writes log lines... to stdout and/or a file.
 func (l *Logger) Printf(msg string, v ...interface{}) {
-	exp.LogFiles.Add("Info Lines", 1)
+	mnd.LogFiles.Add("Info Lines", 1)
 	l.writeMsg(fmt.Sprintf(msg, v...), l.InfoLog, false)
 }
 
 // Error writes log lines... to stdout and/or a file.
 func (l *Logger) Error(v ...interface{}) {
-	exp.LogFiles.Add("Error Lines", 1)
+	mnd.LogFiles.Add("Error Lines", 1)
 	l.writeMsg(fmt.Sprintln(v...), l.ErrorLog, true)
 }
 
 // Errorf writes log lines... to stdout and/or a file.
 func (l *Logger) Errorf(msg string, v ...interface{}) {
-	exp.LogFiles.Add("Error Lines", 1)
+	mnd.LogFiles.Add("Error Lines", 1)
 	l.writeMsg(fmt.Sprintf(msg, v...), l.ErrorLog, true)
 }
 
 // ErrorfNoShare writes log lines... to stdout and/or a file.
 func (l *Logger) ErrorfNoShare(msg string, v ...interface{}) {
-	exp.LogFiles.Add("Error Lines", 1)
+	mnd.LogFiles.Add("Error Lines", 1)
 	l.writeMsg(fmt.Sprintf(msg, v...), l.ErrorLog, false)
 }
 
@@ -284,7 +283,7 @@ func CustomLog(filePath, logName string) *Logger {
 
 func (l *Logger) postRotateCounter(fileName, newFile string) {
 	if fileName != "" {
-		exp.LogFiles.Add("Rotated: "+fileName, 1)
+		mnd.LogFiles.Add("Rotated: "+fileName, 1)
 	}
 
 	if newFile != "" && l != nil {

--- a/pkg/logs/share/share.go
+++ b/pkg/logs/share/share.go
@@ -38,7 +38,7 @@ func Log(msg string) {
 	locker.RLock()
 	defer locker.RUnlock()
 
-	if config == nil || !website.HaveClientInfo() {
+	if ci := website.GetClientInfo(); ci == nil || config == nil {
 		return
 	}
 

--- a/pkg/mnd/metrics.go
+++ b/pkg/mnd/metrics.go
@@ -1,10 +1,12 @@
 //nolint:gochecknoglobals
-package exp
+package mnd
 
 import (
 	"expvar"
 	"strings"
 )
+
+/* This file powers all the exported metrics. */
 
 var mainMap = expvar.NewMap("notifiarr").Init()
 

--- a/pkg/services/checks.go
+++ b/pkg/services/checks.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Notifiarr/notifiarr/pkg/exp"
+	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/Notifiarr/notifiarr/pkg/website"
 )
 
@@ -119,9 +119,9 @@ func (s *Service) update(res *result) bool {
 		return false
 	}
 
-	exp.ServiceChecks.Add(s.Name+"&&Total", 1)
-	exp.ServiceChecks.Add(s.Name+"&&"+res.state.String(), 1)
-	//	exp.ServiceChecks.Add("Total Checks Run", 1)
+	mnd.ServiceChecks.Add(s.Name+"&&Total", 1)
+	mnd.ServiceChecks.Add(s.Name+"&&"+res.state.String(), 1)
+	//	mnd.ServiceChecks.Add("Total Checks Run", 1)
 
 	s.svc.Lock()
 	defer s.svc.Unlock()

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Notifiarr/notifiarr/pkg/exp"
 	"github.com/Notifiarr/notifiarr/pkg/logs"
+	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/Notifiarr/notifiarr/pkg/website"
 )
 
@@ -40,11 +40,11 @@ func (c *Config) setup(services []*Service) error {
 			return err
 		}
 
-		exp.ServiceChecks.Add(check.Name+"&&Total", 0)
-		exp.ServiceChecks.Add(check.Name+"&&"+StateUnknown.String(), 0)
-		exp.ServiceChecks.Add(check.Name+"&&"+StateOK.String(), 0)
-		exp.ServiceChecks.Add(check.Name+"&&"+StateWarning.String(), 0)
-		exp.ServiceChecks.Add(check.Name+"&&"+StateCritical.String(), 0)
+		mnd.ServiceChecks.Add(check.Name+"&&Total", 0)
+		mnd.ServiceChecks.Add(check.Name+"&&"+StateUnknown.String(), 0)
+		mnd.ServiceChecks.Add(check.Name+"&&"+StateOK.String(), 0)
+		mnd.ServiceChecks.Add(check.Name+"&&"+StateWarning.String(), 0)
+		mnd.ServiceChecks.Add(check.Name+"&&"+StateCritical.String(), 0)
 
 		// Add this validated service to our service map.
 		c.services[services[idx].Name] = services[idx]

--- a/pkg/snapshot/mysql.go
+++ b/pkg/snapshot/mysql.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Notifiarr/notifiarr/pkg/exp"
 	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	_ "github.com/go-sql-driver/mysql" // We use mysql driver, this is how it's loaded.
 	"golift.io/cnfg"
@@ -122,14 +121,14 @@ func getMySQL(ctx context.Context, mysql *MySQLConfig) (MySQLProcesses, MySQLSta
 }
 
 func scanMySQLProcessList(ctx context.Context, dbase *sql.DB) (MySQLProcesses, error) {
-	exp.Apps.Add("MySQL&&Process List Queries", 1)
+	mnd.Apps.Add("MySQL&&Process List Queries", 1)
 
 	rows, err := dbase.QueryContext(ctx, "SHOW FULL PROCESSLIST") //nolint:execinquery
 	if err != nil {
-		exp.Apps.Add("MySQL&&Errors", 1)
+		mnd.Apps.Add("MySQL&&Errors", 1)
 		return nil, fmt.Errorf("getting processes: %w", err)
 	} else if err = rows.Err(); err != nil {
-		exp.Apps.Add("MySQL&&Errors", 1)
+		mnd.Apps.Add("MySQL&&Errors", 1)
 		return nil, fmt.Errorf("getting processes rows: %w", err)
 	}
 	defer rows.Close()
@@ -141,7 +140,7 @@ func scanMySQLProcessList(ctx context.Context, dbase *sql.DB) (MySQLProcesses, e
 		// for each row, scan the result into our tag composite object
 		err := rows.Scan(&pid.ID, &pid.User, &pid.Host, &pid.DB, &pid.Cmd, &pid.Time, &pid.State, &pid.Info)
 		if err != nil {
-			exp.Apps.Add("MySQL&&Errors", 1)
+			mnd.Apps.Add("MySQL&&Errors", 1)
 			return nil, fmt.Errorf("scanning process rows: %w", err)
 		}
 
@@ -177,14 +176,14 @@ func scanMySQLStatus(ctx context.Context, dbase *sql.DB) (MySQLStatus, error) {
 	)
 
 	for _, name := range likes {
-		exp.Apps.Add("MySQL&&Global Status Queries", 1)
+		mnd.Apps.Add("MySQL&&Global Status Queries", 1)
 
 		rows, err := dbase.QueryContext(ctx, "SHOW GLOBAL STATUS LIKE '"+name+"%'") //nolint:execinquery
 		if err != nil {
-			exp.Apps.Add("MySQL&&Errors", 1)
+			mnd.Apps.Add("MySQL&&Errors", 1)
 			return nil, fmt.Errorf("getting global status: %w", err)
 		} else if err = rows.Err(); err != nil {
-			exp.Apps.Add("MySQL&&Errors", 1)
+			mnd.Apps.Add("MySQL&&Errors", 1)
 			return nil, fmt.Errorf("getting global status rows: %w", err)
 		}
 
@@ -192,7 +191,7 @@ func scanMySQLStatus(ctx context.Context, dbase *sql.DB) (MySQLStatus, error) {
 			var vname, value string
 
 			if err := rows.Scan(&vname, &value); err != nil {
-				exp.Apps.Add("MySQL&&Errors", 1)
+				mnd.Apps.Add("MySQL&&Errors", 1)
 				return nil, fmt.Errorf("scanning global status rows: %w", err)
 			}
 

--- a/pkg/triggers/backups/backups.go
+++ b/pkg/triggers/backups/backups.go
@@ -13,28 +13,28 @@ import (
 )
 
 // Backup initializes a backup check for all instances of the provided app.
-func (a *Action) Backup(event website.EventType, app starr.App) error {
+func (a *Action) Backup(input *common.ActionInput, app starr.App) error {
 	switch app {
 	default:
 		return fmt.Errorf("%w: %s", common.ErrInvalidApp, app)
 	case "":
 		return fmt.Errorf("%w: <no app provided>", common.ErrInvalidApp)
 	case "All":
-		a.cmd.Exec(event, TrigLidarrBackup)
-		a.cmd.Exec(event, TrigProwlarrBackup)
-		a.cmd.Exec(event, TrigRadarrBackup)
-		a.cmd.Exec(event, TrigReadarrBackup)
-		a.cmd.Exec(event, TrigSonarrBackup)
+		a.cmd.Exec(input, TrigLidarrBackup)
+		a.cmd.Exec(input, TrigProwlarrBackup)
+		a.cmd.Exec(input, TrigRadarrBackup)
+		a.cmd.Exec(input, TrigReadarrBackup)
+		a.cmd.Exec(input, TrigSonarrBackup)
 	case starr.Lidarr:
-		a.cmd.Exec(event, TrigLidarrBackup)
+		a.cmd.Exec(input, TrigLidarrBackup)
 	case starr.Prowlarr:
-		a.cmd.Exec(event, TrigProwlarrBackup)
+		a.cmd.Exec(input, TrigProwlarrBackup)
 	case starr.Radarr:
-		a.cmd.Exec(event, TrigRadarrBackup)
+		a.cmd.Exec(input, TrigRadarrBackup)
 	case starr.Readarr:
-		a.cmd.Exec(event, TrigReadarrBackup)
+		a.cmd.Exec(input, TrigReadarrBackup)
 	case starr.Sonarr:
-		a.cmd.Exec(event, TrigSonarrBackup)
+		a.cmd.Exec(input, TrigSonarrBackup)
 	}
 
 	return nil
@@ -58,7 +58,7 @@ func (c *cmd) makeBackupTriggersLidarr() {
 	c.Add(&common.Action{
 		Name: TrigLidarrBackup,
 		Fn:   c.sendLidarrBackups,
-		C:    make(chan website.EventType, 1),
+		C:    make(chan *common.ActionInput, 1),
 		T:    ticker,
 	})
 }
@@ -81,7 +81,7 @@ func (c *cmd) makeBackupTriggersRadarr() {
 	c.Add(&common.Action{
 		Name: TrigRadarrBackup,
 		Fn:   c.sendRadarrBackups,
-		C:    make(chan website.EventType, 1),
+		C:    make(chan *common.ActionInput, 1),
 		T:    ticker,
 	})
 }
@@ -104,7 +104,7 @@ func (c *cmd) makeBackupTriggersReadarr() {
 	c.Add(&common.Action{
 		Name: TrigReadarrBackup,
 		Fn:   c.sendReadarrBackups,
-		C:    make(chan website.EventType, 1),
+		C:    make(chan *common.ActionInput, 1),
 		T:    ticker,
 	})
 }
@@ -127,7 +127,7 @@ func (c *cmd) makeBackupTriggersSonarr() {
 	c.Add(&common.Action{
 		Name: TrigSonarrBackup,
 		Fn:   c.sendSonarrBackups,
-		C:    make(chan website.EventType, 1),
+		C:    make(chan *common.ActionInput, 1),
 		T:    ticker,
 	})
 }
@@ -150,17 +150,17 @@ func (c *cmd) makeBackupTriggersProwlarr() {
 	c.Add(&common.Action{
 		Name: TrigProwlarrBackup,
 		Fn:   c.sendProwlarrBackups,
-		C:    make(chan website.EventType, 1),
+		C:    make(chan *common.ActionInput, 1),
 		T:    ticker,
 	})
 }
 
-func (c *cmd) sendLidarrBackups(ctx context.Context, event website.EventType) {
+func (c *cmd) sendLidarrBackups(ctx context.Context, input *common.ActionInput) {
 	for idx, app := range c.Apps.Lidarr {
-		if ci := website.GetClientInfo(); event != website.EventCron ||
+		if ci := website.GetClientInfo(); input.Type != website.EventCron ||
 			(ci != nil && ci.Actions.Apps.Lidarr.Backup(idx+1) != mnd.Disabled) {
 			c.sendBackups(ctx, &genericInstance{
-				event: event,
+				event: input.Type,
 				name:  starr.Lidarr,
 				int:   idx + 1,
 				app:   app,
@@ -171,12 +171,12 @@ func (c *cmd) sendLidarrBackups(ctx context.Context, event website.EventType) {
 	}
 }
 
-func (c *cmd) sendProwlarrBackups(ctx context.Context, event website.EventType) {
+func (c *cmd) sendProwlarrBackups(ctx context.Context, input *common.ActionInput) {
 	for idx, app := range c.Apps.Prowlarr {
-		if ci := website.GetClientInfo(); event != website.EventCron ||
+		if ci := website.GetClientInfo(); input.Type != website.EventCron ||
 			(ci != nil && ci.Actions.Apps.Prowlarr.Backup(idx+1) != mnd.Disabled) {
 			c.sendBackups(ctx, &genericInstance{
-				event: event,
+				event: input.Type,
 				name:  starr.Prowlarr,
 				int:   idx + 1,
 				app:   app,
@@ -187,12 +187,12 @@ func (c *cmd) sendProwlarrBackups(ctx context.Context, event website.EventType) 
 	}
 }
 
-func (c *cmd) sendRadarrBackups(ctx context.Context, event website.EventType) {
+func (c *cmd) sendRadarrBackups(ctx context.Context, input *common.ActionInput) {
 	for idx, app := range c.Apps.Radarr {
-		if ci := website.GetClientInfo(); event != website.EventCron ||
+		if ci := website.GetClientInfo(); input.Type != website.EventCron ||
 			(ci != nil && ci.Actions.Apps.Radarr.Backup(idx+1) != mnd.Disabled) {
 			c.sendBackups(ctx, &genericInstance{
-				event: event,
+				event: input.Type,
 				name:  starr.Radarr,
 				int:   idx + 1,
 				app:   app,
@@ -203,12 +203,12 @@ func (c *cmd) sendRadarrBackups(ctx context.Context, event website.EventType) {
 	}
 }
 
-func (c *cmd) sendReadarrBackups(ctx context.Context, event website.EventType) {
+func (c *cmd) sendReadarrBackups(ctx context.Context, input *common.ActionInput) {
 	for idx, app := range c.Apps.Readarr {
-		if ci := website.GetClientInfo(); event != website.EventCron ||
+		if ci := website.GetClientInfo(); input.Type != website.EventCron ||
 			(ci != nil && ci.Actions.Apps.Readarr.Backup(idx+1) != mnd.Disabled) {
 			c.sendBackups(ctx, &genericInstance{
-				event: event,
+				event: input.Type,
 				name:  starr.Readarr,
 				int:   idx + 1,
 				app:   app,
@@ -219,12 +219,12 @@ func (c *cmd) sendReadarrBackups(ctx context.Context, event website.EventType) {
 	}
 }
 
-func (c *cmd) sendSonarrBackups(ctx context.Context, event website.EventType) {
+func (c *cmd) sendSonarrBackups(ctx context.Context, input *common.ActionInput) {
 	for idx, app := range c.Apps.Sonarr {
-		if ci := website.GetClientInfo(); event != website.EventCron ||
+		if ci := website.GetClientInfo(); input.Type != website.EventCron ||
 			(ci != nil && ci.Actions.Apps.Sonarr.Backup(idx+1) != mnd.Disabled) {
 			c.sendBackups(ctx, &genericInstance{
-				event: event,
+				event: input.Type,
 				name:  starr.Sonarr,
 				cName: app.Name,
 				int:   idx + 1,

--- a/pkg/triggers/backups/corruption.go
+++ b/pkg/triggers/backups/corruption.go
@@ -19,28 +19,28 @@ import (
 )
 
 // Corruption initializes a corruption check for all instances of the provided app.
-func (a *Action) Corruption(event website.EventType, app starr.App) error {
+func (a *Action) Corruption(input *common.ActionInput, app starr.App) error {
 	switch app {
 	default:
 		return fmt.Errorf("%w: %s", common.ErrInvalidApp, app)
 	case "":
 		return fmt.Errorf("%w: <no app provided>", common.ErrInvalidApp)
 	case "All":
-		a.cmd.Exec(event, TrigLidarrCorrupt)
-		a.cmd.Exec(event, TrigProwlarrCorrupt)
-		a.cmd.Exec(event, TrigRadarrCorrupt)
-		a.cmd.Exec(event, TrigReadarrCorrupt)
-		a.cmd.Exec(event, TrigSonarrCorrupt)
+		a.cmd.Exec(input, TrigLidarrCorrupt)
+		a.cmd.Exec(input, TrigProwlarrCorrupt)
+		a.cmd.Exec(input, TrigRadarrCorrupt)
+		a.cmd.Exec(input, TrigReadarrCorrupt)
+		a.cmd.Exec(input, TrigSonarrCorrupt)
 	case starr.Lidarr:
-		a.cmd.Exec(event, TrigLidarrCorrupt)
+		a.cmd.Exec(input, TrigLidarrCorrupt)
 	case starr.Prowlarr:
-		a.cmd.Exec(event, TrigProwlarrCorrupt)
+		a.cmd.Exec(input, TrigProwlarrCorrupt)
 	case starr.Radarr:
-		a.cmd.Exec(event, TrigRadarrCorrupt)
+		a.cmd.Exec(input, TrigRadarrCorrupt)
 	case starr.Readarr:
-		a.cmd.Exec(event, TrigReadarrCorrupt)
+		a.cmd.Exec(input, TrigReadarrCorrupt)
 	case starr.Sonarr:
-		a.cmd.Exec(event, TrigSonarrCorrupt)
+		a.cmd.Exec(input, TrigSonarrCorrupt)
 	}
 
 	return nil
@@ -64,7 +64,7 @@ func (c *cmd) makeCorruptionTriggersLidarr() {
 	c.Add(&common.Action{
 		Name: TrigLidarrCorrupt,
 		Fn:   c.sendLidarrCorruption,
-		C:    make(chan website.EventType, 1),
+		C:    make(chan *common.ActionInput, 1),
 		T:    ticker,
 	})
 }
@@ -87,7 +87,7 @@ func (c *cmd) makeCorruptionTriggersProwlarr() {
 	c.Add(&common.Action{
 		Name: TrigProwlarrCorrupt,
 		Fn:   c.sendProwlarrCorruption,
-		C:    make(chan website.EventType, 1),
+		C:    make(chan *common.ActionInput, 1),
 		T:    ticker,
 	})
 }
@@ -110,7 +110,7 @@ func (c *cmd) makeCorruptionTriggersRadarr() {
 	c.Add(&common.Action{
 		Name: TrigRadarrCorrupt,
 		Fn:   c.sendRadarrCorruption,
-		C:    make(chan website.EventType, 1),
+		C:    make(chan *common.ActionInput, 1),
 		T:    ticker,
 	})
 }
@@ -133,7 +133,7 @@ func (c *cmd) makeCorruptionTriggersReadarr() {
 	c.Add(&common.Action{
 		Name: TrigReadarrCorrupt,
 		Fn:   c.sendReadarrCorruption,
-		C:    make(chan website.EventType, 1),
+		C:    make(chan *common.ActionInput, 1),
 		T:    ticker,
 	})
 }
@@ -156,15 +156,15 @@ func (c *cmd) makeCorruptionTriggersSonarr() {
 	c.Add(&common.Action{
 		Name: TrigSonarrCorrupt,
 		Fn:   c.sendSonarrCorruption,
-		C:    make(chan website.EventType, 1),
+		C:    make(chan *common.ActionInput, 1),
 		T:    ticker,
 	})
 }
 
-func (c *cmd) sendLidarrCorruption(ctx context.Context, event website.EventType) {
+func (c *cmd) sendLidarrCorruption(ctx context.Context, input *common.ActionInput) {
 	for idx, app := range c.Apps.Lidarr {
 		c.lidarr[idx] = c.sendAndLogAppCorruption(ctx, &genericInstance{
-			event: event,
+			event: input.Type,
 			last:  c.lidarr[idx],
 			name:  starr.Lidarr,
 			int:   idx + 1,
@@ -175,10 +175,10 @@ func (c *cmd) sendLidarrCorruption(ctx context.Context, event website.EventType)
 	}
 }
 
-func (c *cmd) sendProwlarrCorruption(ctx context.Context, event website.EventType) {
+func (c *cmd) sendProwlarrCorruption(ctx context.Context, input *common.ActionInput) {
 	for idx, app := range c.Apps.Prowlarr {
 		c.prowlarr[idx] = c.sendAndLogAppCorruption(ctx, &genericInstance{
-			event: event,
+			event: input.Type,
 			last:  c.prowlarr[idx],
 			name:  starr.Prowlarr,
 			int:   idx + 1,
@@ -189,10 +189,10 @@ func (c *cmd) sendProwlarrCorruption(ctx context.Context, event website.EventTyp
 	}
 }
 
-func (c *cmd) sendRadarrCorruption(ctx context.Context, event website.EventType) {
+func (c *cmd) sendRadarrCorruption(ctx context.Context, input *common.ActionInput) {
 	for idx, app := range c.Apps.Radarr {
 		c.radarr[idx] = c.sendAndLogAppCorruption(ctx, &genericInstance{
-			event: event,
+			event: input.Type,
 			last:  c.radarr[idx],
 			name:  starr.Radarr,
 			int:   idx + 1,
@@ -203,10 +203,10 @@ func (c *cmd) sendRadarrCorruption(ctx context.Context, event website.EventType)
 	}
 }
 
-func (c *cmd) sendReadarrCorruption(ctx context.Context, event website.EventType) {
+func (c *cmd) sendReadarrCorruption(ctx context.Context, input *common.ActionInput) {
 	for idx, app := range c.Apps.Readarr {
 		c.readarr[idx] = c.sendAndLogAppCorruption(ctx, &genericInstance{
-			event: event,
+			event: input.Type,
 			last:  c.readarr[idx],
 			name:  starr.Readarr,
 			int:   idx + 1,
@@ -217,10 +217,10 @@ func (c *cmd) sendReadarrCorruption(ctx context.Context, event website.EventType
 	}
 }
 
-func (c *cmd) sendSonarrCorruption(ctx context.Context, event website.EventType) {
+func (c *cmd) sendSonarrCorruption(ctx context.Context, input *common.ActionInput) {
 	for idx, app := range c.Apps.Sonarr {
 		c.sonarr[idx] = c.sendAndLogAppCorruption(ctx, &genericInstance{
-			event: event,
+			event: input.Type,
 			last:  c.sonarr[idx],
 			name:  starr.Sonarr,
 			int:   idx + 1,

--- a/pkg/triggers/cfsync/common.go
+++ b/pkg/triggers/cfsync/common.go
@@ -72,12 +72,12 @@ func (c *cmd) create() {
 	c.Add(&common.Action{
 		Name: TrigCFSyncRadarr,
 		Fn:   c.syncRadarr,
-		C:    make(chan website.EventType, 1),
+		C:    make(chan *common.ActionInput, 1),
 		T:    radarrTicker,
 	}, &common.Action{
 		Name: TrigRPSyncSonarr,
 		Fn:   c.syncSonarr,
-		C:    make(chan website.EventType, 1),
+		C:    make(chan *common.ActionInput, 1),
 		T:    sonarrTicker,
 	})
 }
@@ -110,7 +110,7 @@ func (c *cmd) setupRadarr(ci *website.ClientInfo) {
 			Hide: true,
 			Name: TrigCFSyncRadarrInt.WithInstance(instance),
 			Fn:   (&radarrApp{app: app, cmd: c, idx: idx}).syncRadarr,
-			C:    make(chan website.EventType, 1),
+			C:    make(chan *common.ActionInput, 1),
 			T:    ticker,
 		})
 	}
@@ -144,7 +144,7 @@ func (c *cmd) setupSonarr(ci *website.ClientInfo) {
 			Hide: true,
 			Name: TrigRPSyncSonarrInt.WithInstance(instance),
 			Fn:   (&sonarrApp{app: app, cmd: c, idx: idx}).syncSonarr,
-			C:    make(chan website.EventType, 1),
+			C:    make(chan *common.ActionInput, 1),
 			T:    ticker,
 		})
 	}

--- a/pkg/triggers/commands/command.go
+++ b/pkg/triggers/commands/command.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Notifiarr/notifiarr/pkg/mnd"
+	"github.com/Notifiarr/notifiarr/pkg/triggers/common"
 	"github.com/Notifiarr/notifiarr/pkg/website"
 	"github.com/hugelgupf/go-shlex"
 )
@@ -35,12 +36,12 @@ func (c *Command) Setup(logger mnd.Logger, website *website.Server) {
 }
 
 // run executes this command and logs the output. This is executed from the trigger channel.
-func (c *Command) run(ctx context.Context, event website.EventType) {
-	_, _ = c.RunNow(ctx, event)
+func (c *Command) run(ctx context.Context, input *common.ActionInput) {
+	_, _ = c.RunNow(ctx, input)
 }
 
 // RunNow runs the command immediately, waits for and returns the output.
-func (c *Command) RunNow(ctx context.Context, event website.EventType) (string, error) {
+func (c *Command) RunNow(ctx context.Context, input *common.ActionInput) (string, error) {
 	output, err := c.exec(ctx)
 	oLen := 0
 	oStr := output.String()
@@ -56,7 +57,7 @@ func (c *Command) RunNow(ctx context.Context, event website.EventType) (string, 
 	if c.Notify {
 		c.website.SendData(&website.Request{
 			Route: website.CommandRoute,
-			Event: event,
+			Event: input.Type,
 			Payload: map[string]string{
 				"name":   c.Name,
 				"hash":   c.Hash,
@@ -79,12 +80,12 @@ func (c *Command) RunNow(ctx context.Context, event website.EventType) (string, 
 		c.output = eStr + ": " + oStr
 
 		if c.Log && oStr != "" {
-			c.log.Errorf("[%s requested] Custom Command '%s' Failed: %v, Output: %s", event, c.Name, err, oStr)
+			c.log.Errorf("[%s requested] Custom Command '%s' Failed: %v, Output: %s", input.Type, c.Name, err, oStr)
 		} else {
-			c.log.Errorf("[%s requested] Custom Command '%s' Failed: %v", event, c.Name, err)
+			c.log.Errorf("[%s requested] Custom Command '%s' Failed: %v", input.Type, c.Name, err)
 		}
 	} else if c.Log && oLen > 0 {
-		c.log.Printf("[%s requested] Custom Command '%s' Output: %s", event, c.Name, oStr)
+		c.log.Printf("[%s requested] Custom Command '%s' Output: %s", input.Type, c.Name, oStr)
 	}
 
 	return oStr, err

--- a/pkg/triggers/commands/setup.go
+++ b/pkg/triggers/commands/setup.go
@@ -43,7 +43,7 @@ type Command struct {
 	output  string // last output logged
 	lastRun time.Time
 	mu      sync.RWMutex
-	ch      chan website.EventType
+	ch      chan *common.ActionInput
 	log     mnd.Logger
 	website *website.Server
 }
@@ -58,12 +58,12 @@ func New(config *common.Config, commands []*Command) *Action {
 }
 
 // Run fires a custom command.
-func (c *Command) Run(event website.EventType) {
+func (c *Command) Run(input *common.ActionInput) {
 	if c.ch == nil {
 		return
 	}
 
-	c.ch <- event
+	c.ch <- input
 }
 
 // List returns a list of active triggers that can be executed.
@@ -115,7 +115,7 @@ func (c *Command) Stats() Stats {
 
 func (c *cmd) create() {
 	for _, cmd := range c.cmdlist {
-		cmd.ch = make(chan website.EventType, 1)
+		cmd.ch = make(chan *common.ActionInput, 1)
 
 		c.Add(&common.Action{
 			Name: common.TriggerName(fmt.Sprintf("Running Custom Command '%s'", cmd.Name)),

--- a/pkg/triggers/common/timers.go
+++ b/pkg/triggers/common/timers.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/Notifiarr/notifiarr/pkg/exp"
+	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/Notifiarr/notifiarr/pkg/ui"
 	"github.com/Notifiarr/notifiarr/pkg/website"
 )
@@ -76,8 +76,8 @@ func (c *Config) runTimerLoop(ctx context.Context, actions []*Action, cases []re
 			input.Type = "unknown"
 		}
 
-		exp.TimerEvents.Add(string(input.Type)+"&&"+string(action.Name), 1)
-		exp.TimerCounts.Add(string(action.Name), 1)
+		mnd.TimerEvents.Add(string(input.Type)+"&&"+string(action.Name), 1)
+		mnd.TimerCounts.Add(string(action.Name), 1)
 
 		if action.Fn == nil { // stop channel has no Function.
 			return // called by c.Stop(), calls c.stopTimerLoop().

--- a/pkg/triggers/dashboard/dashboard.go
+++ b/pkg/triggers/dashboard/dashboard.go
@@ -164,14 +164,14 @@ func (c *Cmd) getStates(ctx context.Context) *States {
 	sessions, _ := c.PlexCron.GetSessions(ctx)
 
 	return &States{
-		Deluge:   c.getDelugeStates(),
-		Lidarr:   c.getLidarrStates(),
-		Qbit:     c.getQbitStates(),
-		NZBGet:   c.getNZBGetStates(),
+		Deluge:   c.getDelugeStates(ctx),
+		Lidarr:   c.getLidarrStates(ctx),
+		Qbit:     c.getQbitStates(ctx),
+		NZBGet:   c.getNZBGetStates(ctx),
 		RTorrent: c.getRtorrentStates(),
-		Radarr:   c.getRadarrStates(),
-		Readarr:  c.getReadarrStates(),
-		Sonarr:   c.getSonarrStates(),
+		Radarr:   c.getRadarrStates(ctx),
+		Readarr:  c.getReadarrStates(ctx),
+		Sonarr:   c.getSonarrStates(ctx),
 		SabNZB:   c.getSabNZBStates(ctx),
 		Plex:     sessions,
 	}

--- a/pkg/triggers/dashboard/dashboard.go
+++ b/pkg/triggers/dashboard/dashboard.go
@@ -132,17 +132,17 @@ func (c *Cmd) create() {
 	c.Add(&common.Action{
 		Name: TrigDashboard,
 		Fn:   c.sendDashboardState,
-		C:    make(chan website.EventType, 1),
+		C:    make(chan *common.ActionInput, 1),
 		T:    ticker,
 	})
 }
 
 // Send the current states for the dashboard to the website.
 func (a *Action) Send(event website.EventType) {
-	a.cmd.Exec(event, TrigDashboard)
+	a.cmd.Exec(&common.ActionInput{Type: event}, TrigDashboard)
 }
 
-func (c *Cmd) sendDashboardState(ctx context.Context, event website.EventType) {
+func (c *Cmd) sendDashboardState(ctx context.Context, input *common.ActionInput) {
 	var (
 		start  = time.Now()
 		states = c.getStates(ctx)
@@ -152,7 +152,7 @@ func (c *Cmd) sendDashboardState(ctx context.Context, event website.EventType) {
 	data.Save("dashboard", states)
 	c.SendData(&website.Request{
 		Route:      website.DashRoute,
-		Event:      event,
+		Event:      input.Type,
 		LogPayload: true,
 		LogMsg:     fmt.Sprintf("Dashboard State (elapsed: %v)", apps),
 		Payload:    states,

--- a/pkg/triggers/dashboard/deluge.go
+++ b/pkg/triggers/dashboard/deluge.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"time"
@@ -9,7 +10,7 @@ import (
 	"golift.io/cnfg"
 )
 
-func (c *Cmd) getDelugeStates() []*State {
+func (c *Cmd) getDelugeStates(ctx context.Context) []*State {
 	states := []*State{}
 
 	for instance, app := range c.Apps.Deluge {
@@ -19,7 +20,7 @@ func (c *Cmd) getDelugeStates() []*State {
 
 		c.Debugf("Getting Deluge State: %d:%s", instance+1, app.URL)
 
-		state, err := c.getDelugeState(instance+1, app)
+		state, err := c.getDelugeState(ctx, instance+1, app)
 		if err != nil {
 			state.Error = err.Error()
 			c.Errorf("Getting Deluge Data from %d:%s: %v", instance+1, app.URL, err)
@@ -31,9 +32,10 @@ func (c *Cmd) getDelugeStates() []*State {
 	return states
 }
 
-func (c *Cmd) getDelugeState(instance int, app *apps.DelugeConfig) (*State, error) { //nolint:funlen,cyclop
+//nolint:funlen,cyclop
+func (c *Cmd) getDelugeState(ctx context.Context, instance int, app *apps.DelugeConfig) (*State, error) {
 	start := time.Now()
-	xfers, err := app.GetXfersCompat()
+	xfers, err := app.GetXfersCompatContext(ctx)
 	state := &State{
 		Elapsed:  cnfg.Duration{Duration: time.Since(start)},
 		Instance: instance,

--- a/pkg/triggers/dashboard/qbit.go
+++ b/pkg/triggers/dashboard/qbit.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -10,7 +11,7 @@ import (
 	"golift.io/cnfg"
 )
 
-func (c *Cmd) getQbitStates() []*State {
+func (c *Cmd) getQbitStates(ctx context.Context) []*State {
 	states := []*State{}
 
 	for instance, app := range c.Apps.Qbit {
@@ -20,7 +21,7 @@ func (c *Cmd) getQbitStates() []*State {
 
 		c.Debugf("Getting Qbit State: %d:%s", instance+1, app.URL)
 
-		state, err := c.getQbitState(instance+1, app)
+		state, err := c.getQbitState(ctx, instance+1, app)
 		if err != nil {
 			state.Error = err.Error()
 			c.Errorf("Getting Qbit Data from %d:%s: %v", instance+1, app.URL, err)
@@ -32,9 +33,9 @@ func (c *Cmd) getQbitStates() []*State {
 	return states
 }
 
-func (c *Cmd) getQbitState(instance int, app *apps.QbitConfig) (*State, error) { //nolint:cyclop
+func (c *Cmd) getQbitState(ctx context.Context, instance int, app *apps.QbitConfig) (*State, error) { //nolint:cyclop
 	start := time.Now()
-	xfers, err := app.GetXfers()
+	xfers, err := app.GetXfersContext(ctx)
 
 	state := &State{
 		Elapsed:  cnfg.Duration{Duration: time.Since(start)},

--- a/pkg/triggers/dashboard/radarr.go
+++ b/pkg/triggers/dashboard/radarr.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"time"
@@ -9,7 +10,7 @@ import (
 	"golift.io/starr/radarr"
 )
 
-func (c *Cmd) getRadarrStates() []*State {
+func (c *Cmd) getRadarrStates(ctx context.Context) []*State {
 	states := []*State{}
 
 	for instance, app := range c.Apps.Radarr {
@@ -19,7 +20,7 @@ func (c *Cmd) getRadarrStates() []*State {
 
 		c.Debugf("Getting Radarr State: %d:%s", instance+1, app.URL)
 
-		state, err := c.getRadarrState(instance+1, app)
+		state, err := c.getRadarrState(ctx, instance+1, app)
 		if err != nil {
 			state.Error = err.Error()
 			c.Errorf("Getting Radarr Queue from %d:%s: %v", instance+1, app.URL, err)
@@ -31,11 +32,11 @@ func (c *Cmd) getRadarrStates() []*State {
 	return states
 }
 
-func (c *Cmd) getRadarrState(instance int, r *apps.RadarrConfig) (*State, error) {
+func (c *Cmd) getRadarrState(ctx context.Context, instance int, r *apps.RadarrConfig) (*State, error) {
 	state := &State{Instance: instance, Next: []*Sortable{}, Latest: []*Sortable{}, Name: r.Name}
 	start := time.Now()
 
-	movies, err := r.GetMovie(0)
+	movies, err := r.GetMovieContext(ctx, 0)
 	state.Elapsed.Duration = time.Since(start)
 
 	if err != nil {

--- a/pkg/triggers/dashboard/sonarr.go
+++ b/pkg/triggers/dashboard/sonarr.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"time"
@@ -10,7 +11,7 @@ import (
 	"golift.io/starr/sonarr"
 )
 
-func (c *Cmd) getSonarrStates() []*State {
+func (c *Cmd) getSonarrStates(ctx context.Context) []*State {
 	states := []*State{}
 
 	for instance, app := range c.Apps.Sonarr {
@@ -20,7 +21,7 @@ func (c *Cmd) getSonarrStates() []*State {
 
 		c.Debugf("Getting Sonarr State: %d:%s", instance+1, app.URL)
 
-		state, err := c.getSonarrState(instance+1, app)
+		state, err := c.getSonarrState(ctx, instance+1, app)
 		if err != nil {
 			state.Error = err.Error()
 			c.Errorf("Getting Sonarr Queue from %d:%s: %v", instance+1, app.URL, err)
@@ -32,11 +33,11 @@ func (c *Cmd) getSonarrStates() []*State {
 	return states
 }
 
-func (c *Cmd) getSonarrState(instance int, app *apps.SonarrConfig) (*State, error) {
+func (c *Cmd) getSonarrState(ctx context.Context, instance int, app *apps.SonarrConfig) (*State, error) {
 	state := &State{Instance: instance, Next: []*Sortable{}, Name: app.Name}
 	start := time.Now()
 
-	allshows, err := app.GetAllSeries()
+	allshows, err := app.GetAllSeriesContext(ctx)
 	state.Elapsed.Duration = time.Since(start)
 
 	if err != nil {

--- a/pkg/triggers/handler.go
+++ b/pkg/triggers/handler.go
@@ -34,7 +34,7 @@ func (a *Actions) handleTrigger(req *http.Request, event website.EventType) (int
 	if content != "" {
 		a.timers.Debugf("[%s requested] Incoming Trigger: %s (%s)", event, trigger, content)
 	} else {
-		a.timers.Debugf("[%s requested] Incoming Trigger: %s", event, input.Type, trigger)
+		a.timers.Debugf("[%s requested] Incoming Trigger: %s", event, trigger)
 	}
 
 	_ = req.ParseForm()

--- a/pkg/triggers/plexcron/finished.go
+++ b/pkg/triggers/plexcron/finished.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Notifiarr/notifiarr/pkg/apps/apppkg/plex"
+	"github.com/Notifiarr/notifiarr/pkg/triggers/common"
 	"github.com/Notifiarr/notifiarr/pkg/website"
 )
 
@@ -14,7 +15,7 @@ import (
 // This is basically a hack to "watch" Plex for when an active item gets to around 90% complete.
 // This usually means the user has finished watching the item and we can send a "done" notice.
 // Plex does not send a webhook or identify in any other way when an item is "finished".
-func (c *cmd) checkForFinishedItems(ctx context.Context, event website.EventType) {
+func (c *cmd) checkForFinishedItems(ctx context.Context, input *common.ActionInput) {
 	sessions, err := c.getSessions(ctx, time.Second)
 	if err != nil {
 		c.Errorf("[PLEX] Getting Sessions from %s: %v", c.Plex.URL, err)

--- a/pkg/triggers/plexcron/plexcron.go
+++ b/pkg/triggers/plexcron/plexcron.go
@@ -55,7 +55,7 @@ func New(config *common.Config, plex *apps.PlexConfig) *Action {
 
 // SendPlexSessions sends plex sessions in a go routine through a channel.
 func (a *Action) Send(event website.EventType) {
-	a.cmd.Exec(event, TrigPlexSessions)
+	a.cmd.Exec(&common.ActionInput{Type: event}, TrigPlexSessions)
 }
 
 // Run initializes the library.
@@ -82,7 +82,7 @@ func (c *cmd) run() {
 	c.Add(&common.Action{
 		Name: TrigPlexSessions,
 		Fn:   c.sendPlexSessions,
-		C:    make(chan website.EventType, 1),
+		C:    make(chan *common.ActionInput, 1),
 		T:    ticker,
 	})
 

--- a/pkg/triggers/plexcron/sessions.go
+++ b/pkg/triggers/plexcron/sessions.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"github.com/Notifiarr/notifiarr/pkg/apps/apppkg/plex"
+	"github.com/Notifiarr/notifiarr/pkg/triggers/common"
 	"github.com/Notifiarr/notifiarr/pkg/triggers/data"
 	"github.com/Notifiarr/notifiarr/pkg/website"
 )
 
 // sendPlexSessions is fired by a timer if Plex Sessions feature has an interval defined.
-func (c *cmd) sendPlexSessions(ctx context.Context, event website.EventType) {
+func (c *cmd) sendPlexSessions(ctx context.Context, input *common.ActionInput) {
 	sessions, err := c.getSessions(ctx, time.Minute)
 	if err != nil {
 		c.Errorf("Getting Plex sessions: %v", err)
@@ -19,7 +20,7 @@ func (c *cmd) sendPlexSessions(ctx context.Context, event website.EventType) {
 
 	c.SendData(&website.Request{
 		Route:      website.PlexRoute,
-		Event:      event,
+		Event:      input.Type,
 		Payload:    &website.Payload{Snap: c.getMetaSnap(ctx), Plex: sessions},
 		LogMsg:     "Plex Sessions",
 		LogPayload: true,

--- a/pkg/triggers/starrqueue/downloads.go
+++ b/pkg/triggers/starrqueue/downloads.go
@@ -64,7 +64,7 @@ func (c *cmd) getDownloadingItemsLidrr(_ context.Context) itemList {
 		app := items[instance]
 
 		for _, item := range queue.Records {
-			if strings.ToLower(item.Status) == downloading {
+			if s := strings.ToLower(item.Status); s == downloading || s == delay {
 				app.Queue = append(app.Queue, item)
 			}
 		}
@@ -96,7 +96,7 @@ func (c *cmd) getDownloadingItemsRadarr(_ context.Context) itemList {
 		app := items[instance]
 
 		for _, item := range queue.Records {
-			if strings.ToLower(item.Status) == downloading {
+			if s := strings.ToLower(item.Status); s == downloading || s == delay {
 				app.Queue = append(app.Queue, item)
 			}
 		}
@@ -128,7 +128,7 @@ func (c *cmd) getDownloadingItemsReadarr(_ context.Context) itemList {
 		app := items[instance]
 
 		for _, item := range queue.Records {
-			if strings.ToLower(item.Status) == downloading {
+			if s := strings.ToLower(item.Status); s == downloading || s == delay {
 				app.Queue = append(app.Queue, item)
 			}
 		}
@@ -137,7 +137,7 @@ func (c *cmd) getDownloadingItemsReadarr(_ context.Context) itemList {
 	return items
 }
 
-func (c *cmd) getDownloadingItemsSonarr(_ context.Context) itemList {
+func (c *cmd) getDownloadingItemsSonarr(_ context.Context) itemList { //nolint:cyclop
 	items := make(itemList)
 
 	ci := website.GetClientInfo()
@@ -162,7 +162,7 @@ func (c *cmd) getDownloadingItemsSonarr(_ context.Context) itemList {
 		repeatStomper := make(map[string]*sonarr.QueueRecord)
 
 		for _, item := range queue.Records {
-			if strings.ToLower(item.Status) == downloading && repeatStomper[item.DownloadID] == nil {
+			if s := strings.ToLower(item.Status); s == downloading || s == delay && repeatStomper[item.DownloadID] == nil {
 				app.Queue = append(app.Queue, item)
 				repeatStomper[item.DownloadID] = item
 			}

--- a/pkg/triggers/starrqueue/downloads.go
+++ b/pkg/triggers/starrqueue/downloads.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Notifiarr/notifiarr/pkg/triggers/common"
 	"github.com/Notifiarr/notifiarr/pkg/triggers/data"
 	"github.com/Notifiarr/notifiarr/pkg/website"
 	"golift.io/starr/lidarr"
@@ -14,7 +15,7 @@ import (
 )
 
 // sendDownloadingQueues gathers the downloading queue items from cache and sends them.
-func (c *cmd) sendDownloadingQueues(ctx context.Context, event website.EventType) {
+func (c *cmd) sendDownloadingQueues(ctx context.Context, input *common.ActionInput) {
 	lidarr := c.getDownloadingItemsLidrr(ctx)
 	radarr := c.getDownloadingItemsRadarr(ctx)
 	readarr := c.getDownloadingItemsReadarr(ctx)
@@ -26,7 +27,7 @@ func (c *cmd) sendDownloadingQueues(ctx context.Context, event website.EventType
 
 	c.SendData(&website.Request{
 		Route:      website.DownloadRoute,
-		Event:      event,
+		Event:      input.Type,
 		LogPayload: true,
 		ErrorsOnly: true,
 		LogMsg: fmt.Sprintf("Downloading Items; Lidarr: %d, Radarr: %d, Readarr: %d, Sonarr: %d",

--- a/pkg/triggers/starrqueue/lidarr.go
+++ b/pkg/triggers/starrqueue/lidarr.go
@@ -16,7 +16,7 @@ const TrigLidarrQueue common.TriggerName = "Storing Lidarr instance %d queue."
 // Does not send data to the website.
 func (a *Action) StoreLidarr(event website.EventType, instance int) {
 	if name := TrigLidarrQueue.WithInstance(instance); !a.cmd.Exec(&common.ActionInput{Type: event}, name) {
-		a.cmd.Errorf("[%s requested] Failed! %s Disbled?", event, name)
+		a.cmd.Errorf("[%s requested] Failed! %s Disabled?", event, name)
 	}
 }
 

--- a/pkg/triggers/starrqueue/radarr.go
+++ b/pkg/triggers/starrqueue/radarr.go
@@ -16,7 +16,7 @@ const TrigRadarrQueue common.TriggerName = "Storing Radarr instance %d queue."
 // Does not send data to the website.
 func (a *Action) StoreRadarr(event website.EventType, instance int) {
 	if name := TrigRadarrQueue.WithInstance(instance); !a.cmd.Exec(&common.ActionInput{Type: event}, name) {
-		a.cmd.Errorf("[%s requested] Failed! %s Disbled?", event, name)
+		a.cmd.Errorf("[%s requested] Failed! %s Disabled?", event, name)
 	}
 }
 

--- a/pkg/triggers/starrqueue/readarr.go
+++ b/pkg/triggers/starrqueue/readarr.go
@@ -22,7 +22,7 @@ type readarrApp struct {
 // Does not send data to the website.
 func (a *Action) StoreReadarr(event website.EventType, instance int) {
 	if name := TrigReadarrQueue.WithInstance(instance); !a.cmd.Exec(&common.ActionInput{Type: event}, name) {
-		a.cmd.Errorf("[%s requested] Failed! %s Disbled?", event, name)
+		a.cmd.Errorf("[%s requested] Failed! %s Disabled?", event, name)
 	}
 }
 

--- a/pkg/triggers/starrqueue/setup.go
+++ b/pkg/triggers/starrqueue/setup.go
@@ -32,6 +32,7 @@ const (
 	warning     = "warning"
 	completed   = "completed"
 	downloading = "downloading"
+	delay       = "delay"
 )
 
 const (

--- a/pkg/triggers/starrqueue/setup.go
+++ b/pkg/triggers/starrqueue/setup.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/Notifiarr/notifiarr/pkg/triggers/common"
-	"github.com/Notifiarr/notifiarr/pkg/website"
 )
 
 /* This file contains the procedures to send stuck download queue items to notifiarr. */
@@ -64,7 +63,7 @@ func (a *Action) Create() {
 		a.cmd.Add(&common.Action{
 			Name: TrigStuckItems,
 			Fn:   a.cmd.sendStuckQueues,
-			C:    make(chan website.EventType, 1),
+			C:    make(chan *common.ActionInput, 1),
 			T:    time.NewTicker(stuckDuration),
 		})
 
@@ -72,7 +71,7 @@ func (a *Action) Create() {
 			Hide: true,
 			Name: TrigDownloadingItems,
 			Fn:   a.cmd.sendDownloadingQueues,
-			C:    make(chan website.EventType, 1),
+			C:    make(chan *common.ActionInput, 1),
 			T:    time.NewTicker(finishedDuration),
 		})
 	}

--- a/pkg/triggers/starrqueue/sonarr.go
+++ b/pkg/triggers/starrqueue/sonarr.go
@@ -16,7 +16,7 @@ const TrigSonarrQueue common.TriggerName = "Storing Sonarr instance %d queue."
 // Does not send data to the website.
 func (a *Action) StoreSonarr(event website.EventType, instance int) {
 	if name := TrigSonarrQueue.WithInstance(instance); !a.cmd.Exec(&common.ActionInput{Type: event}, name) {
-		a.cmd.Errorf("[%s requested] Failed! %s Disbled?", event, name)
+		a.cmd.Errorf("[%s requested] Failed! %s Disabled?", event, name)
 	}
 }
 

--- a/pkg/triggers/starrqueue/stuckitems.go
+++ b/pkg/triggers/starrqueue/stuckitems.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Notifiarr/notifiarr/pkg/triggers/common"
 	"github.com/Notifiarr/notifiarr/pkg/triggers/data"
 	"github.com/Notifiarr/notifiarr/pkg/website"
 	"golift.io/starr/lidarr"
@@ -16,24 +17,24 @@ import (
 // StuckItems sends the stuck queues items for all apps.
 // Does not fetch fresh data first, uses cache.
 func (a *Action) StuckItems(event website.EventType) {
-	a.cmd.Exec(event, TrigStuckItems)
+	a.cmd.Exec(&common.ActionInput{Type: event}, TrigStuckItems)
 }
 
 // sendStuckQueues gathers the stuck queue from cache and sends them.
-func (c *cmd) sendStuckQueues(ctx context.Context, event website.EventType) {
+func (c *cmd) sendStuckQueues(ctx context.Context, input *common.ActionInput) {
 	lidarr := c.getFinishedItemsLidarr(ctx)
 	radarr := c.getFinishedItemsRadarr(ctx)
 	readarr := c.getFinishedItemsReadarr(ctx)
 	sonarr := c.getFinishedItemsSonarr(ctx)
 
 	if lidarr.Empty() && radarr.Empty() && readarr.Empty() && sonarr.Empty() {
-		c.Debugf("No stuck items found.")
+		c.Debugf("[%s requested] No stuck items found.", input.Type)
 		return
 	}
 
 	c.SendData(&website.Request{
 		Route:      website.StuckRoute,
-		Event:      event,
+		Event:      input.Type,
 		LogPayload: true,
 		LogMsg: fmt.Sprintf("Stuck Items; Lidarr: %d, Radarr: %d, Readarr: %d, Sonarr: %d",
 			lidarr.Len(), radarr.Len(), readarr.Len(), sonarr.Len()),

--- a/pkg/triggers/triggers.go
+++ b/pkg/triggers/triggers.go
@@ -4,6 +4,7 @@ package triggers
 
 import (
 	"context"
+	"os"
 	"reflect"
 
 	"github.com/Notifiarr/notifiarr/pkg/apps"
@@ -89,7 +90,8 @@ type run interface {
 }
 
 // Start creates all the triggers and runs the timers.
-func (a *Actions) Start(ctx context.Context) {
+func (a *Actions) Start(ctx context.Context, reloadCh chan os.Signal) {
+	a.timers.SetReloadCh(reloadCh)
 	defer a.timers.Run(ctx)
 
 	actions := reflect.ValueOf(a).Elem()

--- a/pkg/website/server.go
+++ b/pkg/website/server.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"sync"
 	"time"
 
@@ -39,7 +38,6 @@ type Config struct {
 	Retries    int
 	BaseURL    string
 	Timeout    cnfg.Duration
-	Sighup     chan os.Signal
 	HostID     string
 	mnd.Logger // log file writer
 }
@@ -76,10 +74,6 @@ func New(c *Config) *Server {
 		sendData:     make(chan *Request, mnd.Kilobyte),
 		stopSendData: make(chan struct{}),
 	}
-}
-
-func (s *Server) ReloadCh(sighup chan os.Signal) {
-	s.config.Sighup = sighup
 }
 
 // Start runs the website go routine.


### PR DESCRIPTION
- Passes inputs into triggers. Prerequisite for command args.
- Adds `delay` to download starrqueue payloads.
- Splits large log messages so they fit inside the log file size.
- Changes how metrics collection works when debug is disabled. Should use less memory.
- Various bug fixes:
  - Typos.
  - Plex eyeball 
  - Fixes disabling of apps (timeout = -1s).
  - Pass more contexts through dashboard library.
