### PR TITLE
header support for http services checks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	golift.io/nzbget v0.1.5
 	golift.io/qbit v0.0.0-20240203190039-8f98b32d1e66
 	golift.io/rotatorr v0.0.0-20230911015553-cd2abbd726c7
-	golift.io/starr v1.0.1-0.20240301211050-ac9980369d44
+	golift.io/starr v1.0.1-0.20240302083150-1d7b409c3993
 	golift.io/version v0.0.2
 	golift.io/xtractr v0.2.2
 	modernc.org/sqlite v1.29.2

--- a/go.sum
+++ b/go.sum
@@ -450,8 +450,8 @@ golift.io/qbit v0.0.0-20240203190039-8f98b32d1e66 h1:ipkWG/7cwFrExfQuSuiFAmQjq+j
 golift.io/qbit v0.0.0-20240203190039-8f98b32d1e66/go.mod h1:xdt9wiIDIfIyj6jM93JjAd9Lp5TN9G350E4il0uJyEM=
 golift.io/rotatorr v0.0.0-20230911015553-cd2abbd726c7 h1:8reg8mRdLxCz168FaGPf/kVxmDRDc92/Dhub54trdOc=
 golift.io/rotatorr v0.0.0-20230911015553-cd2abbd726c7/go.mod h1:59bC4ue06MetIY4iiHu3PCqVbzW0leGoCONZhH8dPZ8=
-golift.io/starr v1.0.1-0.20240301211050-ac9980369d44 h1:JOBAEHN8U1mP4OuEVZBsZaVUVj8encTzv2Y89shas7Y=
-golift.io/starr v1.0.1-0.20240301211050-ac9980369d44/go.mod h1:6q8rX7Gg9aam0PWUCL4acTrXvse4nB9Z4ZA9sepCFoo=
+golift.io/starr v1.0.1-0.20240302083150-1d7b409c3993 h1:U0HhxaCPSxmwq6dv12TmMVMyGIDPO4kUmxrBOM1yx3o=
+golift.io/starr v1.0.1-0.20240302083150-1d7b409c3993/go.mod h1:6q8rX7Gg9aam0PWUCL4acTrXvse4nB9Z4ZA9sepCFoo=
 golift.io/version v0.0.2 h1:i0gXRuSDHKs4O0sVDUg4+vNIuOxYoXhaxspftu2FRTE=
 golift.io/version v0.0.2/go.mod h1:76aHNz8/Pm7CbuxIsDi97jABL5Zui3f2uZxDm4vB6hU=
 golift.io/xtractr v0.2.2 h1:MvujxeuX629d1rQs2VJbbcvYMvMmN5SzIkEflU5ryOc=

--- a/pkg/bindata/templates/services.html
+++ b/pkg/bindata/templates/services.html
@@ -20,7 +20,10 @@
                                     <p>The HTTP check type allows you to monitor a URL and expect a specific status code in response.
                                         The expect value should be a a valid HTTP response code like <code>200</code> or <code>400</code>.
                                         Providing an invalid code will default to 200. The check value must be a valid url beginning with
-                                        <code>http://</code> or <code>https://</code>.
+                                        <code>http://</code> or <code>https://</code>.<br>
+                                    </p><p>
+                                        HTTP request headers may be added by appending them to the url after a pipe <code>|</code>.
+                                        Example: <code>https://my.site|Host:another.site|X-Api-Key:secret-value</code>
                                     </p>
                                     <h3>TCP Port Check Type</h3>
                                     <p>The TCP Port check type allows you to monitor a TCP port's connectivity.

