### PR TITLE
Filepath, durafmt and lint

### DIFF
--- a/.github/workflows/codetests.yml
+++ b/.github/workflows/codetests.yml
@@ -50,7 +50,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: 'v1.57'
+          version: v1.59
 
   golangci-linux:
     # description: "Runs golangci-lint on linux against linux and windows."
@@ -71,7 +71,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: 'v1.57'
+          version: v1.59
 
   homebrew-test:
     # description: "Installs dependencies on macOS and runs `make install` to mimic a homebrew install."

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,14 +20,9 @@ linters:
     - nlreturn
     - nonamedreturns
     - varnamelen
-    - godot
+    - godot # does not work with annotations.
     - perfsprint
-    # unneeded (broken because of generics)
-    - rowserrcheck
-    - wastedassign
-    - sqlclosecheck
-    #- revive # TODO: fix this one.
-    - musttag # broken in 1.52.
+    - musttag # broken in 1.59.
     - depguard
     - tagalign
 run:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,16 +11,8 @@ linters:
   enable-all: true
   disable:
   # deprecated
-    - maligned
-    - scopelint
-    - interfacer
-    - golint
-    - exhaustivestruct
-    - nosnakecase
-    - structcheck
-    - deadcode
-    - varcheck
-    - ifshort
+    - gomnd
+    - execinquery
     # unused
     - exhaustruct
     - exhaustive

