### PR TITLE
add fstype and opts to disk snapshots

### DIFF
--- a/pkg/bindata/templates/system.html
+++ b/pkg/bindata/templates/system.html
@@ -236,10 +236,12 @@
                                                 <td style="display:none;">{{$v.Device}}</td>
                                                 <td>
                                                     <div class="row">
-                                                    <div class="col-lg-3 col-md-3 col-sm-6 col-xs-12">{{$v.Device}}</div>
-                                                    <div class="col-lg-3 col-md-3 col-sm-6 col-xs-12">Total: {{megabyte $v.Total}}</div>
-                                                    <div class="col-lg-3 col-md-3 col-sm-6 col-xs-12">Free: {{megabyte $v.Free}}</div>
-                                                    <div class="col-lg-3 col-md-3 col-sm-6 col-xs-12">Used: {{megabyte $v.Used}}</div>
+                                                    <div class="col-lg-2 col-md-4 col-sm-4 col-xs-12">{{$v.Device}}</div>
+                                                    <div class="col-lg-2 col-md-4 col-sm-4 col-xs-12">Total: {{megabyte $v.Total}}</div>
+                                                    <div class="col-lg-2 col-md-4 col-sm-4 col-xs-12">Free: {{megabyte $v.Free}}</div>
+                                                    <div class="col-lg-2 col-md-4 col-sm-4 col-xs-12">Used: {{megabyte $v.Used}}</div>
+                                                    <div class="col-lg-1 col-md-3 col-sm-4 col-xs-12">FS: {{$v.FSType}}{{if $v.ReadOnly}} <span title="read only">(ro)</span>{{end}}</div>
+                                                    {{if $.ClientInfo.User.DevAllowed}}<div class="col-lg-3 col-md-5 col-sm-12 col-xs-12">{{$v.Opts}}</div>{{end}}
                                                     </div>
                                                 </td>
                                             </tr>

--- a/pkg/snapshot/diskusage.go
+++ b/pkg/snapshot/diskusage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -46,10 +47,13 @@ func (s *Snapshot) getDisksUsage(ctx context.Context, run bool, allDrives bool) 
 		}
 
 		s.DiskUsage[partitions[idx].Device] = &Partition{
-			Device: partitions[idx].Mountpoint,
-			Total:  usage.Total,
-			Free:   usage.Free,
-			Used:   usage.Used,
+			Device:   partitions[idx].Mountpoint,
+			Total:    usage.Total,
+			Free:     usage.Free,
+			Used:     usage.Used,
+			FSType:   usage.Fstype,
+			ReadOnly: slices.Contains(partitions[idx].Opts, "ro"),
+			Opts:     partitions[idx].Opts,
 		}
 	}
 
@@ -119,6 +123,11 @@ func (s *Snapshot) getZFSPoolData(ctx context.Context, pools []string) error {
 		return nil
 	}
 
+	// # zpool list -pH
+	// NAME   SIZE          ALLOC         FREE          CKPOINT EXPANDSZ FRAG CAP DEDUP HEALTH  ALTROOT
+	// data   3985729650688 2223640698880 1762088951808 -       -        10   55  1.00  ONLINE  -
+	// data2  996432412672  98463039488   897969373184  -       -        8    9   1.00  ONLINE  -
+	// data3  996432412672  44307656704   952124755968  -       -        4    4   1.00  ONLINE  -
 	cmd, stdout, waitg, err := readyCommand(ctx, false, "zpool", "list", "-pH")
 	if err != nil {
 		return err
@@ -132,7 +141,7 @@ func (s *Snapshot) getZFSPoolData(ctx context.Context, pools []string) error {
 
 			for _, pool := range pools {
 				if len(fields) > 3 && strings.EqualFold(fields[0], pool) {
-					s.ZFSPool[pool] = &Partition{Device: fields[4]}
+					s.ZFSPool[pool] = &Partition{Device: fields[4], FSType: "zfs", Opts: []string{fields[9]}}
 					s.ZFSPool[pool].Total, _ = strconv.ParseUint(fields[1], mnd.Base10, mnd.Bits64)
 					s.ZFSPool[pool].Free, _ = strconv.ParseUint(fields[3], mnd.Base10, mnd.Bits64)
 				}

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -108,10 +108,13 @@ type RaidData struct {
 
 // Partition is used for ZFS pools as well as normal Disk arrays.
 type Partition struct {
-	Device string `json:"name"`
-	Total  uint64 `json:"total"`
-	Free   uint64 `json:"free"`
-	Used   uint64 `json:"used"`
+	Device   string   `json:"name"`
+	Total    uint64   `json:"total"`
+	Free     uint64   `json:"free"`
+	Used     uint64   `json:"used"`
+	FSType   string   `json:"fsType,omitempty"`
+	ReadOnly bool     `json:"readOnly,omitempty"`
+	Opts     []string `json:"opts,omitempty"`
 }
 
 // Validate makes sure the snapshot configuration is valid.


### PR DESCRIPTION
Adds more data per disk for snapshots. Hopefully we can create filters on the site for users to ignore things like read only disks, or specific file system types.