### PR TITLE
Add Plex name to service checks, and service check tags.

### DIFF
--- a/pkg/services/apps.go
+++ b/pkg/services/apps.go
@@ -7,6 +7,9 @@ import (
 	"golift.io/cnfg"
 )
 
+// This name is hard coded as the service name for Plex.
+const PlexServerName = "Plex Server"
+
 const (
 	starrV3StatusURI = "/api/v3/system/status|X-API-Key:"
 	starrV1StatusURI = "/api/v1/system/status|X-API-Key:"
@@ -363,14 +366,13 @@ func (c *Config) collectPlexApp(svcs []*Service) []*Service {
 	}
 
 	svcs = append(svcs, &Service{
-		Name:     "Plex Server",
+		Name:     PlexServerName,
 		Type:     CheckHTTP,
 		Value:    app.URL + "|X-Plex-Token:" + app.Token,
 		Expect:   "200",
 		Timeout:  app.Timeout,
 		Interval: interval,
 		validSSL: app.ValidSSL,
-		Tags:     map[string]any{"name": app.ExtraConfig.Name},
 	})
 
 	return svcs

--- a/pkg/services/apps.go
+++ b/pkg/services/apps.go
@@ -370,6 +370,7 @@ func (c *Config) collectPlexApp(svcs []*Service) []*Service {
 		Timeout:  app.Timeout,
 		Interval: interval,
 		validSSL: app.ValidSSL,
+		Tags:     map[string]any{"name": app.ExtraConfig.Name},
 	})
 
 	return svcs

--- a/pkg/services/checks.go
+++ b/pkg/services/checks.go
@@ -92,8 +92,9 @@ func (s *Service) CheckOnly(ctx context.Context) *CheckResult {
 	res := s.checkNow(ctx)
 
 	return &CheckResult{
-		Output: res.output,
-		State:  res.state,
+		Output:   res.output,
+		State:    res.state,
+		Metadata: s.Tags,
 	}
 }
 

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -85,27 +85,29 @@ type Results struct {
 
 // CheckResult represents the status of a service.
 type CheckResult struct {
-	Name        string        `json:"name"`   // "Radarr"
-	State       CheckState    `json:"state"`  // 0 = OK, 1 = Warn, 2 = Crit, 3 = Unknown
-	Output      string        `json:"output"` // metadata message
-	Type        CheckType     `json:"type"`   // http, tcp, ping
-	Time        time.Time     `json:"time"`   // when it was checked, rounded to Microseconds
-	Since       time.Time     `json:"since"`  // how long it has been in this state, rounded to Microseconds
-	Interval    float64       `json:"interval"`
-	Check       string        `json:"-"`
-	Expect      string        `json:"-"`
-	IntervalDur time.Duration `json:"-"`
+	Name        string         `json:"name"`     // "Radarr"
+	State       CheckState     `json:"state"`    // 0 = OK, 1 = Warn, 2 = Crit, 3 = Unknown
+	Output      string         `json:"output"`   // metadata message
+	Type        CheckType      `json:"type"`     // http, tcp, ping
+	Time        time.Time      `json:"time"`     // when it was checked, rounded to Microseconds
+	Since       time.Time      `json:"since"`    // how long it has been in this state, rounded to Microseconds
+	Interval    float64        `json:"interval"` // interval in seconds
+	Metadata    map[string]any `json:"metadata"` // arbitrary info about the service or result.
+	Check       string         `json:"-"`
+	Expect      string         `json:"-"`
+	IntervalDur time.Duration  `json:"-"`
 }
 
 // Service is a thing we check and report results for.
 type Service struct {
-	Name     string        `toml:"name" xml:"name" json:"name"`             // Radarr
-	Type     CheckType     `toml:"type" xml:"type" json:"type"`             // http
-	Value    string        `toml:"check" xml:"check" json:"value"`          // http://some.url
-	Expect   string        `toml:"expect" xml:"expect" json:"expect"`       // 200
-	Timeout  cnfg.Duration `toml:"timeout" xml:"timeout" json:"timeout"`    // 10s
-	Interval cnfg.Duration `toml:"interval" xml:"interval" json:"interval"` // 1m
-	validSSL bool          // can be set for https checks.
+	Name     string         `toml:"name" xml:"name" json:"name"`             // Radarr
+	Type     CheckType      `toml:"type" xml:"type" json:"type"`             // http
+	Value    string         `toml:"check" xml:"check" json:"value"`          // http://some.url
+	Expect   string         `toml:"expect" xml:"expect" json:"expect"`       // 200
+	Timeout  cnfg.Duration  `toml:"timeout" xml:"timeout" json:"timeout"`    // 10s
+	Interval cnfg.Duration  `toml:"interval" xml:"interval" json:"interval"` // 1m
+	Tags     map[string]any `toml:"tags" xml:"tags" json:"tags"`             // copied to Metadata.
+	validSSL bool           // can be set for https checks.
 	svc      service
 }
 

--- a/pkg/services/interface.go
+++ b/pkg/services/interface.go
@@ -100,6 +100,7 @@ func (s *Service) copyResults() *CheckResult {
 		Check:       s.Value,
 		Expect:      s.Expect,
 		IntervalDur: s.Interval.Duration,
+		Metadata:    s.Tags,
 	}
 }
 


### PR DESCRIPTION
This adds tags to service checks that are passed to the website as metadata. The first tag is the Plex server name. Later we'll add more tag metadata.

![x](https://cdn.discordapp.com/attachments/779473615065448449/1229267530548252752/Screen_Shot_2024-04-14_at_8.10.14_PM.png?ex=662f0f99&is=661c9a99&hm=047c31841df982d81905e9251b8ee99c0a0f78fc768a19eff7ab9f809874b9bf&)

- Closes #698 