### PR TITLE
ask for key instead of open config file

### DIFF
--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -206,7 +206,7 @@ func (c *Client) makeNewConfigFile(ctx context.Context, newPassword string) {
 
 	// write new config file to temporary path.
 	destFile := filepath.Join(filepath.Dir(c.Flags.ConfigFile), "_tmpConfig")
-	if _, err := c.Config.Write(ctx, destFile, true); err != nil { // write our config file template.
+	if _, err := c.Config.Write(ctx, destFile, false); err != nil { // write our config file template.
 		c.Errorf("writing new (temporary) config file: %v", err)
 	}
 
@@ -215,8 +215,10 @@ func (c *Client) makeNewConfigFile(ctx context.Context, newPassword string) {
 		c.Errorf("renaming temporary config file: %v", err)
 	}
 
-	go ui.Warning("Your Web UI password was set to " + newPassword +
-		" and was also printed in the log file:" + c.Config.LogFile)
+	go func() {
+		_, _ = ui.Warning("Your Web UI password was set to " + newPassword +
+			" and was also printed in the log file:" + c.Config.LogFile)
+	}()
 }
 
 // loadConfiguration brings in, and sometimes creates, the initial running configuration.

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -206,7 +206,7 @@ func (c *Client) makeNewConfigFile(ctx context.Context, newPassword string) {
 
 	// write new config file to temporary path.
 	destFile := filepath.Join(filepath.Dir(c.Flags.ConfigFile), "_tmpConfig")
-	if _, err := c.Config.Write(ctx, destFile, false); err != nil { // write our config file template.
+	if _, err := c.Config.Write(ctx, destFile, true); err != nil { // write our config file template.
 		c.Errorf("writing new (temporary) config file: %v", err)
 	}
 
@@ -216,8 +216,11 @@ func (c *Client) makeNewConfigFile(ctx context.Context, newPassword string) {
 	}
 
 	go func() {
-		_, _ = ui.Warning("Your Web UI password was set to " + newPassword +
-			" and was also printed in the log file:" + c.Config.LogFile)
+		open, _ := ui.Question("http://127.0.0/1:5454 - Your Web UI password was set to "+newPassword+
+			" and was also printed in the log file:"+c.Config.LogFile+"\n\nOpen Web UI?\n", false)
+		if open {
+			_ = ui.OpenURL("http://127.0.0.1:5454")
+		}
 	}()
 }
 

--- a/pkg/client/start.go
+++ b/pkg/client/start.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -176,12 +177,12 @@ func (c *Client) start(ctx context.Context, msgs []string, newPassword string) e
 		return err
 	}
 
-	clientInfo := c.configureServices(ctx)
-
 	if newPassword != "" {
 		// If newPassword is set it means we need to write out a new config file for a new installation. Do that now.
 		c.makeNewConfigFile(ctx, newPassword)
 	}
+
+	clientInfo := c.configureServices(ctx)
 
 	if ui.HasGUI() {
 		// This starts the web server and calls os.Exit() when done.
@@ -196,13 +197,26 @@ func (c *Client) makeNewConfigFile(ctx context.Context, newPassword string) {
 	ctx, cancel := context.WithTimeout(ctx, mnd.DefaultTimeout)
 	defer cancel()
 
-	_, _ = c.Config.Write(ctx, c.Flags.ConfigFile, false)
-	_ = ui.OpenFile(c.Flags.ConfigFile)
-	_, _ = ui.Warning("A new configuration file was created @ " +
-		c.Flags.ConfigFile + " - it should open in a text editor. " +
-		"Please edit the file and reload this application using the tray menu. " +
-		"Your Web UI password was set to " + newPassword +
-		" and was also printed in the log file '" + c.Config.LogFile + "' and/or app output.")
+	c.Config.APIKey, _, _ = ui.Entry("Enter 'All' API Key from notifiarr.com", "api-key-from-notifiarr.com")
+	if c.Config.ValidAPIKey() != nil {
+		c.Config.APIKey = "api-key-from-notifiarr.com"
+	} else {
+		c.Input.APIKey = c.Config.APIKey
+	}
+
+	// write new config file to temporary path.
+	destFile := filepath.Join(filepath.Dir(c.Flags.ConfigFile), "_tmpConfig")
+	if _, err := c.Config.Write(ctx, destFile, true); err != nil { // write our config file template.
+		c.Errorf("writing new (temporary) config file: %v", err)
+	}
+
+	// move new config file to existing config file.
+	if err := os.Rename(destFile, c.Flags.ConfigFile); err != nil {
+		c.Errorf("renaming temporary config file: %v", err)
+	}
+
+	go ui.Warning("Your Web UI password was set to " + newPassword +
+		" and was also printed in the log file:" + c.Config.LogFile)
 }
 
 // loadConfiguration brings in, and sometimes creates, the initial running configuration.


### PR DESCRIPTION
When installing a new client on Windows or macOS the app traditionally opens the config file so the user can add their API key. Instead, we now throw a pop-up that asks for the API key.

## Windows

![Screenshot 2025-04-10 at 5 16 49 PM](https://github.com/user-attachments/assets/32b24a49-a978-4c78-95b8-172dd1b8ff50)

![Screenshot 2025-04-10 at 5 17 54 PM](https://github.com/user-attachments/assets/b47563cc-a1cb-47c8-8782-38b491ec6098)

## macOS

![Screenshot 2025-04-10 at 5 19 31 PM](https://github.com/user-attachments/assets/2a1c7eb1-7510-4590-b0ac-6b50f280380a)

![Screenshot 2025-04-10 at 5 19 40 PM](https://github.com/user-attachments/assets/9609b394-2615-43b7-b347-6b41de8d8594)

