### PR TITLE
Add languages help page

### DIFF
--- a/frontend/src/includes/locale/en.json
+++ b/frontend/src/includes/locale/en.json
@@ -133,7 +133,7 @@
     "ShutdownSuccess": "Shutdown successful! Client stopped.",
     "FailedToShutdown": "Failed to shutdown: {error} - Try reloading the page.",
     "LoginHelp": "Login Help",
-    "LoginHelpBody": "If you've forgotten your password, please see the <a href=\"https://notifiarr.wiki/pages/client/gui/#forgotten-passwords\" target=\"_new\">forgotten passwords</a> wiki page. If this is your first time logging in you can find your password in the client log file. If you provided an API key to the client before starting it for the first time, then your password is the API key.",
+    "LoginHelpBody": "If you've forgotten your password, please see the <a href=\"https://notifiarr.wiki/pages/client/gui/#forgotten-passwords\" target=\"_blank\">forgotten passwords</a> wiki page. If this is your first time logging in you can find your password in the client log file. If you provided an API key to the client before starting it for the first time, then your password is the API key.",
     "Changed": "Changed",
     "New": "New",
     "Invalid": "Invalid",
@@ -181,7 +181,7 @@
     },
     "pageDescription": {
       "Configuration": "Configure your Notifiarr client settings here.",
-      "SiteTunnel": "This client keeps a persistent websocket connection to notifiarr.com using a <a href=\"https://github.com/golift/mulery\" target=\"_new\">Mulery tunnel</a>. This tunnel allows the website to make requests to your client without the need for opening a port, or having a static IP. This page allows you to select your primary tunnel and which tunnel you wish to use as backup in case the primary becomes inaccessible.",
+      "SiteTunnel": "This client keeps a persistent websocket connection to notifiarr.com using a <a href=\"https://github.com/golift/mulery\" target=\"_blank\">Mulery tunnel</a>. This tunnel allows the website to make requests to your client without the need for opening a port, or having a static IP. This page allows you to select your primary tunnel and which tunnel you wish to use as backup in case the primary becomes inaccessible.",
       "StarrApps": "Setup Starr integrations.",
       "Downloaders": "Manage download clients.",
       "MediaApps": "Manage media players and related services.",
@@ -401,7 +401,7 @@
       "EnterCurrentPassword": "Enter your current password to make changes.",
       "ProxyAuthDisabled": "Proxy authentication is disabled because your upstream ({upstreamIp}) is not in the allowed upstreams list.",
       "Addit": "Add it.",
-      "SeeWikiForAuthProxyHelp": "See <a href=\"https://notifiarr.wiki/pages/client/reverseProxy/\" target=\"_new\">the wiki</a> for instructions setting up an authentication proxy.",
+      "SeeWikiForAuthProxyHelp": "See <a href=\"https://notifiarr.wiki/pages/client/reverseProxy/\" target=\"_blank\">the wiki</a> for instructions setting up an authentication proxy.",
       "ShowMeMore": "Show me more.",
       "ShowMeLess": "Show me less."
     },
@@ -415,7 +415,7 @@
       },
       "option_desc": {
         "password": " This is the default authentication type. Select the Password option to log into this application with a configured username and password. Only 1 username and password is supported. When selecting this option, you must fill in the username and new password fields. If this is the current authentication type you must also fill in the current password field to make changes.",
-        "header": "Select this option to log into this application using an HTTP header that contains a username. This is commonly known as proxy authentication. We have <a href=\"https://notifiarr.wiki/pages/client/reverseProxy/\" target=\"_new\">a wiki page</a> that provides instructions to configure Nginx for this feature. When selecting this option, you must also select a header for the auth proxy. If no headers are displayed, then no valid headers were provided by the upstream proxy.",
+        "header": "Select this option to log into this application using an HTTP header that contains a username. This is commonly known as proxy authentication. We have <a href=\"https://notifiarr.wiki/pages/client/reverseProxy/\" target=\"_blank\">a wiki page</a> that provides instructions to configure Nginx for this feature. When selecting this option, you must also select a header for the auth proxy. If no headers are displayed, then no valid headers were provided by the upstream proxy.",
         "noauth": "This configuration is not recommended. The No Password authentication type allows any request from any configured <code>upstream IP</code>. It also works with an auth proxy to set the username. If no username is in the provided header, then it defaults to admin."
       }
     },