--- a/pkg/apps/api.go
+++ b/pkg/apps/api.go
@@ -116,7 +116,7 @@ func (a *Apps) handleAPI(app starr.App, api APIHandler) http.HandlerFunc { //nol
 // CheckAPIKey drops a 403 if the API key doesn't match, otherwise run next handler.
 func (a *Apps) CheckAPIKey(next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) { //nolint:varnamelen
-		if _, ok := a.keys[r.Header.Get("X-API-Key")]; !ok {
+		if _, ok := a.keys[r.Header.Get("X-Api-Key")]; !ok {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}

--- a/pkg/apps/apppkg/plex/sessions.go
+++ b/pkg/apps/apppkg/plex/sessions.go
@@ -137,7 +137,7 @@ func GetMediaTranscode(mediaList []*Media) []string {
 			if stream.Decision == "transcode" {
 				videoMsg += fmt.Sprintf(" → %s (%s)", media.VideoResolution, strings.ToUpper(stream.Codec))
 			}
-		} else if stream.StreamType == 2 { //nolint:gomnd
+		} else if stream.StreamType == 2 { //nolint:mnd
 			audioMsg = stream.DisplayTitle
 			if stream.Decision == "transcode" {
 				audioMsg += " → " + strings.ToUpper(stream.Codec)

--- a/pkg/apps/apppkg/sabnzbd/sabnzbd.go
+++ b/pkg/apps/apppkg/sabnzbd/sabnzbd.go
@@ -262,7 +262,7 @@ func (s *SabNZBDate) UnmarshalJSON(b []byte) (err error) {
 	s.String = strings.Trim(string(b), `"`)
 
 	if s.String == "unknown" {
-		s.Time = time.Now().Add(time.Hour * 24 * 366) //nolint:gomnd
+		s.Time = time.Now().Add(time.Hour * 24 * 366) //nolint:mnd
 		return nil
 	}
 
@@ -284,7 +284,7 @@ func (s *SabNZBSize) UnmarshalJSON(b []byte) (err error) {
 		return fmt.Errorf("could not convert to number: %s: %w", split[0], err)
 	}
 
-	if len(split) < 2 { //nolint:gomnd
+	if len(split) < 2 { //nolint:mnd
 		s.Bytes = int64(bytes)
 		return nil
 	}

--- a/pkg/apps/setup.go
+++ b/pkg/apps/setup.go
@@ -140,7 +140,7 @@ func (a *Apps) Setup() error { //nolint:cyclop
 func (a *Apps) InitHandlers() {
 	a.keys = make(map[string]struct{})
 	for _, key := range append(a.ExKeys, a.APIKey) {
-		if len(key) > 3 { //nolint:gomnd
+		if len(key) > 3 { //nolint:mnd
 			a.keys[key] = struct{}{}
 		}
 	}

--- a/pkg/client/client_windows.go
+++ b/pkg/client/client_windows.go
@@ -25,7 +25,7 @@ func (c *Client) upgradeWindows(ctx context.Context, update *update.Update) {
 	yes, _ := ui.Question(mnd.Title, "An Update is available! Upgrade Now?\n\n"+
 		"Your Version: "+version.Version+"-"+version.Revision+"\n"+
 		"New Version: "+update.Current+"\n"+
-		"Date: "+update.RelDate.Format("Jan 2, 2006")+mnd.DurationAgo(update.RelDate), false)
+		"Date: "+update.RelDate.Format("Jan 2, 2006")+mnd.DurationAge(update.RelDate), false)
 	if yes {
 		if err := c.updateNow(ctx, update, "user requested"); err != nil {
 			c.Errorf("Update Failed: %v", err)
@@ -79,7 +79,7 @@ func (c *Client) startAutoUpdater(ctx context.Context, dur time.Duration) {
 	}
 
 	time.Sleep(WaitTime)
-	c.Print(pfx+"Auto-updater started. Check interval:", durafmt.Parse(dur.Round(time.Second)).LimitFirstN(3))
+	c.Print(pfx+"Auto-updater started. Check interval:", durafmt.Parse(dur).LimitFirstN(3)) //nolint:mnd
 
 	// Check for update on startup.
 	if err := c.checkAndUpdate(ctx, "startup check"); err != nil {

--- a/pkg/client/client_windows.go
+++ b/pkg/client/client_windows.go
@@ -79,7 +79,8 @@ func (c *Client) startAutoUpdater(ctx context.Context, dur time.Duration) {
 	}
 
 	time.Sleep(WaitTime)
-	c.Print(pfx+"Auto-updater started. Check interval:", durafmt.Parse(dur).String())
+	c.Print(pfx+"Auto-updater started. Check interval:",
+		durafmt.Parse(dur).LimitFirstN(3).Format(mnd.DurafmtUnits)) //nolint:mnd
 
 	// Check for update on startup.
 	if err := c.checkAndUpdate(ctx, "startup check"); err != nil {

--- a/pkg/client/client_windows.go
+++ b/pkg/client/client_windows.go
@@ -79,8 +79,7 @@ func (c *Client) startAutoUpdater(ctx context.Context, dur time.Duration) {
 	}
 
 	time.Sleep(WaitTime)
-	c.Print(pfx+"Auto-updater started. Check interval:",
-		durafmt.Parse(dur).LimitFirstN(3).Format(mnd.DurafmtUnits)) //nolint:mnd
+	c.Print(pfx+"Auto-updater started. Check interval:", durafmt.Parse(dur.Round(time.Second)).LimitFirstN(3))
 
 	// Check for update on startup.
 	if err := c.checkAndUpdate(ctx, "startup check"); err != nil {

--- a/pkg/client/handlers.go
+++ b/pkg/client/handlers.go
@@ -180,7 +180,7 @@ func (c *Client) stripSecrets(next http.Handler) http.Handler {
 		}
 
 		// save into a request header for the logger.
-		r.Header.Set("X-Redacted-URI", uri)
+		r.Header.Set("X-Redacted-Uri", uri)
 		next.ServeHTTP(w, r)
 	})
 }
@@ -188,7 +188,7 @@ func (c *Client) stripSecrets(next http.Handler) http.Handler {
 func (c *Client) addUsernameHeader(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(response http.ResponseWriter, req *http.Request) {
 		if username, _ := c.getUserName(req); username != "" {
-			req.Header.Set("X-NotiClient-Username", username)
+			req.Header.Set("X-Noticlient-Username", username)
 		}
 
 		next.ServeHTTP(response, req)

--- a/pkg/client/handlers_gui.go
+++ b/pkg/client/handlers_gui.go
@@ -775,7 +775,7 @@ func (c *Client) validateNewServiceConfig(config *configfile.Config) error {
 }
 
 func (c *Client) indexPage(ctx context.Context, response http.ResponseWriter, request *http.Request, msg string) {
-	response.Header().Add("content-type", "text/html")
+	response.Header().Add("Content-Type", "text/html")
 
 	user, _ := c.getUserName(request)
 	if request.Method != http.MethodGet || (user == "" && c.webauth) {
@@ -856,7 +856,7 @@ func (c *Client) handleInternalAsset(response http.ResponseWriter, request *http
 	}
 
 	mime := mime.TypeByExtension(path.Ext(request.URL.Path))
-	response.Header().Set("content-type", mime)
+	response.Header().Set("Content-Type", mime)
 
 	if _, err = response.Write(data); err != nil {
 		c.Errorf("Writing HTTP Response: %v", err)

--- a/pkg/client/handlers_websocket.go
+++ b/pkg/client/handlers_websocket.go
@@ -86,7 +86,7 @@ func (c *Client) handleWebSockets(response http.ResponseWriter, request *http.Re
 func (c *Client) webSocketWriter(socket *websocket.Conn, fileTail *tail.Tail) {
 	var (
 		lastError  = ""
-		pingTicker = time.NewTicker(29 * time.Second) //nolint:gomnd
+		pingTicker = time.NewTicker(29 * time.Second) //nolint:mnd
 		writeWait  = 10 * time.Second
 	)
 

--- a/pkg/client/html_templates.go
+++ b/pkg/client/html_templates.go
@@ -324,9 +324,8 @@ func since(t time.Time) string {
 	if t.IsZero() {
 		return "N/A"
 	}
-
-	return strings.ReplaceAll(durafmt.Parse(time.Since(t).Round(time.Second)).
-		LimitFirstN(3).Format(mnd.DurafmtShort), " ", "") //nolint:mnd
+	//nolint:mnd
+	return strings.ReplaceAll(durafmt.Parse(time.Since(t)).LimitFirstN(3).Format(mnd.DurafmtShort), " ", "")
 }
 
 // ParseGUITemplates parses the baked-in templates, and overrides them if a template directory is provided.

--- a/pkg/client/html_templates.go
+++ b/pkg/client/html_templates.go
@@ -326,15 +326,7 @@ func since(t time.Time) string {
 	}
 
 	return strings.ReplaceAll(durafmt.Parse(time.Since(t).Round(time.Second)).
-		LimitFirstN(3). //nolint:mnd
-		Format(durafmt.Units{
-			Year:   durafmt.Unit{Singular: "y", Plural: "y"},
-			Week:   durafmt.Unit{Singular: "w", Plural: "w"},
-			Day:    durafmt.Unit{Singular: "d", Plural: "d"},
-			Hour:   durafmt.Unit{Singular: "h", Plural: "h"},
-			Minute: durafmt.Unit{Singular: "m", Plural: "m"},
-			Second: durafmt.Unit{Singular: "s", Plural: "s"},
-		}), " ", "")
+		LimitFirstN(3).Format(mnd.DurafmtShort), " ", "") //nolint:mnd
 }
 
 // ParseGUITemplates parses the baked-in templates, and overrides them if a template directory is provided.

--- a/pkg/client/html_templates.go
+++ b/pkg/client/html_templates.go
@@ -154,7 +154,7 @@ func (c *Client) getFuncMap() template.FuncMap { //nolint:funlen,cyclop
 		"locked":   func(env string) bool { return c.Flags.ConfigFile == "" || os.Getenv(env) != "" },
 		"contains": strings.Contains,
 		"since":    since,
-		"percent":  func(i, j float64) int64 { return int64(i / j * 100) }, //nolint:gomnd
+		"percent":  func(i, j float64) int64 { return int64(i / j * 100) }, //nolint:mnd
 		"min": func(s string) string {
 			for _, pieces := range strings.Split(s, ",") {
 				if split := strings.Split(pieces, ":"); len(split) >= 2 && split[0] == "count" {
@@ -326,7 +326,7 @@ func since(t time.Time) string {
 	}
 
 	return strings.ReplaceAll(durafmt.Parse(time.Since(t).Round(time.Second)).
-		LimitFirstN(3). //nolint:gomnd
+		LimitFirstN(3). //nolint:mnd
 		Format(durafmt.Units{
 			Year:   durafmt.Unit{Singular: "y", Plural: "y"},
 			Week:   durafmt.Unit{Singular: "w", Plural: "w"},
@@ -484,7 +484,7 @@ func environ() map[string]string {
 	out := make(map[string]string)
 
 	for _, v := range os.Environ() {
-		if s := strings.SplitN(v, "=", 2); len(s) == 2 && s[0] != "" { //nolint:gomnd
+		if s := strings.SplitN(v, "=", 2); len(s) == 2 && s[0] != "" { //nolint:mnd
 			out[s[0]] = s[1]
 		}
 	}
@@ -612,7 +612,7 @@ func readFileTail(fileHandle *os.File, fileSize int64, count, skip int) ([]byte,
 
 	// This is a magic number.
 	// We assume 150 characters per line to optimize the buffer.
-	output.Grow(count * 150) //nolint:gomnd
+	output.Grow(count * 150) //nolint:mnd
 
 	for {
 		location-- // read 1 byte
@@ -624,7 +624,7 @@ func readFileTail(fileHandle *os.File, fileSize int64, count, skip int) ([]byte,
 			return nil, fmt.Errorf("reading open file: %w", err)
 		}
 
-		if location != -1 && (char[0] == 10) { //nolint:gomnd
+		if location != -1 && (char[0] == 10) { //nolint:mnd
 			found++ // we found a line
 		}
 
@@ -654,7 +654,7 @@ func readFileHead(fileHandle *os.File, fileSize int64, count, skip int) ([]byte,
 
 	// This is a magic number.
 	// We assume 150 characters per line to optimize the buffer.
-	output.Grow(count * 150) //nolint:gomnd
+	output.Grow(count * 150) //nolint:mnd
 
 	for ; ; location++ {
 		if _, err := fileHandle.Seek(location, io.SeekStart); err != nil {
@@ -665,7 +665,7 @@ func readFileHead(fileHandle *os.File, fileSize int64, count, skip int) ([]byte,
 			return nil, fmt.Errorf("reading open file: %w", err)
 		}
 
-		if char[0] == 10 { //nolint:gomnd
+		if char[0] == 10 { //nolint:mnd
 			found++ // we have a line
 
 			if found <= skip {

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -284,7 +284,7 @@ func (c *Client) Exit(ctx context.Context, cancel context.CancelFunc) error {
 		defer c.CapturePanic()
 		cancel()
 		//nolint:mnd
-		c.Print(" ❌ Good bye! Uptime:", durafmt.Parse(time.Since(version.Started).Round(time.Second)).LimitFirstN(3))
+		c.Print(" ❌ Good bye! Uptime:", durafmt.Parse(time.Since(version.Started)).LimitFirstN(3).Format(mnd.DurafmtUnits))
 	}()
 
 	c.StartWebServer(ctx)

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -283,7 +283,7 @@ func (c *Client) Exit(ctx context.Context, cancel context.CancelFunc) error {
 	defer func() {
 		defer c.CapturePanic()
 		cancel()
-		//nolint:gomnd
+		//nolint:mnd
 		c.Print(" ❌ Good bye! Uptime:", durafmt.Parse(time.Since(version.Started).Round(time.Second)).LimitFirstN(3))
 	}()
 

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -27,7 +27,6 @@ import (
 	"github.com/Notifiarr/notifiarr/pkg/website"
 	"github.com/Notifiarr/notifiarr/pkg/website/clientinfo"
 	"github.com/gorilla/securecookie"
-	"github.com/hako/durafmt"
 	flag "github.com/spf13/pflag"
 	mulery "golift.io/mulery/client"
 	"golift.io/version"
@@ -283,8 +282,7 @@ func (c *Client) Exit(ctx context.Context, cancel context.CancelFunc) error {
 	defer func() {
 		defer c.CapturePanic()
 		cancel()
-		//nolint:mnd
-		c.Print(" ❌ Good bye! Uptime:", durafmt.Parse(time.Since(version.Started)).LimitFirstN(3).Format(mnd.DurafmtUnits))
+		c.Print(" ❌ Good bye! Exiting" + mnd.DurationAge(version.Started))
 	}()
 
 	c.StartWebServer(ctx)

--- a/pkg/client/tray_commands.go
+++ b/pkg/client/tray_commands.go
@@ -59,7 +59,7 @@ func (c *Client) checkForUpdate(ctx context.Context, unstable bool) {
 	if unstable {
 		c.Print("[user requested] Unstable Update Check")
 
-		data, err = update.CheckUnstable(ctx, mnd.DefaultName, version.Revision)
+		data, err = update.CheckUnstable(ctx, mnd.Title, version.Revision)
 		where = "Unstable website"
 	} else {
 		c.Print("[user requested] GitHub Update Check")
@@ -77,7 +77,7 @@ func (c *Client) checkForUpdate(ctx context.Context, unstable bool) {
 		c.downloadOther(data, unstable)
 	default:
 		_, _ = ui.Info(mnd.Title, "You're up to date! Version: "+data.Current+"\n"+
-			"Updated: "+data.RelDate.Format("Jan 2, 2006")+mnd.DurationAgo(data.RelDate))
+			"Updated: "+data.RelDate.Format("Jan 2, 2006")+mnd.DurationAge(data.RelDate))
 	}
 }
 
@@ -91,7 +91,7 @@ func (c *Client) downloadOther(update *update.Update, unstable bool) {
 	yes, _ := ui.Question(mnd.Title, msg+
 		"Your Version: "+version.Version+"-"+version.Revision+"\n"+
 		"New Version: "+update.Current+"\n"+
-		"Date: "+update.RelDate.Format("Jan 2, 2006")+mnd.DurationAgo(update.RelDate), false)
+		"Date: "+update.RelDate.Format("Jan 2, 2006")+mnd.DurationAge(update.RelDate), false)
 	if yes {
 		_ = ui.OpenURL(update.CurrURL)
 	}

--- a/pkg/client/tunnel.go
+++ b/pkg/client/tunnel.go
@@ -82,7 +82,7 @@ func (c *Client) makeTunnel(ctx context.Context, ci *clientinfo.ClientInfo) {
 	remWs, _ := apachelog.New(`%{X-Forwarded-For}i %{X-User-ID}i env:%{X-User-Environment}i %t "%r" %>s %b ` +
 		`"%{X-Client-ID}i" "%{User-agent}i" %{X-Request-Time}i %{ms}Tms`)
 
-	//nolint:gomnd // just attempting a tiny bit of splay.
+	//nolint:mnd // just attempting a tiny bit of splay.
 	c.tunnel = mulery.NewClient(&mulery.Config{
 		Name:             hostname,
 		ID:               c.Config.HostID,
@@ -103,7 +103,7 @@ func (c *Client) makeTunnel(ctx context.Context, ci *clientinfo.ClientInfo) {
 	})
 }
 
-//nolint:gomnd // arbitrary failover time frames.
+//nolint:mnd // arbitrary failover time frames.
 func (c *Client) roundRobinConfig(ci *clientinfo.ClientInfo) *mulery.RoundRobinConfig {
 	interval := 10 * time.Minute
 	if ci.IsSub() {
@@ -239,7 +239,7 @@ func (c *Client) pingTunnels(response http.ResponseWriter, request *http.Request
 
 	for idx, tunnel := range ci.User.Mulery {
 		wait.Add(1)
-		time.Sleep(70 * time.Millisecond) //nolint:gomnd
+		time.Sleep(70 * time.Millisecond) //nolint:mnd
 
 		go c.pingTunnel(request.Context(), idx, tunnel.Socket, inCh)
 	}

--- a/pkg/configfile/config.go
+++ b/pkg/configfile/config.go
@@ -16,7 +16,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/Notifiarr/notifiarr/pkg/apps"
@@ -31,7 +30,6 @@ import (
 	"github.com/Notifiarr/notifiarr/pkg/website"
 	"github.com/Notifiarr/notifiarr/pkg/website/clientinfo"
 	"github.com/dsnet/compress/bzip2"
-	"github.com/hako/durafmt"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/shirou/gopsutil/v4/host"
 	"golift.io/cnfg"
@@ -251,8 +249,7 @@ func (c *Config) FindAndReturn(ctx context.Context, configFile string, write boo
 
 	if configFile = ""; confFile != "" {
 		configFile, _ = filepath.Abs(confFile)
-		return configFile, "", MsgConfigFound + configFile + ", age: " + durafmt.Parse(time.Since(stat.ModTime())).
-			LimitFirstN(3).Format(mnd.DurafmtUnits) //nolint:mnd
+		return configFile, "", MsgConfigFound + configFile + mnd.DurationAge(stat.ModTime())
 	}
 
 	if defaultConfigFile != "" && write {

--- a/pkg/configfile/password.go
+++ b/pkg/configfile/password.go
@@ -131,9 +131,9 @@ func (p CryptPass) IsCrypted() bool {
 	return strings.HasPrefix(p.Val(), authPassword)
 }
 
-// GeneratePassword uses a word list to create a randmo password of two words and a number.
+// GeneratePassword uses a word list to create a random password of two words and a number.
 //
-//nolint:gosec,gomnd
+//nolint:gosec,mnd
 func GeneratePassword() string {
 	title := cases.Title(language.AmericanEnglish)
 	pieces := make([]string, 4)

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -235,7 +235,7 @@ func (l *Logger) writeMsg(msg string, log *log.Logger, name string, shared bool)
 // writeSplitMsg splits the message in half and attempts to write each half.
 // If the message is still too large, it'll be split again, and the process continues until it works.
 func (l *Logger) writeSplitMsg(msg string, log *log.Logger, name string) {
-	half := len(msg) / 2 //nolint:gomnd // split messages in half, recursively as needed.
+	half := len(msg) / 2 //nolint:mnd // split messages in half, recursively as needed.
 	part1 := msg[:half]
 	part2 := "...continuing: " + msg[half:]
 

--- a/pkg/mnd/functions.go
+++ b/pkg/mnd/functions.go
@@ -1,4 +1,4 @@
-//nolint:gomnd
+//nolint:mnd
 package mnd
 
 import (

--- a/pkg/mnd/functions.go
+++ b/pkg/mnd/functions.go
@@ -49,10 +49,10 @@ func FormatBytes(size interface{}) string { //nolint:cyclop
 	}
 }
 
-// DurationAgo returns an elapsed-time formatted for humans.
+// DurationAge returns an elapsed-time formatted for humans.
 // Print this after a date to show how long ago it was.
-func DurationAgo(when time.Time) string {
-	return " (" + durafmt.Parse(time.Since(when)).Format(DurafmtShort) + " ago)"
+func DurationAge(when time.Time) string {
+	return "; age: " + durafmt.Parse(time.Since(when)).LimitFirstN(3).Format(DurafmtUnits) //nolint:mnd
 }
 
 // PrintVersionInfo returns version information.

--- a/pkg/mnd/functions.go
+++ b/pkg/mnd/functions.go
@@ -52,7 +52,7 @@ func FormatBytes(size interface{}) string { //nolint:cyclop
 // DurationAgo returns an elapsed-time formatted for humans.
 // Print this after a date to show how long ago it was.
 func DurationAgo(when time.Time) string {
-	return " (" + durafmt.Parse(time.Since(when).Round(time.Hour)).String() + " ago)"
+	return " (" + durafmt.Parse(time.Since(when)).Format(DurafmtShort) + " ago)"
 }
 
 // PrintVersionInfo returns version information.

--- a/pkg/mnd/metrics.go
+++ b/pkg/mnd/metrics.go
@@ -77,7 +77,7 @@ func GetKeys(mapName *expvar.Map) map[string]interface{} {
 	return output
 }
 
-//nolint:gomnd
+//nolint:mnd
 func GetSplitKeys(mapName *expvar.Map) map[string]map[string]interface{} {
 	output := make(map[string]map[string]interface{})
 

--- a/pkg/mnd/variables.go
+++ b/pkg/mnd/variables.go
@@ -1,7 +1,7 @@
 package mnd
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"strings"
 
@@ -12,19 +12,23 @@ import (
 //nolint:gochecknoglobals
 var (
 	// IsSynology tells us if this we're running on a Synology.
-	IsSynology bool
-	// IsDocker tells us if this is our Docker container.
-	IsDocker        = os.Getpid() == 1
+	IsSynology = isSynology()
+	// IsDocker tells us if this is a Docker container.
+	IsDocker        = isDocker()
 	IsUnstable      = strings.HasPrefix(version.Branch, "unstable")
 	DurafmtUnits, _ = durafmt.DefaultUnitsCoder.Decode("year,week,day,hour,min,sec,ms:ms,µs:µs")
 	DurafmtShort, _ = durafmt.DefaultUnitsCoder.Decode("y:y,w:w,d:d,h:h,m:m,s:s,ms:ms,µs:µs")
 )
 
 // ErrDisabledInstance is returned when a request for a disabled instance is performed.
-var ErrDisabledInstance = fmt.Errorf("instance is administratively disabled")
+var ErrDisabledInstance = errors.New("instance is administratively disabled")
 
-//nolint:gochecknoinits
-func init() {
+func isSynology() bool {
 	_, err := os.Stat(Synology)
-	IsSynology = err == nil
+	return err == nil
+}
+
+func isDocker() bool {
+	_, err := os.Stat("/.dockerenv")
+	return os.Getpid() == 1 || err == nil
 }

--- a/pkg/mnd/variables.go
+++ b/pkg/mnd/variables.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/hako/durafmt"
 	"golift.io/version"
 )
 
@@ -13,8 +14,9 @@ var (
 	// IsSynology tells us if this we're running on a Synology.
 	IsSynology bool
 	// IsDocker tells us if this is our Docker container.
-	IsDocker   = os.Getpid() == 1
-	IsUnstable = strings.HasPrefix(version.Branch, "unstable")
+	IsDocker        = os.Getpid() == 1
+	IsUnstable      = strings.HasPrefix(version.Branch, "unstable")
+	DurafmtUnits, _ = durafmt.DefaultUnitsCoder.Decode("year,week,day,hour,min,sec,ms:ms,µs:µs")
 )
 
 // ErrDisabledInstance is returned when a request for a disabled instance is performed.

--- a/pkg/mnd/variables.go
+++ b/pkg/mnd/variables.go
@@ -17,6 +17,7 @@ var (
 	IsDocker        = os.Getpid() == 1
 	IsUnstable      = strings.HasPrefix(version.Branch, "unstable")
 	DurafmtUnits, _ = durafmt.DefaultUnitsCoder.Decode("year,week,day,hour,min,sec,ms:ms,µs:µs")
+	DurafmtShort, _ = durafmt.DefaultUnitsCoder.Decode("y:y,w:w,d:d,h:h,m:m,s:s,ms:ms,µs:µs")
 )
 
 // ErrDisabledInstance is returned when a request for a disabled instance is performed.

--- a/pkg/services/check_ping.go
+++ b/pkg/services/check_ping.go
@@ -53,7 +53,7 @@ func (s *Service) fillPingExpect(icmp bool) (err error) {
 	}
 
 	splitStr := strings.Split(s.Expect, ":")
-	if len(splitStr) != 3 { //nolint:gomnd
+	if len(splitStr) != 3 { //nolint:mnd
 		return ErrPingExpect
 	}
 

--- a/pkg/services/check_proc.go
+++ b/pkg/services/check_proc.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/Notifiarr/notifiarr/pkg/mnd"
-	"github.com/hako/durafmt"
 	"github.com/shirou/gopsutil/v4/process"
 )
 
@@ -154,7 +153,7 @@ func (s *Service) getProcessStrings(pids []int32, ages []time.Time) (min, max, a
 	}
 
 	if len(ages) == 1 && !ages[0].IsZero() {
-		age = ", age: " + durafmt.Parse(time.Since(ages[0])).Format(mnd.DurafmtShort)
+		age = mnd.DurationAge(ages[0])
 	}
 
 	for _, activePid := range pids {

--- a/pkg/services/check_proc.go
+++ b/pkg/services/check_proc.go
@@ -154,7 +154,7 @@ func (s *Service) getProcessStrings(pids []int32, ages []time.Time) (min, max, a
 	}
 
 	if len(ages) == 1 && !ages[0].IsZero() {
-		age = fmt.Sprintf(", age: %v", durafmt.ParseShort(time.Since(ages[0]).Round(time.Second)))
+		age = ", age: " + durafmt.Parse(time.Since(ages[0])).Format(mnd.DurafmtShort)
 	}
 
 	for _, activePid := range pids {

--- a/pkg/services/check_proc_pre.go
+++ b/pkg/services/check_proc_pre.go
@@ -85,7 +85,7 @@ func (s *Service) fillExpectCounts(str string) (err error) {
 		}
 	}
 
-	if len(countSplit) > 2 { //nolint:gomnd
+	if len(countSplit) > 2 { //nolint:mnd
 		if s.svc.proc.countMax, err = strconv.Atoi(countSplit[2]); err != nil {
 			return fmt.Errorf("invalid maximum count: %s: %w", countSplit[2], err)
 		}

--- a/pkg/services/checks.go
+++ b/pkg/services/checks.go
@@ -163,7 +163,7 @@ func (s *Service) checkHTTPReq(ctx context.Context) (*http.Client, *http.Request
 
 	for _, val := range splitVal[1:] {
 		// s.Value: http://url.com|header=value|another-header=val
-		if sv := strings.SplitN(val, ":", 2); len(sv) == 2 { //nolint:gomnd
+		if sv := strings.SplitN(val, ":", 2); len(sv) == 2 { //nolint:mnd
 			req.Header.Add(sv[0], sv[1])
 
 			if strings.EqualFold(sv[0], "host") {
@@ -242,7 +242,7 @@ func (s *Service) checkHTTP(ctx context.Context) *result {
 
 // RemoveSecrets removes secret token values in a message parsed from a url.
 func RemoveSecrets(appURL, message string) string {
-	url, err := url.Parse(strings.SplitN(appURL, "|", 2)[0]) //nolint:gomnd
+	url, err := url.Parse(strings.SplitN(appURL, "|", 2)[0]) //nolint:mnd
 	if err != nil {
 		return message
 	}

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -180,7 +180,7 @@ func (c *Config) runServiceChecker() { //nolint:cyclop
 		ticker = time.NewTicker(c.Interval.Duration)
 		defer ticker.Stop()
 
-		second = time.NewTicker(10 * time.Second) //nolint:gomnd
+		second = time.NewTicker(10 * time.Second) //nolint:mnd
 		defer second.Stop()
 
 		c.runChecks(true)

--- a/pkg/snapshot/diskio.go
+++ b/pkg/snapshot/diskio.go
@@ -130,13 +130,13 @@ func (s *Snapshot) scanIOTop(stdout *bufio.Scanner, wg *sync.WaitGroup) {
 		case strings.Contains(text, "illegal option"):
 			return
 			// it's a bad command wrong OS.
-		case len(fields) < 10, fields[0] == "PID": //nolint:gomnd
+		case len(fields) < 10, fields[0] == "PID": //nolint:mnd
 			// PID  PRIO  USER     DISK READ  DISK WRITE  SWAPIN      IO    COMMAND
 			// not enough fields, or header row.
 			continue
 		case fields[0] == "Total":
 			//	Total DISK READ:         0.00 K/s | Total DISK WRITE:         0.00 K/s
-			if nums := regex.FindAllString(text, 2); len(nums) == 2 { //nolint:gomnd
+			if nums := regex.FindAllString(text, 2); len(nums) == 2 { //nolint:mnd
 				s.IOTop.TotalRead, _ = strconv.ParseFloat(nums[0], mnd.Bits64)
 				s.IOTop.TotalWrite, _ = strconv.ParseFloat(nums[1], mnd.Bits64)
 				s.IOTop.TotalRead *= mnd.Kilobyte  // convert to bytes.
@@ -144,13 +144,13 @@ func (s *Snapshot) scanIOTop(stdout *bufio.Scanner, wg *sync.WaitGroup) {
 			}
 		case fields[0] == "Current", fields[0] == "Actual":
 			//	Current DISK READ:       0.00 K/s | Current DISK WRITE:       0.00 K/s
-			if nums := regex.FindAllString(text, 2); len(nums) == 2 { //nolint:gomnd
+			if nums := regex.FindAllString(text, 2); len(nums) == 2 { //nolint:mnd
 				s.IOTop.CurrRead, _ = strconv.ParseFloat(nums[0], mnd.Bits64)
 				s.IOTop.CurrWrite, _ = strconv.ParseFloat(nums[1], mnd.Bits64)
 				s.IOTop.CurrRead *= mnd.Kilobyte  // convert to bytes.
 				s.IOTop.CurrWrite *= mnd.Kilobyte // convert to bytes.
 			}
-		case len(fields) >= 12: //nolint:gomnd
+		case len(fields) >= 12: //nolint:mnd
 			// 780711 be/4 david       0.00 K/s    0.00 K/s  0.00 %  0.00 % pulseaudio --daemonize=no --log-target=journal
 			proc := &IOTopProc{
 				// Pid:   fields[0]

--- a/pkg/snapshot/helpers_windows.go
+++ b/pkg/snapshot/helpers_windows.go
@@ -6,5 +6,5 @@ import (
 )
 
 func sysCallSettings(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: 0x08000000} //nolint:gomnd
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: 0x08000000} //nolint:mnd
 }

--- a/pkg/snapshot/ipmi.go
+++ b/pkg/snapshot/ipmi.go
@@ -1,4 +1,4 @@
-//nolint:gomnd
+//nolint:mnd
 package snapshot
 
 import (

--- a/pkg/snapshot/memory_linux.go
+++ b/pkg/snapshot/memory_linux.go
@@ -22,7 +22,7 @@ func (s *Snapshot) GetMemoryUsage(ctx context.Context) error {
 
 	for scanner.Scan() {
 		switch fields := strings.Fields(scanner.Text()); {
-		case len(fields) < 3: //nolint:gomnd
+		case len(fields) < 3: //nolint:mnd
 			continue
 		case strings.EqualFold(fields[0], "MemTotal:"):
 			s.System.MemTotal, _ = strconv.ParseUint(fields[1], mnd.Base10, mnd.Bits64)

--- a/pkg/snapshot/nvidia.go
+++ b/pkg/snapshot/nvidia.go
@@ -62,7 +62,7 @@ func (s *Snapshot) GetNvidia(ctx context.Context, config *NvidiaConfig) error {
 	} else if cmdPath, err = exec.LookPath(nvidiaSMIname()); err != nil {
 		// do not throw an error if nvidia-smi is missing.
 		// return fmt.Errorf("nvidia-smi missing! %w", err)
-		return nil //nolint:nilerr
+		return nil
 	}
 
 	cmd := exec.CommandContext(ctx, cmdPath, "--format=csv,noheader", "--query-gpu="+

--- a/pkg/snapshot/raid.go
+++ b/pkg/snapshot/raid.go
@@ -128,7 +128,7 @@ func (s *Snapshot) scanMegaCLI(stdout *bufio.Scanner, waitg *sync.WaitGroup) {
 			continue
 		}
 
-		if split := strings.SplitN(strings.TrimSpace(text), ":", 2); len(split) == 2 && current != nil { //nolint:gomnd
+		if split := strings.SplitN(strings.TrimSpace(text), ":", 2); len(split) == 2 && current != nil { //nolint:mnd
 			current.Data[strings.TrimSpace(split[0])] = strings.TrimSpace(split[1])
 		}
 	}

--- a/pkg/snapshot/smartctl.go
+++ b/pkg/snapshot/smartctl.go
@@ -182,7 +182,7 @@ func (s *Snapshot) scanSmartctl(stdout *bufio.Scanner, name string, waitg *sync.
 		case strings.Contains(text, "self-assessment ") ||
 			strings.Contains(text, "SMART Health Status:"):
 			s.DiskHealth[name] = fields[len(fields)-1]
-		case len(fields) < 10: //nolint: gomnd
+		case len(fields) < 10: //nolint:mnd
 			continue
 		case strings.HasPrefix(fields[1], "Airflow_Temp") ||
 			strings.HasPrefix(fields[1], "Temperature_Cel"):

--- a/pkg/snapshot/synology.go
+++ b/pkg/snapshot/synology.go
@@ -58,7 +58,7 @@ func GetSynology() (*Synology, error) { //nolint:cyclop
 		}
 
 		lsplit := strings.Split(line, "=")
-		if len(lsplit) < 2 { //nolint:gomnd
+		if len(lsplit) < 2 { //nolint:mnd
 			continue
 		}
 

--- a/pkg/snapshot/system.go
+++ b/pkg/snapshot/system.go
@@ -106,7 +106,7 @@ func (s *Snapshot) GetProcesses(ctx context.Context, count int) error {
 		_, _ = proc.PercentWithContext(ctx, 0)
 	}
 
-	time.Sleep(4 * time.Second) //nolint:gomnd
+	time.Sleep(4 * time.Second) //nolint:mnd
 
 	for idx, proc := range procs {
 		s.Processes[idx].CPUPercent, _ = proc.PercentWithContext(ctx, 0)

--- a/pkg/triggers/dashboard/lidarr.go
+++ b/pkg/triggers/dashboard/lidarr.go
@@ -91,7 +91,7 @@ func (c *Cmd) getLidarrState(ctx context.Context, instance int, app *apps.Lidarr
 func (c *Cmd) getLidarrHistory(ctx context.Context, app *apps.LidarrConfig) ([]*Sortable, error) {
 	history, err := app.GetHistoryPageContext(ctx, &starr.PageReq{
 		Page:     1,
-		PageSize: showLatest + 20, //nolint:gomnd // grab extra in case some are tracks and not albums.
+		PageSize: showLatest + 20, //nolint:mnd // grab extra in case some are tracks and not albums.
 		SortDir:  starr.SortDescend,
 		SortKey:  "date",
 		Filter:   lidarr.FilterTrackFileImported,

--- a/pkg/triggers/dashboard/sonarr.go
+++ b/pkg/triggers/dashboard/sonarr.go
@@ -83,7 +83,7 @@ func (c *Cmd) getSonarrState(ctx context.Context, instance int, app *apps.Sonarr
 func (c *Cmd) getSonarrHistory(app *apps.SonarrConfig) ([]*Sortable, error) {
 	history, err := app.GetHistoryPage(&starr.PageReq{
 		Page:     1,
-		PageSize: showLatest + 5, //nolint:gomnd // grab extra in case there's an error.
+		PageSize: showLatest + 5, //nolint:mnd // grab extra in case there's an error.
 		SortDir:  starr.SortDescend,
 		SortKey:  "date",
 		Filter:   sonarr.FilterDownloadFolderImported,

--- a/pkg/triggers/handler.go
+++ b/pkg/triggers/handler.go
@@ -427,7 +427,7 @@ func (a *Actions) backup(input *common.ActionInput, content string) (int, string
 func (a *Actions) handleConfigReload() (int, string) {
 	go func() {
 		// Until we have a way to reliably finish the tunnel requests, this is the best I got.
-		time.Sleep(200 * time.Millisecond) //nolint:gomnd
+		time.Sleep(200 * time.Millisecond) //nolint:mnd
 		a.Timers.ReloadApp("HTTP Triggered Reload")
 	}()
 

--- a/pkg/triggers/plexcron/plexcron.go
+++ b/pkg/triggers/plexcron/plexcron.go
@@ -124,7 +124,7 @@ func (c *cmd) sendWebhook(hook *plex.IncomingWebhook) {
 		cancel()
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second) //nolint:gomnd // wait max 5 seconds for system info.
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second) //nolint:mnd // wait max 5 seconds for system info.
 	defer cancel()
 
 	c.SendData(&website.Request{

--- a/pkg/update/unstable.go
+++ b/pkg/update/unstable.go
@@ -77,7 +77,7 @@ func GetUnstable(ctx context.Context, uri string) (*UnstableFile, error) {
 		return nil, fmt.Errorf("decoding %s response: %w", uri, err)
 	}
 
-	release.Time, _ = time.Parse(time.RFC1123, resp.Header.Get("last-modified"))
+	release.Time, _ = time.Parse(time.RFC1123, resp.Header.Get("Last-Modified"))
 
 	return &release, nil
 }

--- a/pkg/update/unstable.go
+++ b/pkg/update/unstable.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Notifiarr/notifiarr/pkg/mnd"
@@ -26,12 +27,13 @@ const unstableURL = "https://unstable.golift.io"
 // CheckUnstable checks if the provided app has an updated version on GitHub.
 // Pass in revision only, no version.
 func CheckUnstable(ctx context.Context, app string, revision string) (*Update, error) {
-	uri := fmt.Sprintf("%s/%s/%s.%s.exe.zip", unstableURL, app, app, runtime.GOARCH)
+	lower := strings.ToLower(app)
+	uri := fmt.Sprintf("%s/%s/%s.%s.exe.zip", unstableURL, lower, lower, runtime.GOARCH)
 
 	if mnd.IsDarwin {
-		uri = fmt.Sprintf("%s/%s/%s.dmg", unstableURL, app, app)
+		uri = fmt.Sprintf("%s/%s/%s.dmg", unstableURL, lower, app)
 	} else if !mnd.IsWindows {
-		uri = fmt.Sprintf("%s/%s/%s.%s.%s.gz", unstableURL, app, app, runtime.GOARCH, runtime.GOOS)
+		uri = fmt.Sprintf("%s/%s/%s.%s.%s.gz", unstableURL, lower, lower, runtime.GOARCH, runtime.GOOS)
 	}
 
 	release, err := GetUnstable(ctx, uri)

--- a/pkg/website/website.go
+++ b/pkg/website/website.go
@@ -73,7 +73,7 @@ func (s *Server) sendJSON(ctx context.Context, url string, data []byte, log bool
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-API-Key", s.Config.Apps.APIKey)
+	req.Header.Set("X-Api-Key", s.Config.Apps.APIKey)
 
 	start := time.Now()
 
@@ -127,7 +127,7 @@ func (s *Server) sendFile(ctx context.Context, uri string, file *UploadFile) (*R
 	}
 
 	req.Header.Set("Content-Type", contentType)
-	req.Header.Set("X-API-Key", s.Config.Apps.APIKey)
+	req.Header.Set("X-Api-Key", s.Config.Apps.APIKey)
 
 	start := time.Now()
 	msg := fmt.Sprintf("Upload %s, %d bytes", file.FileName, sent)
@@ -212,7 +212,7 @@ func (h *httpClient) Do(req *http.Request) (*http.Response, error) { //nolint:cy
 			}
 
 			if resp.StatusCode < http.StatusInternalServerError &&
-				(resp.StatusCode != http.StatusBadRequest || resp.Header.Get("content-type") != "text/html") {
+				(resp.StatusCode != http.StatusBadRequest || resp.Header.Get("Content-Type") != "text/html") {
 				mnd.Website.Add(req.Method+mnd.BytesSent, resp.Request.ContentLength)
 				return resp, nil
 			}


### PR DESCRIPTION
Adds the ability to suck in variables using the `filepath:` notation. If you set an api key to, for instance, `filepath:/some/file.txt` the app will read in `/some/file.txt` and set that to the api key. Clicking save in the UI will overwrite the saved file path with the actual API key. This feature is for automated systems. This 'bug' may be fixed in the future or before merge; unsure yet.

Updates lint, which made a lot of changes.

Fixes a bug with the unstable update check on macOS.

Prints config file age on startup. Unifies how time ages are displayed.