### PR TITLE
Allow changing auth header. Allow passing ui_password from env variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ docker logs <container id from docker run>
 
 ### WebUI
 
-To enable the webui, add this parameter to your config file, toward the top next to quiet, and restart the client:
+To enable the webui, add this parameter to your config file, toward the top next to `quiet`, and restart the client:
 
 ```yaml
 ui_password = "username:9CharacterPassword"
@@ -502,7 +502,7 @@ Make sure the Nginx `location` path matches the `urlbase` Notifiarr setting.
 That's all there is to it.
 
 Using an auth proxy? Be sure to set `ui_password` to the string `"webauth"`.
-The Nginx config looks more like this:
+Also see the [WebUI](#WebUI) section above. The Nginx config looks more like this:
 
 ```nginx
 location /notifiarr/api {

--- a/examples/notifiarr.conf.example
+++ b/examples/notifiarr.conf.example
@@ -1,15 +1,17 @@
 ###############################################
 # Notifiarr Client Example Configuration File #
-# Created by Notifiarr v0.2.7   @ 220103T0842 #
+# Created by Notifiarr v0.4.4   @ 232801T0734 #
 ###############################################
 
 ## This API key must be copied from your notifiarr.com account.
 api_key = "api-key-from-notifiarr.com"
 
-## Setting a UI password enables the human accessible web GUI. Must be at least 16 characters.
+## Setting a UI password enables the human accessible web GUI. Must be at least 9 characters.
 ## The default username is admin; change it by setting ui_password to "username:password"
 ## Set to "webauth" to disable the login form and use only proxy authentication. See upstreams, below.
-## Your proxy auth must pass x-webauth-user header if you set this to "webauth".
+## Your auth proxy must pass the x-webauth-user header if you set this to "webauth".
+## You may also set a custom auth header by setting to "webauth:<header>" e.g. "webauth:remote-user"
+## Disable auth by setting this to "noauth". Not recommended. Requires "upstreams" being set.
 ui_password = ""
 
 ## The ip:port to listen on for incoming HTTP requests. 0.0.0.0 means all/any IP and is recommended!
@@ -71,9 +73,15 @@ log_files = 0
 ## Missing, blank or 0 uses default of 0600. Permissive is 0644. Ignored by Windows.
 file_mode = "0600"
 
-## Web server and application timeouts.
+## Web server and website timeout.
 ##
 timeout = "1m"
+
+## This application can integrate with apt on Debian-based OSes.
+## Set apt to true to enable this integration. A true setting causes
+## notifiarr to relay apt package install/update hooks to notifiarr.com.
+##
+apt = false
 
 ## Setting serial to true makes the app use fewer threads when polling apps.
 ## This spreads CPU usage out and uses a bit less memory.
@@ -82,8 +90,7 @@ serial = false
 ## Retries controls how many times to retry requests to notifiarr.com.
 ## Sometimes cloudflare returns a 521, and this mitigates those problems.
 ## Setting this to 0 will take the default of 4. Use 1 to disable retrying.
-retries = 0
-
+retries = 4
 
 ##################
 # Starr Settings #
@@ -95,18 +102,17 @@ retries = 0
 ## See the Service Checks section below for information about setting the names.
 ##
 ## Examples follow. UNCOMMENT (REMOVE #), AT MINIMUM: [[header]], url, api_key
-##
-## NOTE: The url should match what you see in your address bar locally
+## Setting any application timeout to "-1s" will disable that application.
 
 #[[lidarr]]
 #name     = "" # Set a name to enable checks of your service.
-#url      = "http://lidarr:8989"
+#url      = "http://lidarr:8989/"
 #api_key  = ""
 
 
 #[[prowlarr]]
 #name     = "" # Set a name to enable checks of your service.
-#url      = "http://prowlarr:9696"
+#url      = "http://prowlarr:9696/"
 #api_key  = ""
 
 
@@ -124,7 +130,7 @@ retries = 0
 
 #[[sonarr]]
 #name      = ""  # Set a name to enable checks of your service.
-#url       = "http://sonarr:8989"
+#url       = "http://sonarr:8989/"
 #api_key   = ""
 
 
@@ -132,20 +138,34 @@ retries = 0
 
 #[[deluge]]
 #name     = ""  # Set a name to enable checks of your service.
-#url      = "http://deluge:8112"
+#url      = "http://deluge:8112/"
 #password = ""
 
 
 #[[qbit]]
 #name     = ""  # Set a name to enable checks of your service.
-#url      = "http://qbit:8080"
+#url      = "http://qbit:8080/"
+#user     = ""
+#pass     = ""
+
+
+#[[rtorrent]]
+#name     = ""  # Set a name to enable checks of your service.
+#url      = "http://rtorrent:5000/"
+#user     = ""
+#pass     = ""
+
+
+#[[nzbget]]
+#name     = ""  # Set a name to enable checks of your service.
+#url      = "http://nzbget:6789/"
 #user     = ""
 #pass     = ""
 
 
 #[[sabnzbd]]
 #name     = ""  # Set a name to enable checks of this application.
-#url      = "http://sabnzbd:8080"
+#url      = "http://sabnzbd:8080/"
 #api_key  = ""
 
 
@@ -186,6 +206,19 @@ retries = 0
 #user = "notifiarr"
 #pass = "password"
 
+###################
+# Nvidia Snapshot #
+###################
+
+# The app will automatically collect Nvidia data if nvidia-smi is present.
+# Use the settings below to disable Nvidia GPU collection, or restrict collection to only specific Bus IDs.
+# SMI Path is found automatically if left blank. Set it to path to nvidia-smi (nvidia-smi.exe on Windows).
+
+[snapshot.nvidia]
+disabled = false
+smi_path = ''''''
+bus_ids  = []
+
 ##################
 # Service Checks #
 ##################
@@ -193,6 +226,7 @@ retries = 0
 ## This application performs service checks on configured services at the specified interval.
 ## The service states are sent to Notifiarr.com. Failed services generate a notification.
 ## Setting names on Starr apps (above) enables service checks for that app.
+## Setting the Interval to "-1s" (Disabled in UI) will disable service checks on that named instance.
 ## Use the [[service]] directive to add more service checks. Example below.
 
 [services]
@@ -222,3 +256,43 @@ retries = 0
 #  check   = 'http://10.1.1.2:6767/series/'
 #  expect  = "200"
 #  timeout = "10s"
+
+
+######################
+# File & Log Watcher #
+######################
+
+## Tail a log file, regex match lines, and send notifications.
+## Example:
+
+#[[watch_file]]
+#  path  = '/var/log/system.log'
+#  skip  = '''error'''
+#  regex = '''[Ee]rror'''
+#  poll  = false
+#  pipe  = false
+#  must_exist = false
+#  log_match  = true
+
+
+
+###################
+# Custom Commands #
+###################
+
+## Run and trigger custom commands.
+## Commands may have required arguments thet can be passed in when the command is run.
+## These use the format ({regex}) - a regular expression wrapped by curly braces and parens.
+## The example below allows a user to run any combination of ls -la on /usr, /home, or /tmp:
+## command = "/bin/ls ({-la|-al|-l|-a}) ({/usr|/home|/tmp})"
+##
+## Full Example (remove the leading # hashes to use it):
+
+#[[command]]
+#  name    = 'some-name-for-logs'
+#  command = '/var/log/system.log'
+#  shell   = false
+#  log     = true
+#  notify  = true
+#  timeout = "10s"
+

--- a/pkg/client/handlers_gui.go
+++ b/pkg/client/handlers_gui.go
@@ -79,14 +79,14 @@ func (c *Client) getUserName(request *http.Request) (string, bool) {
 	}
 
 	ip := strings.Trim(request.RemoteAddr[:strings.LastIndex(request.RemoteAddr, ":")], "[]")
-	if c.Config.Allow.Contains(ip) {
+	if c.Config.Allow.Contains(ip) && c.webauth {
 		// If the upstream is allowed and gave us a username header, use it.
-		if userName := request.Header.Get("x-webauth-user"); userName != "" && c.webauth {
+		if userName := request.Header.Get(c.authHeader); userName != "" {
 			return userName, true
 		}
 
 		// If the upstream IP is allowed and no auth is enabled, set a username.
-		if c.noauth {
+		if c.noauth { // c.webauth is always true if c.noauth is true.
 			return configfile.DefaultUsername, true
 		}
 	}

--- a/pkg/client/init.go
+++ b/pkg/client/init.go
@@ -51,7 +51,12 @@ func (c *Client) PrintStartupInfo(ctx context.Context, clientInfo *clientinfo.Cl
 	c.printTautulli()
 	c.printMySQL()
 	c.Printf(" => Timeout: %s, Quiet: %v", c.Config.Timeout, c.Config.Quiet)
-	c.Printf(" => Trusted Upstream Networks: %v", c.Config.Allow)
+
+	if c.Config.UIPassword.Webauth() {
+		c.Printf(" => Trusted Upstream Networks: %v, Auth Proxy Header: %s", c.Config.Allow, c.Config.UIPassword.Header())
+	} else {
+		c.Printf(" => Trusted Upstream Networks: %v", c.Config.Allow)
+	}
 
 	if c.Config.SSLCrtFile != "" && c.Config.SSLKeyFile != "" {
 		c.Print(" => Web HTTPS Listen:", "https://"+c.Config.BindAddr+path.Join("/", c.Config.URLBase))

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -49,6 +49,7 @@ type Client struct {
 	template   *template.Template
 	webauth    bool
 	noauth     bool
+	authHeader string
 	reloading  bool
 	// this locks anything that may be updated while running.
 	// at least "UIPassword" and "reloading" as of its creation.

--- a/pkg/client/webserver.go
+++ b/pkg/client/webserver.go
@@ -30,6 +30,7 @@ func (c *Client) StartWebServer() {
 	c.Config.Router.Use(c.addUsernameHeader)
 	c.webauth = c.Config.UIPassword.Webauth() // this needs to be locked since password can be changed without reloading.
 	c.noauth = c.Config.UIPassword.Noauth()
+	c.authHeader = c.Config.UIPassword.Header()
 
 	// Make a multiplexer because websockets can't use apache log.
 	smx := http.NewServeMux()

--- a/pkg/configfile/config.go
+++ b/pkg/configfile/config.go
@@ -42,6 +42,7 @@ const (
 		"and will not be printed again. Log in, and change it."
 	MsgConfigFound  = "Using Config File: "
 	DefaultUsername = "admin"
+	DefaultHeader   = "x-webauth-user"
 )
 
 // Config represents the data in our config file.

--- a/pkg/configfile/template.go
+++ b/pkg/configfile/template.go
@@ -46,7 +46,9 @@ extra_keys = [{{range $s := .ExKeys}}"{{$s}}",{{end}}]{{end}}
 ## Setting a UI password enables the human accessible web GUI. Must be at least 9 characters.
 ## The default username is admin; change it by setting ui_password to "username:password"
 ## Set to "webauth" to disable the login form and use only proxy authentication. See upstreams, below.
-## Your proxy auth must pass x-webauth-user header if you set this to "webauth".
+## Your auth proxy must pass the x-webauth-user header if you set this to "webauth".
+## You may also set a custom auth header by setting to "webauth:<header>" e.g. "webauth:remote-user"
+## Disable auth by setting this to "noauth". Not recommended. Requires "upstreams" being set.
 ui_password = "{{.UIPassword}}"
 
 ## The ip:port to listen on for incoming HTTP requests. 0.0.0.0 means all/any IP and is recommended!
@@ -75,11 +77,12 @@ quiet = {{.Quiet}}
 debug = {{.Debug}}
 max_body = {{.MaxBody}} # maximum body size for debug logs. 0 = no limit.
 
+{{- if not force}}
+
 ## HostID is used to uniquely identify this client's system.
 ## Do not set or change this unless you have a good reason.
 ## Do not copy this value to another server, every client must be unique.
-##
-host_id = "{{.HostID}}"
+host_id = "{{.HostID}}"{{end}}
 
 ## All API paths start with /api. This does not affect incoming /plex webhooks.
 ## Change it to /somethingelse/api by setting urlbase to "/somethingelse"


### PR DESCRIPTION
- This change allows changing the auth proxy header from the default of `x-webauth-user`. 
- You do this by changing the value of `ui_password` to `webauth:<header>` 
- e.g. `webauth:x-webauth-user` or `webauth:remote-user`
- Closes #401
- This also fixes the bug preventing `DN_UI_PASSWORD` from working as environment variable.
- You can now pass things like these from env vars, and it will work. 
```
DN_UI_PASSWORD=webauth
DN_UI_PASSWORD=webauth:remote-user
DN_UI_PASSWORD=noauth
DN_UI_PASSWORD=mySuperCoolPassw0rd
```
- Fixes #416