@@ -511,7 +511,7 @@
   "MediaApps": {
     "Plex": {
       "title": "Plex",
-      "description": "The Plex integration is comprehensive, and many of the settings are configured on the <a href=\"https://notifiarr.com/\" target=\"_new\">Notifiarr.com website</a>.",
+      "description": "The Plex integration is comprehensive, and many of the settings are configured on the <a href=\"https://notifiarr.com/\" target=\"_blank\">Notifiarr.com website</a>.",
       "name": {
         "label": "Server Name",
         "description": "Name of the Plex server.",
@@ -526,7 +526,7 @@
         "label": "Token",
         "description": "Token for the Plex server.",
         "placeholder": "pl3x-to_Ken",
-        "tooltip": "You may find directions for locating your Plex token at <a href=\"https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/\" target=\"_new\">this Plex Article</a>."
+        "tooltip": "You may find directions for locating your Plex token at <a href=\"https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/\" target=\"_blank\">this Plex Article</a>."
       }
     },
     "Tautulli": {
@@ -1056,7 +1056,7 @@
       "label": "Payload Template",
       "description": "Parse payload into this template.",
       "placeholder": "pihole",
-      "tooltip": "The template is used by the website to figure out how to turn the payload into a chat notification. Find a list of available templates or create your own on <a href=\"https://notifiarr.com/\" target=\"_new\">the website</a> @ <code>Integrations: Endpoints</code>.",
+      "tooltip": "The template is used by the website to figure out how to turn the payload into a chat notification. Find a list of available templates or create your own on <a href=\"https://notifiarr.com/\" target=\"_blank\">the website</a> @ <code>Integrations: Endpoints</code>.",
       "required": "A template is required. Enter 'test' if you are not sure what to enter."
     },
     "timeout": {
@@ -1628,5 +1628,10 @@
       "NoPlexData": "No plex integration data.",
       "StateForTime": "{state} for {timeDuration}"
     }
+  },
+  "Languages": {
+    "menuTitle": "Language Help",
+    "title": "Localization Support",
+    "body": "This application is available in multiple languages. You can change the language by clicking the language selector in the profile menu. Some languages do not have active translators, so some translations may be incomplete. If you are interested in helping translate the application, please <a href=\"https://notifiarr.com/discord\" target=\"_blank\">visit us on Discord</a>. Leave a message in any channel, even <code>#off-topic</code>, and we'll get you started."
   }
 }

--- a/frontend/src/includes/locale/fr.json
+++ b/frontend/src/includes/locale/fr.json
@@ -401,7 +401,7 @@
             "System": "Afficher les informations système et client et.",
             "TrustProfile": "Configurez la manière dont vous vous connectez à cette application client Notifiarr.",
             "Landing": "C'est le plus bel endroit sur Terre !",
-            "SiteTunnel": "Ce client maintient une connexion websocket persistante à notifiarr.com via un <a href=\"https://github.com/golift/mulery\" target=\"_new\">tunnel Mulery</a>. Ce tunnel permet au site web d'adresser des requêtes à votre client sans avoir à ouvrir de port ni à utiliser d'adresse IP statique. Cette page vous permet de sélectionner votre tunnel principal et celui que vous souhaitez utiliser comme tunnel de secours en cas d'inaccessibilité du tunnel principal.",
+            "SiteTunnel": "Ce client maintient une connexion websocket persistante à notifiarr.com via un <a href=\"https://github.com/golift/mulery\" target=\"_blank\">tunnel Mulery</a>. Ce tunnel permet au site web d'adresser des requêtes à votre client sans avoir à ouvrir de port ni à utiliser d'adresse IP statique. Cette page vous permet de sélectionner votre tunnel principal et celui que vous souhaitez utiliser comme tunnel de secours en cas d'inaccessibilité du tunnel principal.",
             "Actions": "Retrouvez ici les actions internes du client Notifiarr. Elles sont exécutées par des minuteurs, des planifications et des événements provenant du site web ou d'un serveur de chat. Généralement réservées au dépannage, vous pouvez les déclencher manuellement dans cette interface."
         }
     },
@@ -742,7 +742,7 @@
             "label": "Modèle de charge utile",
             "description": "Analyser la charge utile dans ce modèle.",
             "placeholder": "trou d'homme",
