### PR TITLE
Logs improvements

### DIFF
--- a/pkg/client/html_templates.go
+++ b/pkg/client/html_templates.go
@@ -139,7 +139,7 @@ func (c *Client) getFuncMap() template.FuncMap { //nolint:funlen
 		// returns the current time.
 		"now": time.Now,
 		// returns an integer divided by a million.
-		"megabyte": megabyte,
+		"megabyte": mnd.FormatBytes,
 		// returns the URL base.
 		"base": func() string { return path.Join(c.Config.URLBase, "ui") + "/" },
 		// returns the files url base.
@@ -308,34 +308,6 @@ func durShort(dur time.Duration) string {
 	}
 
 	return output
-}
-
-func megabyte(size interface{}) string {
-	val := int64(0)
-
-	switch valtype := size.(type) {
-	case int64:
-		val = valtype
-	case uint64:
-		val = int64(valtype)
-	case int:
-		val = int64(valtype)
-	}
-
-	switch {
-	case val > mnd.Megabyte*mnd.Megabyte*mnd.Kilobyte*1000: // 2^60
-		return fmt.Sprintf("%.2f EiB", float64(val)/float64(mnd.Megabyte*mnd.Megabyte*mnd.Megabyte))
-	case val > mnd.Megabyte*mnd.Megabyte*1000: // 2^50
-		return fmt.Sprintf("%.2f PiB", float64(val)/float64(mnd.Megabyte*mnd.Megabyte*mnd.Kilobyte))
-	case val > mnd.Megabyte*mnd.Kilobyte*1000: // 2^40
-		return fmt.Sprintf("%.2f TiB", float64(val)/float64(mnd.Megabyte*mnd.Megabyte))
-	case val > mnd.Megabyte*1000: // 2^30
-		return fmt.Sprintf("%.2f GiB", float64(val)/float64(mnd.Megabyte*mnd.Kilobyte))
-	case val > mnd.Kilobyte*1000: // 2^20
-		return fmt.Sprintf("%.1f MiB", float64(val)/float64(mnd.Megabyte))
-	default: // 2^10
-		return fmt.Sprintf("%.1f KiB", float64(val)/float64(mnd.Kilobyte))
-	}
 }
 
 func since(t time.Time) string {

--- a/pkg/mnd/functions.go
+++ b/pkg/mnd/functions.go
@@ -1,0 +1,39 @@
+package mnd
+
+import "fmt"
+
+// FormatBytes converts a byte counter into a pretty UI string.
+// The input val must be int, int64, uint64 or float64.
+func FormatBytes(size interface{}) string { //nolint:cyclop
+	var val float64
+
+	switch valtype := size.(type) {
+	case float64:
+		val = valtype
+	case int64:
+		val = float64(valtype)
+	case uint64:
+		val = float64(valtype)
+	case int:
+		val = float64(valtype)
+	default:
+		panic("non-number provided to FormatBytes function")
+	}
+
+	switch {
+	case val > Megabyte*Megabyte*Kilobyte*1000: // 2^60
+		return fmt.Sprintf("%.2f EiB", val/float64(Megabyte*Megabyte*Megabyte))
+	case val > Megabyte*Megabyte*1000: // 2^50
+		return fmt.Sprintf("%.2f PiB", val/float64(Megabyte*Megabyte*Kilobyte))
+	case val > Megabyte*Kilobyte*1000: // 2^40
+		return fmt.Sprintf("%.2f TiB", val/float64(Megabyte*Megabyte))
+	case val > Megabyte*1000: // 2^30
+		return fmt.Sprintf("%.2f GiB", val/float64(Megabyte*Kilobyte))
+	case val > Kilobyte*1000: // 2^20
+		return fmt.Sprintf("%.1f MiB", val/float64(Megabyte))
+	case val > Kilobyte: // 2^10
+		return fmt.Sprintf("%.1f KiB", val/float64(Kilobyte))
+	default: // 2^1
+		return fmt.Sprintf("%.1f B", val)
+	}
+}

--- a/pkg/mnd/functions.go
+++ b/pkg/mnd/functions.go
@@ -1,3 +1,4 @@
+//nolint:gomnd
 package mnd
 
 import "fmt"

--- a/pkg/mnd/functions.go
+++ b/pkg/mnd/functions.go
@@ -31,9 +31,9 @@ func FormatBytes(size interface{}) string { //nolint:cyclop
 		return fmt.Sprintf("%.2f GiB", val/float64(Megabyte*Kilobyte))
 	case val > Kilobyte*1000: // 2^20
 		return fmt.Sprintf("%.1f MiB", val/float64(Megabyte))
-	case val > Kilobyte: // 2^10
+	case val > 1000: // 2^10
 		return fmt.Sprintf("%.1f KiB", val/float64(Kilobyte))
 	default: // 2^1
-		return fmt.Sprintf("%.1f B", val)
+		return fmt.Sprintf("%f B", val)
 	}
 }

