### PR TITLE
Limit count, disable active queue for non-patron.

### DIFF
--- a/pkg/triggers/starrqueue/downloads.go
+++ b/pkg/triggers/starrqueue/downloads.go
@@ -91,7 +91,7 @@ func (c *cmd) getDownloadingItemsLidarr(_ context.Context) itemList { //nolint:c
 		}
 
 		appList.Total = len(appList.Queue)
-		appList.Queue = truncateQueue(appList.Queue, maxQueuePayloadSize)
+		appList.Queue = truncateQueue(appList.Queue)
 		items[instance] = appList
 	}
 
@@ -136,7 +136,7 @@ func (c *cmd) getDownloadingItemsRadarr(_ context.Context) itemList { //nolint:c
 		}
 
 		appList.Total = len(appList.Queue)
-		appList.Queue = truncateQueue(appList.Queue, maxQueuePayloadSize)
+		appList.Queue = truncateQueue(appList.Queue)
 		items[instance] = appList
 	}
 
@@ -181,7 +181,7 @@ func (c *cmd) getDownloadingItemsReadarr(_ context.Context) itemList { //nolint:
 		}
 
 		appList.Total = len(appList.Queue)
-		appList.Queue = truncateQueue(appList.Queue, maxQueuePayloadSize)
+		appList.Queue = truncateQueue(appList.Queue)
 		items[instance] = appList
 	}
 
@@ -226,17 +226,17 @@ func (c *cmd) getDownloadingItemsSonarr(_ context.Context) itemList { //nolint:c
 		}
 
 		appList.Total = len(appList.Queue)
-		appList.Queue = truncateQueue(appList.Queue, maxQueuePayloadSize)
+		appList.Queue = truncateQueue(appList.Queue)
 		items[instance] = appList
 	}
 
 	return items
 }
 
-func truncateQueue(queue []any, length int) []any {
-	if len(queue) <= length {
+func truncateQueue(queue []any) []any {
+	if len(queue) <= maxQueuePayloadSize {
 		return queue
 	}
 
-	return queue[:length]
+	return queue[:maxQueuePayloadSize]
 }

--- a/pkg/triggers/starrqueue/downloads.go
+++ b/pkg/triggers/starrqueue/downloads.go
@@ -15,6 +15,8 @@ import (
 	"golift.io/starr/sonarr"
 )
 
+const maxQueuePayloadSize = 50
+
 // sendDownloadingQueues gathers the downloading queue items from cache and sends them.
 func (c *cmd) sendDownloadingQueues(ctx context.Context, input *common.ActionInput) {
 	lidarr := c.getDownloadingItemsLidarr(ctx)
@@ -88,6 +90,8 @@ func (c *cmd) getDownloadingItemsLidarr(_ context.Context) itemList { //nolint:c
 			}
 		}
 
+		appList.Total = len(appList.Queue)
+		appList.Queue = truncateQueue(appList.Queue, maxQueuePayloadSize)
 		items[instance] = appList
 	}
 
@@ -131,6 +135,8 @@ func (c *cmd) getDownloadingItemsRadarr(_ context.Context) itemList { //nolint:c
 			}
 		}
 
+		appList.Total = len(appList.Queue)
+		appList.Queue = truncateQueue(appList.Queue, maxQueuePayloadSize)
 		items[instance] = appList
 	}
 
@@ -174,6 +180,8 @@ func (c *cmd) getDownloadingItemsReadarr(_ context.Context) itemList { //nolint:
 			}
 		}
 
+		appList.Total = len(appList.Queue)
+		appList.Queue = truncateQueue(appList.Queue, maxQueuePayloadSize)
 		items[instance] = appList
 	}
 
@@ -217,8 +225,18 @@ func (c *cmd) getDownloadingItemsSonarr(_ context.Context) itemList { //nolint:c
 			}
 		}
 
+		appList.Total = len(appList.Queue)
+		appList.Queue = truncateQueue(appList.Queue, maxQueuePayloadSize)
 		items[instance] = appList
 	}
 
 	return items
+}
+
+func truncateQueue(queue []any, length int) []any {
+	if len(queue) <= length {
+		return queue
+	}
+
+	return queue[:length]
 }

--- a/pkg/triggers/starrqueue/setup.go
+++ b/pkg/triggers/starrqueue/setup.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/Notifiarr/notifiarr/pkg/triggers/common"
+	"github.com/Notifiarr/notifiarr/pkg/website/clientinfo"
 	"golift.io/cnfg"
 )
 
@@ -71,13 +72,16 @@ func (a *Action) Create() {
 			D:    cnfg.Duration{Duration: stuckDuration},
 		})
 
-		a.cmd.Add(&common.Action{
-			Hide: true,
-			Name: TrigDownloadingItems,
-			Fn:   a.cmd.sendDownloadingQueues,
-			C:    make(chan *common.ActionInput, 1),
-			D:    cnfg.Duration{Duration: finishedDuration},
-		})
+		// Only enable this timer if the user is a patron.
+		if ci := clientinfo.Get(); ci != nil && ci.IsPatron() {
+			a.cmd.Add(&common.Action{
+				Hide: true,
+				Name: TrigDownloadingItems,
+				Fn:   a.cmd.sendDownloadingQueues,
+				C:    make(chan *common.ActionInput, 1),
+				D:    cnfg.Duration{Duration: finishedDuration},
+			})
+		}
 	}
 }
 
@@ -85,6 +89,7 @@ func (a *Action) Create() {
 type listItem struct {
 	Name  string        `json:"name"`
 	Queue []interface{} `json:"queue"`
+	Total int           `json:"total"`
 }
 
 // itemList stores an instance->queue map.


### PR DESCRIPTION
Active queue is always enabled but website throws a 400 for the 1 request the client makes on startup. This disables the active queue timer if the user is not a patron.

This also adds a limit to the number of items sent in the active download payload.