--- a/pkg/client/html_templates.go
+++ b/pkg/client/html_templates.go
@@ -198,6 +198,8 @@ type option struct {
 func intervaloptions(current cnfg.Duration) []*option { //nolint:funlen
 	times := []time.Duration{
 		-1 * time.Second, // Disable Service Checks
+		10 * time.Second,
+		15 * time.Second,
 		30 * time.Second,
 		45 * time.Second,
 		1 * time.Minute,

--- a/pkg/services/apps.go
+++ b/pkg/services/apps.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	starrV3StatusURI = "/api/v3/system/status|X-API-Key="
-	starrV1StatusURI = "/api/v1/system/status|X-API-Key="
+	starrV3StatusURI = "/api/v3/system/status|X-API-Key:"
+	starrV1StatusURI = "/api/v1/system/status|X-API-Key:"
 )
 
 // collectApps turns app configs into service checks if they have a name.
@@ -365,7 +365,7 @@ func (c *Config) collectPlexApp(svcs []*Service) []*Service {
 	svcs = append(svcs, &Service{
 		Name:     "Plex Server",
 		Type:     CheckHTTP,
-		Value:    app.URL + "|X-Plex-Token=" + app.Token,
+		Value:    app.URL + "|X-Plex-Token:" + app.Token,
 		Expect:   "200",
 		Timeout:  app.Timeout,
 		Interval: interval,

--- a/pkg/services/apps.go
+++ b/pkg/services/apps.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	starrV3StatusURI = "/api/v3/system/status?apikey="
-	starrV1StatusURI = "/api/v1/system/status?apikey="
+	starrV3StatusURI = "/api/v3/system/status|X-API-Key="
+	starrV1StatusURI = "/api/v1/system/status|X-API-Key="
 )
 
 // collectApps turns app configs into service checks if they have a name.
@@ -365,7 +365,7 @@ func (c *Config) collectPlexApp(svcs []*Service) []*Service {
 	svcs = append(svcs, &Service{
 		Name:     "Plex Server",
 		Type:     CheckHTTP,
-		Value:    app.URL + "?X-Plex-Token=" + app.Token,
+		Value:    app.URL + "|X-Plex-Token=" + app.Token,
 		Expect:   "200",
 		Timeout:  app.Timeout,
 		Interval: interval,

--- a/pkg/services/checks.go
+++ b/pkg/services/checks.go
@@ -164,6 +164,7 @@ func (s *Service) checkHTTPReq(ctx context.Context) (*http.Client, *http.Request
 		// s.Value: http://url.com|header=value|another-header=val
 		if sv := strings.SplitN(val, ":", 2); len(sv) == 2 { //nolint:gomnd
 			req.Header.Add(sv[0], sv[1])
+
 			if strings.EqualFold(sv[0], "host") {
 				req.Host = sv[1] // https://github.com/golang/go/issues/29865
 			}
@@ -171,7 +172,7 @@ func (s *Service) checkHTTPReq(ctx context.Context) (*http.Client, *http.Request
 	}
 
 	return &http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
 		Timeout: s.Timeout.Duration, Transport: &http.Transport{

--- a/pkg/services/checks.go
+++ b/pkg/services/checks.go
@@ -150,6 +150,36 @@ func (s *Service) update(res *result) bool {
 
 const maxBody = 150
 
+// checkHTTPReq builds the client and request for the http service check.
+func (s *Service) checkHTTPReq(ctx context.Context) (*http.Client, *http.Request, error) {
+	// Allow adding headers by apending them after a pipe symbol.
+	splitVal := strings.Split(s.Value, "|")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, splitVal[0], nil)
+	if err != nil {
+		return nil, nil, err //nolint:wrapcheck // handled by caller
+	}
+
+	for _, val := range splitVal[1:] {
+		// s.Value: http://url.com|header=value|another-header=val
+		if sv := strings.SplitN(val, ":", 2); len(sv) == 2 { //nolint:gomnd
+			req.Header.Add(sv[0], sv[1])
+			if strings.EqualFold(sv[0], "host") {
+				req.Host = sv[1] // https://github.com/golang/go/issues/29865
+			}
+		}
+	}
+
+	return &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Timeout: s.Timeout.Duration, Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: !s.validSSL}, //nolint:gosec
+		},
+	}, req, nil
+}
+
 func (s *Service) checkHTTP(ctx context.Context) *result {
 	res := &result{
 		state:  StateUnknown,
@@ -159,25 +189,13 @@ func (s *Service) checkHTTP(ctx context.Context) *result {
 	ctx, cancel := context.WithTimeout(ctx, s.Timeout.Duration)
 	defer cancel()
 
-	// Allow adding headers by apending them after a pipe symbol.
-	splitVal := strings.Split(s.Value, "|")
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, splitVal[0], nil)
+	client, req, err := s.checkHTTPReq(ctx)
 	if err != nil {
 		res.output = "creating request: " + RemoveSecrets(s.Value, err.Error())
 		return res
 	}
 
-	for _, val := range splitVal[1:] {
-		// s.Value: http://url.com|header=value|another-header=val
-		if sv := strings.SplitN(val, "=", 2); len(sv) == 2 { //nolint:gomnd
-			req.Header.Add(sv[0], sv[1])
-		}
-	}
-
-	resp, err := (&http.Client{Timeout: s.Timeout.Duration, Transport: &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: !s.validSSL}, //nolint:gosec
-	}}).Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		res.output = "making request: " + RemoveSecrets(s.Value, err.Error())
 		return res

--- a/pkg/triggers/plexcron/sessions.go
+++ b/pkg/triggers/plexcron/sessions.go
@@ -2,6 +2,7 @@ package plexcron
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -40,9 +41,17 @@ func (c *cmd) getSessions(ctx context.Context, allowedAge time.Duration) (*plex.
 		return item.Data.(*plex.Sessions), nil //nolint:forcetypeassert
 	}
 
+	deadline, _ := ctx.Deadline()
+	start := time.Now()
+	timeout := deadline.Sub(start)
 	sessions, err := c.Plex.GetSessionsWithContext(ctx)
 
 	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return &plex.Sessions{Name: c.Plex.Server.Name()}, fmt.Errorf("plex sessions timed out after %s: %w", timeout, err)
+	case errors.Is(err, context.Canceled):
+		return &plex.Sessions{Name: c.Plex.Server.Name()},
+			fmt.Errorf("plex sessions cancelled after %s: %w", time.Since(start), err)
 	case err != nil:
 		return &plex.Sessions{Name: c.Plex.Server.Name()}, fmt.Errorf("plex sessions: %w", err)
 	case item != nil && item.Data != nil:


### PR DESCRIPTION
This adds the ability to add headers to http service checks. That change allows hiding the Plex token from errors.

- Checks some boxes on #601 
