### PR TITLE
add backup cleanup codez

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ linters:
     - dupl        # Maybe one day we can reduce the duplicate code with generics.
     - nlreturn    # Not needed because wsl is good enough; better actually.
     - godot       # Does not work with annotations.
-    - musttag     # Broken in 1.59: https://github.com/go-simpler/musttag/issues/98
     - depguard    # Not even sure why this is useful. We have too many deps to care.
 run:
   timeout: 5m

--- a/pkg/client/handlers_gui.go
+++ b/pkg/client/handlers_gui.go
@@ -705,6 +705,7 @@ func (c *Client) mergeAndValidateNewConfig(config *configfile.Config, request *h
 	config.Commands = nil
 	config.Service = nil
 	config.Snapshot.Plugins.MySQL = nil
+	config.Snapshot.Plugins.Nvidia = nil
 
 	// for k, v := range request.PostForm {
 	// 	c.Errorf("Config Post: %s = %+v", k, v)

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -63,7 +63,7 @@ const (
 // LogConfig allows sending logs to rotating files.
 // Setting an AppName will force log creation even if LogFile and HTTPLog are empty.
 type LogConfig struct {
-	AppName   string   `json:"-"`
+	AppName   string   `json:"-"         toml:"-"           xml:"-"           yaml:"-"`
 	LogFile   string   `json:"logFile"   toml:"log_file"    xml:"log_file"    yaml:"logFile"`
 	DebugLog  string   `json:"debugLog"  toml:"debug_log"   xml:"debug_log"   yaml:"debugLog"`
 	HTTPLog   string   `json:"httpLog"   toml:"http_log"    xml:"http_log"    yaml:"httpLog"`

--- a/pkg/snapshot/mysql.go
+++ b/pkg/snapshot/mysql.go
@@ -16,13 +16,13 @@ import (
 
 // MySQLConfig allows us to gather a process list for the snapshot.
 type MySQLConfig struct {
-	Name    string        `toml:"name"    xml:"name"`
-	Host    string        `toml:"host"    xml:"host"`
-	User    string        `toml:"user"    xml:"user"`
-	Pass    string        `toml:"pass"    xml:"pass"`
-	Timeout cnfg.Duration `toml:"timeout" xml:"timeout"`
-	// only used by service checks, snapshot interval is used for mysql.
-	Interval cnfg.Duration `toml:"interval" xml:"interval"`
+	Name    string        `json:"name"    toml:"name"    xml:"name"`
+	Host    string        `json:"host"    toml:"host"    xml:"host"`
+	User    string        `json:"-"       toml:"user"    xml:"user"`
+	Pass    string        `json:"-"       toml:"pass"    xml:"pass"`
+	Timeout cnfg.Duration `json:"timeout" toml:"timeout" xml:"timeout"`
+	// Only used by service checks, snapshot interval is used for mysql.
+	Interval cnfg.Duration `json:"interval" toml:"interval" xml:"interval"`
 }
 
 // MySQLProcesses allows us to manipulate our list with methods.

--- a/pkg/snapshot/nvidia.go
+++ b/pkg/snapshot/nvidia.go
@@ -60,9 +60,7 @@ func (s *Snapshot) GetNvidia(ctx context.Context, config *NvidiaConfig) error {
 			return fmt.Errorf("unable to locate nvidia-smi at provided path '%s': %w", cmdPath, err)
 		}
 	} else if cmdPath, err = exec.LookPath(nvidiaSMIname()); err != nil {
-		// do not throw an error if nvidia-smi is missing.
-		// return fmt.Errorf("nvidia-smi missing! %w", err)
-		return nil
+		return fmt.Errorf("nvidia-smi missing from PATH! %w", err)
 	}
 
 	cmd := exec.CommandContext(ctx, cmdPath, "--format=csv,noheader", "--query-gpu="+

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -53,7 +53,6 @@ type Config struct {
 	IPMI      bool          `json:"ipmi"          toml:"ipmi"           xml:"ipmi"`           // get ipmi sensor info.
 	IPMISudo  bool          `json:"ipmiSudo"      toml:"ipmiSudo"       xml:"ipmiSudo"`       // use sudo to get ipmi sensor info.
 	Plugins
-	// Debug     bool          `toml:"debug" xml:"debug" json:"debug"`
 }
 
 // Plugins is optional configuration for "plugins".

--- a/pkg/triggers/autoupdate/autoupdate.go
+++ b/pkg/triggers/autoupdate/autoupdate.go
@@ -161,7 +161,7 @@ func (c *cmd) updateNow(ctx context.Context, u *update.Update, msg website.Event
 
 	cmd := &update.Command{
 		URL:    u.CurrURL,
-		Logger: c.Logger.DebugLog,
+		Logger: c.Logger,
 		Args:   []string{"--restart", "--config", c.ConfigFile},
 		Path:   os.Args[0],
 	}

--- a/pkg/update/cleanup.go
+++ b/pkg/update/cleanup.go
@@ -24,7 +24,7 @@ func (f fileList) Len() int {
 }
 
 func (f fileList) Less(i, j int) bool {
-	return f[i].when.UnixMicro() > f[j].when.UnixMicro()
+	return f[i].when.UnixMicro() < f[j].when.UnixMicro()
 }
 
 func (f fileList) Swap(i, j int) {
@@ -56,12 +56,11 @@ func (u *Command) cleanOldBackups() {
 	sort.Sort(consider)
 
 	for idx, file := range consider {
-		total := len(consider)
-		if total-1-idx < keepBackups {
+		if len(consider)-idx <= keepBackups {
 			return
 		}
 
 		err := os.Remove(filepath.Join(dir, file.name))
-		u.Printf("Deleted old backup file: %s%s (error: %v)", file.name, mnd.DurationAge(file.when), err)
+		u.Printf("[UPDATE] Deleted old backup file: %s%s (error: %v)", file.name, mnd.DurationAge(file.when), err)
 	}
 }

--- a/pkg/update/cleanup.go
+++ b/pkg/update/cleanup.go
@@ -1,0 +1,67 @@
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Notifiarr/notifiarr/pkg/mnd"
+)
+
+const keepBackups = 3
+
+type file struct {
+	name string
+	when time.Time
+}
+
+type fileList []file
+
+func (f fileList) Len() int {
+	return len(f)
+}
+
+func (f fileList) Less(i, j int) bool {
+	return f[i].when.UnixMicro() > f[j].when.UnixMicro()
+}
+
+func (f fileList) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
+
+func (u *Command) cleanOldBackups() {
+	dir := filepath.Dir(u.Path)
+	pfx := strings.TrimSuffix(filepath.Base(u.Path), dotExe) + ".backup."
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+
+	consider := fileList{}
+
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), pfx) || len(entry.Name()) < len(pfx)+len(backupTimeFormat) {
+			continue
+		}
+
+		date := strings.TrimSuffix(strings.TrimPrefix(entry.Name(), pfx), dotExe)
+		if when, err := time.Parse(backupTimeFormat, date); err == nil {
+			consider = append(consider, file{name: entry.Name(), when: when})
+		}
+	}
+
+	sort.Sort(consider)
+
+	for idx, file := range consider {
+		total := len(consider)
+		if total-1-idx < keepBackups {
+			return
+		}
+
+		err := os.Remove(filepath.Join(dir, file.name))
+		u.Printf("Deleted old backup file: %s%s (error: %v)", file.name, mnd.DurationAge(file.when), err)
+	}
+}

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -45,13 +45,13 @@ var (
 )
 
 // Restart is meant to be called from a special flag that reloads the app after an upgrade.
-func Restart(u *Command) error {
+func Restart(cmd *Command) error {
 	// A small pause to give the parent time to exit.
 	time.Sleep(time.Second)
 	// A small pause to give the new app time to fork.
 	defer time.Sleep(time.Second)
 
-	if err := exec.Command(u.Path, u.Args...).Start(); err != nil { //nolint:gosec
+	if err := exec.Command(cmd.Path, cmd.Args...).Start(); err != nil { //nolint:gosec
 		return fmt.Errorf("executing command %w", err)
 	}
 


### PR DESCRIPTION
### Updater
- Closes #776 
- Improves updater logs.
- Deletes all old backups except most recent 3.

### Linter
- Adds `musttag` linter.

### Snapshots
- Stop sending mysql auth info to website. (oops)
- Fix bug removing nvidia-smi path using WebUI.
- Return LookPath error when nvidia-smi cannot be found.