### PR TITLE
Make back button work with tabs

### DIFF
--- a/frontend/src/pages/downloadApps/Index.svelte
+++ b/frontend/src/pages/downloadApps/Index.svelte
@@ -11,7 +11,7 @@
   import Footer from '../../includes/Footer.svelte'
   import Header from '../../includes/Header.svelte'
   import { nav } from '../../navigation/nav.svelte'
-  import Tab, { getTab } from '../../includes/InstancesTab.svelte'
+  import Tab, { setTab, goto } from '../../includes/InstancesTab.svelte'
   import type {
     DelugeConfig,
     NZBGetConfig,
@@ -42,22 +42,26 @@
     if (!profile.error) Object.values(flt).forEach(iv => iv.resetAll())
   }
 
-  let tab = $state(getTab(App.tabs))
-
   $effect(() => {
     nav.formChanged = Object.values(flt).some(iv => iv.formChanged)
   })
+  setTab(App.tabs) // this sets the initial tab.
 </script>
 
+<!-- update the tab when the user navigates back -->
+<svelte:window on:popstate={() => setTab(App.tabs)} />
+
 <Header {page} />
+
 <CardBody>
-  <TabContent on:tab={e => nav.goto(e, page.id, [e.detail.toString()])}>
-    <Tab flt={flt.Qbittorrent} bind:tab titles={App.title} />
-    <Tab flt={flt.Rtorrent} bind:tab titles={App.title} />
-    <Tab flt={flt.Transmission} bind:tab titles={App.title} />
-    <Tab flt={flt.Deluge} bind:tab titles={App.title} />
-    <Tab flt={flt.SabNZB} bind:tab titles={App.title} />
-    <Tab flt={flt.NZBGet} bind:tab titles={App.title} />
+  <!-- only nav.goto if the tab is different -->
+  <TabContent on:tab={e => goto(e, page.id)}>
+    <Tab flt={flt.Qbittorrent} titles={App.title} />
+    <Tab flt={flt.Rtorrent} titles={App.title} />
+    <Tab flt={flt.Transmission} titles={App.title} />
+    <Tab flt={flt.Deluge} titles={App.title} />
+    <Tab flt={flt.SabNZB} titles={App.title} />
+    <Tab flt={flt.NZBGet} titles={App.title} />
   </TabContent>
 </CardBody>
 

--- a/frontend/src/pages/fileWatcher/Index.svelte
+++ b/frontend/src/pages/fileWatcher/Index.svelte
@@ -36,10 +36,14 @@
       {index + 1}. {flt.original?.[index]?.path}
     {/snippet}
     {#snippet headerCollapsed(index)}
-      <span class="text-primary">Match:</span>
-      {flt.original?.[index]?.regex}
-      <span class="text-warning">Skip:</span>
-      {flt.original?.[index]?.skip}
+      {#if flt.original?.[index]?.regex}
+        <span class="text-primary">Match:</span>
+        {flt.original?.[index]?.regex}
+      {/if}
+      {#if flt.original?.[index]?.skip}
+        <span class="text-warning">Skip:</span>
+        {flt.original?.[index]?.skip}
+      {/if}
     {/snippet}
   </Instances>
   <!-- Test regular expression -->

--- a/frontend/src/pages/starrApps/Index.svelte
+++ b/frontend/src/pages/starrApps/Index.svelte
@@ -9,7 +9,7 @@
   import { CardBody, TabContent } from '@sveltestrap/sveltestrap'
   import Footer from '../../includes/Footer.svelte'
   import Header from '../../includes/Header.svelte'
-  import Tab, { getTab } from '../../includes/InstancesTab.svelte'
+  import Tab, { goto, setTab } from '../../includes/InstancesTab.svelte'
   import { nav } from '../../navigation/nav.svelte'
   import type { StarrConfig } from '../../api/notifiarrConfig'
   import { FormListTracker } from '../../includes/formsTracker.svelte'
@@ -38,22 +38,25 @@
     Object.values(flt).forEach(iv => iv.resetAll())
   }
 
-  let tab = $state(getTab(Starr.tabs))
-
   $effect(() => {
     nav.formChanged = Object.values(flt).some(iv => iv.formChanged)
   })
+  setTab(Starr.tabs) // this sets the initial tab.
 </script>
+
+<!-- update the tab when the user navigates back -->
+<svelte:window on:popstate={() => setTab(Starr.tabs)} />
 
 <Header {page} />
 
 <CardBody>
-  <TabContent on:tab={e => nav.goto(e, page.id, [e.detail.toString()])}>
-    <Tab flt={flt.Sonarr} bind:tab titles={Starr.title} />
-    <Tab flt={flt.Radarr} bind:tab titles={Starr.title} />
-    <Tab flt={flt.Readarr} bind:tab titles={Starr.title} />
-    <Tab flt={flt.Lidarr} bind:tab titles={Starr.title} />
-    <Tab flt={flt.Prowlarr} bind:tab titles={Starr.title} />
+  <!-- only nav.goto if the tab is different -->
+  <TabContent on:tab={e => goto(e, page.id)}>
+    <Tab flt={flt.Sonarr} titles={Starr.title} />
+    <Tab flt={flt.Radarr} titles={Starr.title} />
+    <Tab flt={flt.Readarr} titles={Starr.title} />
+    <Tab flt={flt.Lidarr} titles={Starr.title} />
+    <Tab flt={flt.Prowlarr} titles={Starr.title} />
   </TabContent>
 </CardBody>
 


### PR DESCRIPTION
Back button was mostly working. Thought it was worse than it was. I only found that tabs on Starr and Downloaders pages didn't work with the back button. This fixes the problem by calling `setTab` on `popState`.

Also made a change to only show the `Match:` and `Skip:` regex on file watcher if they're set.