### PR TITLE
Allow resetting ssl cert and key files

### DIFF
--- a/pkg/client/cli.go
+++ b/pkg/client/cli.go
@@ -51,10 +51,11 @@ func (c *Client) forceWriteWithExit(ctx context.Context, fileName string) error 
 }
 
 func (c *Client) resetAdminPassword(ctx context.Context) error {
-	password := configfile.GeneratePassword()
+	c.Config.SSLCrtFile = ""
+	c.Config.SSLKeyFile = ""
 
-	err := c.Config.UIPassword.Set(configfile.DefaultUsername + ":" + password)
-	if err != nil {
+	password := configfile.DefaultUsername + ":" + configfile.GeneratePassword()
+	if err := c.Config.UIPassword.Set(password); err != nil {
 		return fmt.Errorf("setting password failed: %w", err)
 	}
 

--- a/pkg/client/handlers_gui.go
+++ b/pkg/client/handlers_gui.go
@@ -704,6 +704,8 @@ func (c *Client) mergeAndValidateNewConfig(config *configfile.Config, request *h
 		config.Apps.Tautulli = nil
 	}
 
+	config.SSLCrtFile = ""
+	config.SSLKeyFile = ""
 	config.Plex = nil
 	config.WatchFiles = nil
 	config.Commands = nil
@@ -711,7 +713,7 @@ func (c *Client) mergeAndValidateNewConfig(config *configfile.Config, request *h
 	config.Snapshot.Plugins.MySQL = nil
 
 	// for k, v := range request.PostForm {
-	// 	c.Debugf("Config Post: %s = %+v", k, v)
+	// 	c.Errorf("Config Post: %s = %+v", k, v)
 	// }
 
 	// Decode the POST'd data directly into the mostly-empty config struct.


### PR DESCRIPTION
- Makes `--reset` clean SSL cert and key files.
- Fixes bug preventing removing ssl cert and key in UI.
- Closes #579