-            "tooltip": "Le modèle est utilisé par le site web pour déterminer comment transformer la charge utile en notification de chat. Consultez la liste des modèles disponibles ou créez le vôtre sur <a href=\"https://notifiarr.com/\" target=\"_new\">le site web</a> @ <code>Integrations : Endpoints</code>.",
+            "tooltip": "Le modèle est utilisé par le site web pour déterminer comment transformer la charge utile en notification de chat. Consultez la liste des modèles disponibles ou créez le vôtre sur <a href=\"https://notifiarr.com/\" target=\"_blank\">le site web</a> @ <code>Integrations : Endpoints</code>.",
             "required": "Un modèle est requis. Saisissez « test » si vous ne savez pas quoi saisir."
         },
         "timeout": {
@@ -820,7 +820,7 @@
         "Changed": "Modifié",
         "New": "Nouveau",
         "ERROR": "ERREUR",
-        "LoginHelpBody": "Si vous avez oublié votre mot de passe, veuillez consulter la page wiki <a href=\"https://notifiarr.wiki/pages/client/gui/#forgotten-passwords\" target=\"_new\">mots de passe oubliés</a>. Si c'est votre première connexion, vous trouverez votre mot de passe dans le fichier journal du client. Si vous avez fourni une clé API au client avant de le démarrer pour la première fois, votre mot de passe est la clé API.",
+        "LoginHelpBody": "Si vous avez oublié votre mot de passe, veuillez consulter la page wiki <a href=\"https://notifiarr.wiki/pages/client/gui/#forgotten-passwords\" target=\"_blank\">mots de passe oubliés</a>. Si c'est votre première connexion, vous trouverez votre mot de passe dans le fichier journal du client. Si vous avez fourni une clé API au client avant de le démarrer pour la première fois, votre mot de passe est la clé API.",
         "Loading": "Chargement...",
         "BackEndUpdated": "Back-end mis à jour il y a {timeDuration}.",
         "ShowMore": "Afficher plus d'informations"
@@ -989,7 +989,7 @@
             "ProfileUpdated": "Profil mis à jour avec succès il y a {timeDuration}!",
             "EnterCurrentPassword": "Saisissez votre mot de passe actuel pour apporter des modifications.",
             "ProxyAuthDisabled": "L'authentification proxy est désactivée car votre flux en amont ({upstreamIp}) ne figure pas dans la liste des flux en amont autorisés.",
-            "SeeWikiForAuthProxyHelp": "Consultez le <a href=\"https://notifiarr.wiki/pages/client/reverseProxy/\" target=\"_new\">wiki</a> pour obtenir des instructions sur la configuration d'un proxy d'authentification.",
+            "SeeWikiForAuthProxyHelp": "Consultez le <a href=\"https://notifiarr.wiki/pages/client/reverseProxy/\" target=\"_blank\">wiki</a> pour obtenir des instructions sur la configuration d'un proxy d'authentification.",
             "ShowMeMore": "Montre m'en plus.",
             "ShowMeLess": "Montre-moi moins."
         },
@@ -1059,7 +1059,7 @@
         },
         "Plex": {
             "title": "Plex",
-            "description": "L'intégration Plex est complète et de nombreux paramètres sont configurés sur le <a href=\"https://notifiarr.com/\" target=\"_new\">site Web Notifiarr.com</a>.",
+            "description": "L'intégration Plex est complète et de nombreux paramètres sont configurés sur le <a href=\"https://notifiarr.com/\" target=\"_blank\">site Web Notifiarr.com</a>.",
             "name": {
                 "label": "Nom du serveur",
                 "description": "Nom du serveur Plex.",
@@ -1074,7 +1074,7 @@
                 "label": "Jeton",
                 "description": "Jeton pour le serveur Plex.",
                 "placeholder": "pl3x-à_Ken",
-                "tooltip": "Vous pouvez trouver des instructions pour localiser votre jeton Plex dans <a href=\"https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/\" target=\"_new\">cet article Plex</a>."
+                "tooltip": "Vous pouvez trouver des instructions pour localiser votre jeton Plex dans <a href=\"https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/\" target=\"_blank\">cet article Plex</a>."
             }
         }
     },

--- a/frontend/src/includes/locale/it.json
+++ b/frontend/src/includes/locale/it.json
@@ -1209,7 +1209,7 @@
             "EnterCurrentPassword": "",
             "ProxyAuthDisabled": "",
             "Addit": "Aggiungilo.",
