### PR TITLE
Use actual item count for itemList.Total

### DIFF
--- a/pkg/triggers/starrqueue/downloads.go
+++ b/pkg/triggers/starrqueue/downloads.go
@@ -105,7 +105,7 @@ func (c *cmd) getDownloadingItemsLidarr(ctx context.Context) itemList {
 
 		queue, _ := cacheItem.Data.(*lidarr.Queue)
 		lidarrQueue := c.rangeDownloadingItemsLidarr(ctx, idx, &app, queue.Records)
-		items[instance] = listItem{Name: app.Name, Queue: lidarrQueue, Total: queue.TotalRecords}
+		items[instance] = listItem{Name: app.Name, Queue: lidarrQueue, Total: len(lidarrQueue)}
 	}
 
 	return items
@@ -186,7 +186,7 @@ func (c *cmd) getDownloadingItemsRadarr(ctx context.Context) itemList {
 
 		queue, _ := cacheItem.Data.(*radarr.Queue)
 		radarrQueue := c.rangeDownloadingItemsRadarr(ctx, idx, &app, queue.Records)
-		items[instance] = listItem{Name: app.Name, Queue: radarrQueue, Total: queue.TotalRecords}
+		items[instance] = listItem{Name: app.Name, Queue: radarrQueue, Total: len(radarrQueue)}
 	}
 
 	return items
@@ -265,7 +265,7 @@ func (c *cmd) getDownloadingItemsReadarr(ctx context.Context) itemList {
 
 		queue, _ := cacheItem.Data.(*readarr.Queue)
 		readarrQueue := c.rangeDownloadingItemsReadarr(ctx, idx, &app, queue.Records)
-		items[instance] = listItem{Name: app.Name, Queue: readarrQueue, Total: queue.TotalRecords}
+		items[instance] = listItem{Name: app.Name, Queue: readarrQueue, Total: len(readarrQueue)}
 	}
 
 	return items
@@ -346,7 +346,7 @@ func (c *cmd) getDownloadingItemsSonarr(ctx context.Context) itemList {
 
 		queue, _ := cacheItem.Data.(*sonarr.Queue)
 		sonarrQueue := c.rangeDownloadingItemsSonarr(ctx, idx, &app, queue.Records)
-		items[instance] = listItem{Name: app.Name, Queue: sonarrQueue, Total: queue.TotalRecords}
+		items[instance] = listItem{Name: app.Name, Queue: sonarrQueue, Total: len(sonarrQueue)}
 	}
 
 	return items

--- a/pkg/triggers/starrqueue/stuckitems.go
+++ b/pkg/triggers/starrqueue/stuckitems.go
@@ -84,7 +84,7 @@ func (c *cmd) getFinishedItemsLidarr(_ context.Context) itemList { //nolint:cycl
 			appqueue = append(appqueue, &lidarrRecord{QueueRecord: minimalLidarrRecord(item)}) //nolint:wsl
 		}
 
-		stuck[instance] = listItem{Name: app.Name, Queue: appqueue, Total: queue.TotalRecords}
+		stuck[instance] = listItem{Name: app.Name, Queue: appqueue, Total: len(appqueue)}
 		mnd.Log.Debugf("Checking Lidarr (%d) Queue for Stuck Items, queue size: %d, stuck: %d",
 			instance, len(queue.Records), len(appqueue))
 	}
@@ -126,7 +126,7 @@ func (c *cmd) getFinishedItemsRadarr(_ context.Context) itemList { //nolint:cycl
 			appqueue = append(appqueue, &radarrRecord{QueueRecord: minimalRadarrRecord(item)}) //nolint:wsl
 		}
 
-		stuck[instance] = listItem{Name: app.Name, Queue: appqueue, Total: queue.TotalRecords}
+		stuck[instance] = listItem{Name: app.Name, Queue: appqueue, Total: len(appqueue)}
 		mnd.Log.Debugf("Checking Radarr (%d) Queue for Stuck Items, queue size: %d, stuck: %d",
 			instance, len(queue.Records), len(appqueue))
 	}
@@ -168,7 +168,7 @@ func (c *cmd) getFinishedItemsReadarr(_ context.Context) itemList { //nolint:cyc
 			appqueue = append(appqueue, &readarrRecord{QueueRecord: minimalReadarrRecord(item)}) //nolint:wsl
 		}
 
-		stuck[instance] = listItem{Name: app.Name, Queue: appqueue, Total: queue.TotalRecords}
+		stuck[instance] = listItem{Name: app.Name, Queue: appqueue, Total: len(appqueue)}
 		mnd.Log.Debugf("Checking Readarr (%d) Queue for Stuck Items, queue size: %d, stuck: %d",
 			instance, len(queue.Records), len(appqueue))
 	}
@@ -210,7 +210,7 @@ func (c *cmd) getFinishedItemsSonarr(_ context.Context) itemList { //nolint:cycl
 			appqueue = append(appqueue, &sonarrRecord{QueueRecord: minimalSonarrRecord(item)}) //nolint:wsl
 		}
 
-		stuck[instance] = listItem{Name: app.Name, Queue: appqueue, Total: queue.TotalRecords}
+		stuck[instance] = listItem{Name: app.Name, Queue: appqueue, Total: len(appqueue)}
 		mnd.Log.Debugf("Checking Sonarr (%d) Queue for Stuck Items, queue size: %d, stuck: %d",
 			instance, len(queue.Records), len(appqueue))
 	}


### PR DESCRIPTION
## Use actual item count for itemList.Total

- `listItem.Total` was set from `queue.TotalRecords` (full queue size) instead of the filtered item count
- `itemList.Len()` sums `Total` values, so `Empty()` returned false even when no items matched
- This caused payloads to be sent when there were no downloading/stuck items

## Changes

| File | Change |
|------|--------|
| `downloads.go` | `Total: len(lidarrQueue)` / `len(radarrQueue)` / `len(readarrQueue)` / `len(sonarrQueue)` |
| `stuckitems.go` | `Total: len(appqueue)` for all 4 apps |


Made with [Cursor](https://cursor.com)