### PR TITLE
Bug Fixes

### DIFF
--- a/pkg/bindata/templates/includes/filetablelist.html
+++ b/pkg/bindata/templates/includes/filetablelist.html
@@ -1,6 +1,6 @@
 {{- /* This is imported by configfiles and logfiles. */}}
                                     {{- range $file := . }}
-                                        <table class="table table-bordered fileinfo-table" style="display:none;table-layout:fixed;" id="fileinfo-{{$file.ID}}" data-url="{{base}}/ws" data-name="{{$file.Name}}" data-id="{{$file.ID}}" data-used="{{$file.Used}}" data-filename="{{$file.Path}}">
+                                        <table class="table table-bordered fileinfo-table" style="display:none;table-layout:fixed;" id="fileinfo-{{$file.ID}}" data-url="{{base}}ws" data-name="{{$file.Name}}" data-id="{{$file.ID}}" data-used="{{$file.Used}}" data-filename="{{$file.Path}}">
                                             <tr>
                                                 <th style="width:15%;">Path</th>
                                                 <td style="word-wrap:break-word;">{{$file.Path}}</td>

--- a/pkg/client/handlers_websocket.go
+++ b/pkg/client/handlers_websocket.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"path/filepath"
 	"time"
 
 	"github.com/Notifiarr/notifiarr/pkg/logs"
@@ -34,13 +33,9 @@ func (c *Client) handleWebSockets(response http.ResponseWriter, request *http.Re
 
 	var fileInfos *logs.LogFileInfos
 
-	backupPath := filepath.Join(filepath.Dir(c.Flags.ConfigFile), "backups", filepath.Base(c.Flags.ConfigFile))
-
 	switch src := mux.Vars(request)["source"]; src {
 	case fileSourceLogs:
 		fileInfos = c.Logger.GetAllLogFilePaths()
-	case fileSourceConfig:
-		fileInfos = logs.GetFilePaths(c.Flags.ConfigFile, backupPath)
 	default:
 		http.Error(response, "invalid source: "+src, http.StatusBadRequest)
 		c.socketLog(http.StatusBadRequest, request)

--- a/pkg/client/webserver.go
+++ b/pkg/client/webserver.go
@@ -34,7 +34,7 @@ func (c *Client) StartWebServer() {
 
 	// Make a multiplexer because websockets can't use apache log.
 	smx := http.NewServeMux()
-	smx.Handle(path.Join(c.Config.URLBase, "/ws"), c.Config.Router)
+	smx.Handle(path.Join(c.Config.URLBase, "ui", "ws"), c.Config.Router) // websockets cannot go through the apache logger.
 	smx.Handle("/", c.stripSecrets(apache.Wrap(c.Config.Router, c.Logger.HTTPLog.Writer())))
 
 	// Create a server.
@@ -126,6 +126,8 @@ func (r *responseWrapper) Write(b []byte) (int, error) {
 func (r *responseWrapper) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	hijack, ok := r.ResponseWriter.(http.Hijacker)
 	if !ok {
+		// This fires if you move the /ui/ws endpoint to another name.
+		// It needs to be updated in two places.
 		panic("cannot hijack connection!")
 	}
 


### PR DESCRIPTION
- Fixes the plex web hook -> session collection context. Closes #478. Fixes at least 2 bugs. One bug where it sets the timeout before it sleeps for the configured web hook->session delay. Another bug where the timeout was hard coded to 1 minute when the configured Plex timeout was readily available.
- Fixes web sockets and closes #487. Also fixes 2 bugs. One bug making it not go to the handler (extra `/`), and then another bug making it route the handler through a logger that doesn't support web sockets.