-            "SeeWikiForAuthProxyHelp": "Vedi <a href=\"https://notifiarr.wiki/pages/client/reverseProxy/\" target=\"_new\">la wiki</a> per le istruzioni per impostare un proxy di autenticazione.",
+            "SeeWikiForAuthProxyHelp": "Vedi <a href=\"https://notifiarr.wiki/pages/client/reverseProxy/\" target=\"_blank\">la wiki</a> per le istruzioni per impostare un proxy di autenticazione.",
             "ShowMeMore": "Mostrami di più.",
             "ShowMeLess": "Mostrami di meno."
         },

--- a/frontend/src/includes/locale/nl.json
+++ b/frontend/src/includes/locale/nl.json
@@ -72,7 +72,7 @@
     "phrases": {
         "BackEndUpdated": "Back-end {timeDuration} geleden bijgewerkt.",
         "ReloadSuccess": "Herladen succesvol! Client is herladen.",
-        "LoginHelpBody": "Bent u uw wachtwoord vergeten? Raadpleeg dan de wikipagina <a href=\"https://notifiarr.wiki/pages/client/gui/#forgotten-passwords\" target=\"_new\">vergeten wachtwoorden</a>. Als dit uw eerste keer is dat u inlogt, kunt u uw wachtwoord vinden in het logbestand van de client. Als u de client een API-sleutel hebt gegeven voordat u deze voor het eerst startte, is uw wachtwoord de API-sleutel.",
+        "LoginHelpBody": "Bent u uw wachtwoord vergeten? Raadpleeg dan de wikipagina <a href=\"https://notifiarr.wiki/pages/client/gui/#forgotten-passwords\" target=\"_blank\">vergeten wachtwoorden</a>. Als dit uw eerste keer is dat u inlogt, kunt u uw wachtwoord vinden in het logbestand van de client. Als u de client een API-sleutel hebt gegeven voordat u deze voor het eerst startte, is uw wachtwoord de API-sleutel.",
         "FailedToUpdateBackEnd": "Back-end updaten mislukt: {error}",
         "TryRefreshingThePage": "Probeer de pagina te vernieuwen.",
         "ConfigurationSavedReloading": "Configuratie opgeslagen! Client wordt opnieuw geladen...",
@@ -123,7 +123,7 @@
             "SnapshotApps": "De meeste snapshot configuraties vindt u op de website Notifiarr.com. Hieronder vindt u de plug-in instellingen voor de snapshotfunctie.",
             "FileWatcher": "Let op bestandswijzigingen en activeer acties! Deze Notifiarr client kan (log)bestanden controleren op regels die overeenkomen met een reguliere expressie. Dit is vergelijkbaar met <code>tail -f file | grep string</code> en stelt u in staat om meldingen te versturen wanneer er bijvoorbeeld een nieuwe regel in een logbestand is geschreven die overeenkomt met een reguliere expressie.",
             "Metrics": "Bekijk metrische totalen voor client configuraties.",
-            "SiteTunnel": "Deze client onderhoud een permanente websocket verbinding met notifiarr.com via een <a href=\"https://github.com/golift/mulery\" target=\"_new\">Mulery-tunnel</a>. Deze tunnel stelt de website in staat om verzoeken naar uw client te sturen zonder dat er een poort hoeft te worden geopend of een statisch IP-adres hoeft te worden gebruikt. Op deze pagina kunt u uw primaire tunnel selecteren en welke tunnel u als back-up wilt gebruiken voor het geval de primaire tunnel ontoegankelijk wordt.",
+            "SiteTunnel": "Deze client onderhoud een permanente websocket verbinding met notifiarr.com via een <a href=\"https://github.com/golift/mulery\" target=\"_blank\">Mulery-tunnel</a>. Deze tunnel stelt de website in staat om verzoeken naar uw client te sturen zonder dat er een poort hoeft te worden geopend of een statisch IP-adres hoeft te worden gebruikt. Op deze pagina kunt u uw primaire tunnel selecteren en welke tunnel u als back-up wilt gebruiken voor het geval de primaire tunnel ontoegankelijk wordt.",
             "Commands": "Aangepaste opdrachten en scripts instellen en uitvoeren.",
             "Services": "De Notifiarr client toepassing kan services bewaken via HTTP-controles, TCP poort controles of controles op processen die wel of niet worden uitgevoerd. <b>De clientservice controles werken met de Notifiarr.com netwerkintegratie.</b>",
             "Configuration": "Configureer hier uw Notifiarr clientinstellingen.",
@@ -210,7 +210,7 @@
             "AuthTypeChange": "Als het authenticatie type verandert, meldt u zich af om het proces te voltooien.",
             "ProfileUpdated": "Profiel succesvol bijgewerkt {timeDuration} geleden!",
             "EnterCurrentPassword": "Voer uw huidige wachtwoord in om wijzigingen aan te brengen.",
-            "SeeWikiForAuthProxyHelp": "Zie <a href=\"https://notifiarr.wiki/pages/client/reverseProxy/\" target=\"_new\">de wiki</a> voor instructies over het instellen van een authenticatie proxy.",
+            "SeeWikiForAuthProxyHelp": "Zie <a href=\"https://notifiarr.wiki/pages/client/reverseProxy/\" target=\"_blank\">de wiki</a> voor instructies over het instellen van een authenticatie proxy.",
             "ShowMeMore": "Laat meer zien.",
             "ShowMeLess": "Laat minder zien."
         },
