### PR TITLE
make http service checks go critical on errors

### DIFF
--- a/pkg/services/checks.go
+++ b/pkg/services/checks.go
@@ -197,6 +197,9 @@ func (s *Service) checkHTTP(ctx context.Context) *result {
 		return res
 	}
 
+	// If there is an error at this point it's a bad request.
+	res.state = StateCritical
+
 	resp, err := client.Do(req)
 	if err != nil {
 		res.output = "making request: " + RemoveSecrets(s.Value, err.Error())


### PR DESCRIPTION
HTTP service checks start out unknown, then get set to OK if we get a valid status code. They get set to critical if we get an invalid status code. They never get set to critical if the request fails. This contribution changes that behavior so a failed request will now make the service critical.

- Closes #697