### PR TITLE
Use Plex ID in Tautulli map. Remove map from startup payload.

### DIFF
--- a/pkg/apps/apppkg/tautulli/tautulli.go
+++ b/pkg/apps/apppkg/tautulli/tautulli.go
@@ -139,30 +139,21 @@ type User struct {
 	AllowGuest      int      `json:"allow_guest"`   // 1,0 (bool)
 }
 
-// MapEmailName returns a map of email => name for Tautulli users.
-func (u *Users) MapEmailName() map[string]string {
+// MapIDName returns a map of plex user ID => Feiendly Name (or username) for Tautulli users.
+func (u *Users) MapIDName() map[int64]string {
 	if u == nil {
 		return nil
 	}
 
-	nameMap := map[string]string{}
+	nameMap := map[int64]string{}
 
 	for _, user := range u.Response.Data {
-		// user.FriendlyName always seems to be set, so this first if-block is safety only.
-		if user.FriendlyName == "" && user.Email != "" && user.Username != "" {
-			nameMap[user.Email] = user.Username
-			continue
-		} else if user.FriendlyName == "" {
-			// This user has no mapability.
-			continue
+		if user.FriendlyName == "" {
+			nameMap[user.UserID] = user.Username
+		} else {
+			nameMap[user.UserID] = user.FriendlyName
 		}
 
-		// We only need username or email, not both, but in the order username then email.
-		if user.Username != "" {
-			nameMap[user.Username] = user.FriendlyName
-		} else if user.Email != "" {
-			nameMap[user.Email] = user.FriendlyName
-		}
 	}
 
 	return nameMap

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -207,7 +207,7 @@ func (c *Client) loadConfiguration(ctx context.Context) (msg string, newPassword
 
 // Load configuration from the website.
 func (c *Client) loadSiteConfig(ctx context.Context) *clientinfo.ClientInfo {
-	clientInfo, err := c.clientinfo.SaveClientInfo(ctx)
+	clientInfo, err := c.clientinfo.SaveClientInfo(ctx, true)
 	if err != nil || clientInfo == nil {
 		if errors.Is(err, website.ErrInvalidAPIKey) {
 			c.ErrorfNoShare("==> Problem validating API key: %v", err)

--- a/pkg/triggers/crontimer/custom.go
+++ b/pkg/triggers/crontimer/custom.go
@@ -132,7 +132,7 @@ func (c *cmd) PollForReload(ctx context.Context, input *common.ActionInput) {
 	body, err := c.GetData(&website.Request{
 		Route:      website.ClientRoute,
 		Event:      website.EventPoll,
-		Payload:    c.CIC.Info(ctx),
+		Payload:    c.CIC.Info(ctx, true), // true avoids polling tautulli.
 		LogPayload: true,
 	})
 	if err != nil {

--- a/pkg/website/clientinfo/clientinfo.go
+++ b/pkg/website/clientinfo/clientinfo.go
@@ -134,11 +134,11 @@ func (c *ClientInfo) IsPatron() bool {
 }
 
 // SaveClientInfo returns an error if the API key is wrong. Caches and returns client info otherwise.
-func (c *Config) SaveClientInfo(ctx context.Context) (*ClientInfo, error) {
+func (c *Config) SaveClientInfo(ctx context.Context, startup bool) (*ClientInfo, error) {
 	body, err := c.GetData(&website.Request{
 		Route:      website.ClientRoute,
 		Event:      website.EventStart,
-		Payload:    c.Info(ctx),
+		Payload:    c.Info(ctx, startup),
 		LogPayload: true,
 	})
 	if err != nil {

--- a/pkg/website/clientinfo/handlers.go
+++ b/pkg/website/clientinfo/handlers.go
@@ -106,7 +106,7 @@ type AppStatuses struct {
 //
 //nolint:lll
 func (c *Config) InfoHandler(r *http.Request) (int, interface{}) {
-	return http.StatusOK, c.Info(r.Context())
+	return http.StatusOK, c.Info(r.Context(), false)
 }
 
 // VersionHandler returns application run and build time data and application statuses.
@@ -119,7 +119,7 @@ func (c *Config) InfoHandler(r *http.Request) (int, interface{}) {
 // @Router       /api/version [get]
 // @Security     ApiKeyAuth
 func (c *Config) VersionHandler(r *http.Request) (int, interface{}) {
-	output := c.Info(r.Context())
+	output := c.Info(r.Context(), false)
 	output.AppsStatus = c.appStatsForVersion(r.Context())
 
 	return http.StatusOK, output
@@ -138,7 +138,7 @@ func (c *Config) VersionHandler(r *http.Request) (int, interface{}) {
 // @Router       /api/version/{app}/{instance} [get]
 // @Security     ApiKeyAuth
 func (c *Config) VersionHandlerInstance(r *http.Request) (int, interface{}) {
-	output := c.Info(r.Context())
+	output := c.Info(r.Context(), false)
 	instance, _ := strconv.Atoi(mux.Vars(r)["instance"])
 	output.AppsStatus = c.appStatsForVersionInstance(r.Context(), mux.Vars(r)["app"], instance)
 


### PR DESCRIPTION
Closes https://github.com/Notifiarr/notifiarr/issues/362.

Of note: Tautulli data cache internally for 10 minutes. This cache persists a reload.