### PR TITLE
Tautulli: Send Plex User Id not username or email

### DIFF
--- a/pkg/apps/apppkg/tautulli/tautulli.go
+++ b/pkg/apps/apppkg/tautulli/tautulli.go
@@ -139,8 +139,8 @@ type User struct {
 	AllowGuest      int      `json:"allow_guest"`   // 1,0 (bool)
 }
 
-// MapEmailName returns a map of email => name for Tautulli users.
-func (u *Users) MapEmailName() map[string]string {
+// MapIdName returns a map of plex id => name for Tautulli users.
+func (u *Users) MapIdName() map[string]string {
 	if u == nil {
 		return nil
 	}
@@ -149,20 +149,8 @@ func (u *Users) MapEmailName() map[string]string {
 
 	for _, user := range u.Response.Data {
 		// user.FriendlyName always seems to be set, so this first if-block is safety only.
-		if user.FriendlyName == "" && user.Email != "" && user.Username != "" {
-			nameMap[user.Email] = user.Username
-			continue
-		} else if user.FriendlyName == "" {
-			// This user has no mapability.
-			continue
-		}
-
-		// We only need username or email, not both, but in the order username then email.
-		if user.Username != "" {
-			nameMap[user.Username] = user.FriendlyName
-		} else if user.Email != "" {
-			nameMap[user.Email] = user.FriendlyName
-		}
+		// We now send the id and the mapped name as Plex Webhook sends the Profile Title not Profile UserName
+		nameMap[string(user.UserID)] = user.FriendlyName
 	}
 
 	return nameMap

--- a/pkg/website/clientinfo/appinfo.go
+++ b/pkg/website/clientinfo/appinfo.go
@@ -188,7 +188,7 @@ func (c *Config) getAppConfigs(ctx context.Context) *AppConfigs {
 			strings.ReplaceAll(c.Apps.Tautulli.APIKey, "<redacted>", err.Error()))
 	} else {
 		apps.Tautulli = &AppInfoTautulli{
-			Users: u.MapEmailName(),
+			Users: u.MapIdName(),
 		}
 	}
 


### PR DESCRIPTION
BREAKING CHANGE - Requires Notifiarr Site Updates and this will need to be merged in concurrent with a new stable release as it will not be backwards compatible.

Closes #362