@@ -221,7 +221,7 @@
                 "header": "Auth Proxy: koptekst"
             },
             "option_desc": {
-                "header": "Selecteer deze optie om in te loggen bij deze applicatie met een HTTP header die een gebruikersnaam bevat. Dit staat algemeen bekend als proxy authenticatie. We hebben <a href=\"https://notifiarr.wiki/pages/client/reverseProxy/\" target=\"_new\">een wikipagina</a> met instructies voor het configureren van Nginx voor deze functie. Wanneer u deze optie selecteert, moet u ook een header voor de auth proxy selecteren. Als er geen headers worden weergegeven, zijn er geen geldige headers door de upstream proxy verstrekt.",
+                "header": "Selecteer deze optie om in te loggen bij deze applicatie met een HTTP header die een gebruikersnaam bevat. Dit staat algemeen bekend als proxy authenticatie. We hebben <a href=\"https://notifiarr.wiki/pages/client/reverseProxy/\" target=\"_blank\">een wikipagina</a> met instructies voor het configureren van Nginx voor deze functie. Wanneer u deze optie selecteert, moet u ook een header voor de auth proxy selecteren. Als er geen headers worden weergegeven, zijn er geen geldige headers door de upstream proxy verstrekt.",
                 "password": " Dit is het standaard authenticatie type. Selecteer de optie 'Wachtwoord' om in te loggen bij deze applicatie met een geconfigureerde gebruikersnaam en wachtwoord. Er wordt slechts één gebruikersnaam en wachtwoord ondersteund. Wanneer u deze optie selecteert, moet u de velden voor de gebruikersnaam en het nieuwe wachtwoord invullen. Als dit het huidige authenticatietype is, moet u ook het veld voor het huidige wachtwoord invullen om wijzigingen aan te brengen.",
                 "noauth": "Deze configuratie wordt niet aanbevolen. Het authenticatietype 'Geen wachtwoord' staat alle verzoeken toe van elk geconfigureerd <code>upstream IP</code>. Het werkt ook met een authenticatie proxy om de gebruikersnaam in te stellen. Als er geen gebruikersnaam in de opgegeven header staat, wordt standaard admin gebruikt."
             },
@@ -540,7 +540,7 @@
                 "label": "URL",
                 "description": "URL van de Plex server."
             },
