### PR TITLE
local install script

### DIFF
--- a/userscripts/install-local.sh
+++ b/userscripts/install-local.sh
@@ -24,6 +24,22 @@ echo "<-------------------------------------------------->"
 
 PACKAGE=notifiarr
 
+if [ "$1" == "remove" ] || [ "$1" == "uninstall" ]; then
+  [ -n "${HOME}" ] || (echo "${P} [ERROR] HOME environment variable is not set. Cannot continue!" && exit 1)
+  echo "${P} Uninstalling notifiarr client..."
+  systemctl --user stop notifiarr
+  systemctl --user disable notifiarr
+  tar -jcf "${HOME}/notifiarr-backup-$(date +%Y%m%d).tar.bz2" \
+    "${HOME}/notifiarr" \
+    "${HOME}/.config/systemd/user/notifiarr.service" \
+    "${HOME}/.apps/nginx/proxy.d/notifiarr.conf" \
+    >/dev/null 2>&1
+  echo "${P} Backup created: ${HOME}/notifiarr-backup-$(date +%Y%m%d).tar.bz2"
+  rm -rf "${HOME}/notifiarr" "${HOME}/.config/systemd/user/notifiarr.service" "${HOME}/.apps/nginx/proxy.d/notifiarr.conf"
+  echo "${P} Backed up, stopped and removed notifiarr client, service unit file, and nginx proxy configuration."
+  exit 0
+fi
+
 # $ARCH is passed into egrep to find the right file.
 if [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "amd64" ]; then
   ARCH="x86_64|amd64"


### PR DESCRIPTION
- Closes #1095
```
david@ubuntu:~$ bash install-local.sh 
<-------------------------------------------------->
 ==> Installing notifiarr version 0.9.0.
 ==> Paste your 'All' API Key from notifiarr.com profile page: 3A0FF715-1FB5-4E68-B903-B197209BE8B5
 ==> Downloading: https://github.com/Notifiarr/notifiarr/releases/download/v0.9.0/notifiarr.amd64.linux.gz
 ==> To Location: /home/david/notifiarr/notifiarr.amd64.linux.gz
 ==> Downloaded. Installing the binary to /home/david/notifiarr/notifiarr
 ==> Updating unit file: /home/david/.config/systemd/user/notifiarr.service
 ==> Your API key is stored in this file ^^^^ change it there if ever needed.
 ==> Creating nginx proxy configuration for the Notifiarr Web UI.
 ==> Installed. Open the Web UI @ http://your-local-or-seedbox-url:5454 and login as 'admin' using your API Key as the password.
 ==> If nginx is running you should be able to access the Web UI at https://your-local-or-seedbox-url/notifiarr
 ==> Start the service with:  systemctl --user start notifiarr
 ==> Stop the service with:   systemctl --user stop notifiarr
 ==> Check service status:    systemctl --user status notifiarr
<-------------------------------------------------->

david@ubuntu:~$ bash install-local.sh 
<-------------------------------------------------->
 ==> The installed version of notifiarr (0.9.0) is current: 0.9.0
```