### PR TITLE
fix(services): truncate body instead of output in HTTP check

### DIFF
--- a/pkg/services/checks.go
+++ b/pkg/services/checks.go
@@ -229,9 +229,10 @@ func (s *Service) checkHTTP(ctx context.Context) *result {
 		}
 	}
 
-	// Reduce the size of the string before processing it to speed things up on large body outputs.
-	if len(res.output.str) > maxOutput+maxOutput {
-		res.output.str = res.output.str[:maxOutput+maxOutput]
+	// Reduce the size of the body before processing it to speed things up on large body outputs.
+	// This avoids expensive string operations (EscapeString, Fields, Join) on large responses.
+	if len(body) > maxOutput+maxOutput {
+		body = body[:maxOutput+maxOutput]
 	}
 
 	res.state = StateCritical


### PR DESCRIPTION
## truncate body instead of output in HTTP check

Fixes a bug where the HTTP service check pre-truncation optimization was checking the wrong variable.

## Problem

The code intended to truncate large HTTP response bodies before expensive string operations:

```go
// Reduce the size of the string before processing it to speed things up on large body outputs.
if len(res.output.str) > maxOutput+maxOutput {
    res.output.str = res.output.str[:maxOutput+maxOutput]
}
```

However, `res.output.str` was still set to `"unknown"` at this point (from line 193). The actual response data is in the `body` variable.

## Fix

Check and truncate the `body` variable instead:

```go
// Reduce the size of the body before processing it to speed things up on large body outputs.
// This avoids expensive string operations (EscapeString, Fields, Join) on large responses.
if len(body) > maxOutput+maxOutput {
    body = body[:maxOutput+maxOutput]
}
```

## Impact

- Large HTTP response bodies (>340 bytes) are now properly truncated before string processing
- Reduces CPU usage when checking endpoints that return large error pages
- No behavioral change for normal-sized responses

## Backward Compatibility

No breaking changes - this is a pure bug fix that makes the existing optimization work as intended.