-            "description": "De Plex integratie is uitgebreid en veel van de instellingen worden geconfigureerd op de <a href=\"https://notifiarr.com/\" target=\"_new\">Notifiarr.com website</a>.",
+            "description": "De Plex integratie is uitgebreid en veel van de instellingen worden geconfigureerd op de <a href=\"https://notifiarr.com/\" target=\"_blank\">Notifiarr.com website</a>.",
             "name": {
                 "label": "Server naam",
                 "description": "Naam van de Plex server.",
@@ -550,7 +550,7 @@
                 "label": "Token",
                 "description": "Token voor de Plex server.",
                 "placeholder": "pl3x-to_Ken",
-                "tooltip": "Instructies voor het vinden van uw Plex token vindt u in <a href=\"https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/\" target=\"_new\">dit Plex artikel</a>."
+                "tooltip": "Instructies voor het vinden van uw Plex token vindt u in <a href=\"https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/\" target=\"_blank\">dit Plex artikel</a>."
             }
         },
         "Tautulli": {
@@ -1223,7 +1223,7 @@
             "label": "Payload sjabloon",
             "description": "Kopieer de payload in deze sjabloon.",
             "placeholder": "pihole",
-            "tooltip": "De website gebruikt de template om te bepalen hoe de payload kan worden omgezet in een chat melding. Bekijk een lijst met beschikbare templates of maak je eigen template op <a href=\"https://notifiarr.com/\" target=\"_new\">de website</a> @ <code>Integraties: Eindpunten</code>."
+            "tooltip": "De website gebruikt de template om te bepalen hoe de payload kan worden omgezet in een chat melding. Bekijk een lijst met beschikbare templates of maak je eigen template op <a href=\"https://notifiarr.com/\" target=\"_blank\">de website</a> @ <code>Integraties: Eindpunten</code>."
         },
         "header": {
             "placeholder": "Inhoud-Type: toepassing/json",

--- a/frontend/src/navigation/ProfileMenu.svelte
+++ b/frontend/src/navigation/ProfileMenu.svelte
@@ -15,6 +15,7 @@
   import { Input } from '@sveltestrap/sveltestrap'
   import { faStarship, faSun } from '@fortawesome/sharp-duotone-light-svg-icons'
   import { page as ProfilePage } from '../pages/profile/Index.svelte'
+  import { page as LanguagesPage } from '../pages/stubs/Languages.svelte'
   import { closeSidebar } from './Index.svelte'
 
   let newLang = $derived(locale.current)
@@ -49,6 +50,10 @@
           {/each}
         </Input>
       </span>
+      <DropdownItem class="nav-link-custom" onclick={e => nav.goto(e, LanguagesPage.id)}>
+        <span class="nav-icon"><Fa {...LanguagesPage} scale="1.2x" /></span>
+        {$_(LanguagesPage.id + '.menuTitle')}
+      </DropdownItem>
       <DropdownItem class="nav-link-custom" onclick={theme.toggle}>
         <Fa
           i={faStarship}

--- a/frontend/src/navigation/pages.ts
+++ b/frontend/src/navigation/pages.ts
@@ -20,6 +20,7 @@ import type { Page } from './nav.svelte'
 import ProcessList, { page as ProcessListPage } from '../pages/stubs/ProcessList.svelte'
 import ClientInfo, { page as ClientInfoPage } from '../pages/stubs/ClientInfo.svelte'
 import ApiDocs, { page as ApiDocsPage } from '../pages/stubs/ApiDocs.svelte'
+import Languages, { page as LanguagesPage } from '../pages/stubs/Languages.svelte'
 
 // Page structure for navigation with icons
 // 'id' (from page) is used for navigation AND translations.
@@ -53,6 +54,7 @@ export const others: Page[] = [
   { component: ProcessList, ...ProcessListPage },
   { component: ClientInfo, ...ClientInfoPage },
   { component: ApiDocs, ...ApiDocsPage },
+  { component: Languages, ...LanguagesPage },
 ]
 
 export const allPages: Page[] = [...settings, ...insights, ...others]

--- a/frontend/src/pages/stubs/Languages.svelte
+++ b/frontend/src/pages/stubs/Languages.svelte
@@ -1,0 +1,23 @@
+<!-- Displays a simple Languages help modal. -->
+<script lang="ts" module>
+  import { faLanguage } from '@fortawesome/sharp-duotone-light-svg-icons'
+  export const page = {
+    type: 'modal' as const,
+    id: 'Languages',
+    i: faLanguage,
+    c1: 'coral',
+    c2: 'steelblue',
+    d1: 'darkcyan',
+    d2: 'darkslategray',
+  }
+</script>
+
+<script lang="ts">
+  import ModalWrap from './ModalWrap.svelte'
+  import T from '../../includes/Translate.svelte'
+
+  let modal = $state<ModalWrap>()
+  export const toggle = () => modal?.toggle()
+</script>
+
+<ModalWrap {page} bind:this={modal}><T id="{page.id}.body" /></ModalWrap>


### PR DESCRIPTION
- Adds a localization info page. Rather sparse, but can be extended.
- Fixes all the usage of _new where it should have been _blank.