--- a/pkg/mnd/functions.go
+++ b/pkg/mnd/functions.go
@@ -35,6 +35,6 @@ func FormatBytes(size interface{}) string { //nolint:cyclop
 	case val > 1000: // 2^10
 		return fmt.Sprintf("%.1f KiB", val/float64(Kilobyte))
 	default: // 2^1
-		return fmt.Sprintf("%f B", val)
+		return fmt.Sprintf("%.0f B", val)
 	}
 }

--- a/pkg/mnd/variables.go
+++ b/pkg/mnd/variables.go
@@ -1,6 +1,7 @@
 package mnd
 
 import (
+	"fmt"
 	"math/rand"
 	"os"
 	"time"
@@ -13,6 +14,9 @@ var (
 	// IsDocker tells us if this is our Docker container.
 	IsDocker = os.Getpid() == 1
 )
+
+// ErrDisabledInstance is returned when a request for a disabled instance is performed.
+var ErrDisabledInstance = fmt.Errorf("instance is administratively disabled")
 
 //nolint:gochecknoinits
 func init() {

--- a/pkg/website/server.go
+++ b/pkg/website/server.go
@@ -154,7 +154,9 @@ func (s *Server) sendPayload(ctx context.Context, uri string, payload interface{
 	}
 
 	resp, err := unmarshalResponse(s.Config.BaseURL+uri, code, body)
-	resp.sent = len(post)
+	if resp != nil {
+		resp.sent = len(post)
+	}
 
 	return resp, err
 }

--- a/pkg/website/server.go
+++ b/pkg/website/server.go
@@ -153,7 +153,10 @@ func (s *Server) sendPayload(ctx context.Context, uri string, payload interface{
 		return nil, err
 	}
 
-	return unmarshalResponse(s.Config.BaseURL+uri, code, body)
+	resp, err := unmarshalResponse(s.Config.BaseURL+uri, code, body)
+	resp.sent = len(post)
+
+	return resp, err
 }
 
 // SendData puts a send-data request to notifiarr.com into a channel queue.

--- a/pkg/website/website_routes.go
+++ b/pkg/website/website_routes.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Notifiarr/notifiarr/pkg/apps/apppkg/plex"
+	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/Notifiarr/notifiarr/pkg/snapshot"
 	"golift.io/cnfg"
 )
@@ -192,6 +193,8 @@ func (r Route) Path(event EventType, params ...string) string {
 */
 // nitsua: all responses should be that way.. but response might not always be an object.
 type Response struct {
+	size    int64
+	sent    int
 	Result  string `json:"result"`
 	Details struct {
 		Response json.RawMessage `json:"response"` // can be anything. type it out later.
@@ -208,6 +211,6 @@ func (r *Response) String() string {
 		return ""
 	}
 
-	return fmt.Sprintf(" => Website took %s and replied with: %s, %s %s",
-		r.Details.Elapsed, r.Result, r.Details.Response, r.Details.Help)
+	return fmt.Sprintf(" => Website took %s and replied with (%s): %s, %s %s",
+		r.Details.Elapsed, mnd.FormatBytes(r.size), r.Result, r.Details.Response, r.Details.Help)
 }


### PR DESCRIPTION
Adds byte counters to most log lines. Adds API GET debug logs (only non-GET were being logged previously). Adds logging for errors generated during `/api/version` requests. Closes #446.