### PR TITLE
dashboard: page Lidarr album stats collection to reduce memory spikes

### DIFF
--- a/pkg/triggers/dashboard/lidarr.go
+++ b/pkg/triggers/dashboard/lidarr.go
@@ -3,6 +3,8 @@ package dashboard
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"path"
 	"sort"
 	"time"
 
@@ -11,6 +13,8 @@ import (
 	"golift.io/starr"
 	"golift.io/starr/lidarr"
 )
+
+const lidarrAlbumPageSize = 500
 
 func (c *Cmd) getLidarrStates(ctx context.Context) []*State {
 	states := []*State{}
@@ -37,50 +41,43 @@ func (c *Cmd) getLidarrStates(ctx context.Context) []*State {
 func (c *Cmd) getLidarrState(ctx context.Context, instance int, app *apps.Lidarr) (*State, error) {
 	state := &State{Instance: instance, Next: []*Sortable{}, Name: app.Name}
 	start := time.Now()
-
-	albums, err := app.GetAlbumContext(ctx, "") // all albums
-	state.Elapsed.Duration = time.Since(start)
-
-	if err != nil {
-		return state, fmt.Errorf("getting albums from instance %d: %w", instance, err)
-	}
-
+	now := time.Now()
 	artistIDs := make(map[int64]struct{})
 
-	for _, album := range albums {
-		have := false
-		state.Albums++
+	for page := 1; ; page++ {
+		albums, totalRecords, err := c.getLidarrAlbumPageContext(ctx, app, page, lidarrAlbumPageSize)
+		if err != nil {
+			if page != 1 {
+				return state, fmt.Errorf("getting albums page %d from instance %d: %w", page, instance, err)
+			}
 
-		if album.Statistics != nil {
-			artistIDs[album.ArtistID] = struct{}{}
-			state.Percent += album.Statistics.PercentOfTracks
-			state.Size += int64(album.Statistics.SizeOnDisk)
-			state.Tracks += int64(album.Statistics.TotalTrackCount)
-			state.Missing += int64(album.Statistics.TrackCount - album.Statistics.TrackFileCount)
-			have = album.Statistics.TrackCount-album.Statistics.TrackFileCount < 1
-			state.OnDisk += int64(album.Statistics.TrackFileCount)
+			// Older Lidarr versions may not support paginated album responses.
+			albums, err = app.GetAlbumContext(ctx, "") // all albums
+			if err != nil {
+				return state, fmt.Errorf("getting albums from instance %d: %w", instance, err)
+			}
+
+			accumulateLidarrAlbumStats(state, artistIDs, albums, now)
+			break
 		}
 
-		if album.ReleaseDate.After(time.Now()) && album.Monitored && !have {
-			state.Next = append(state.Next, &Sortable{
-				id:   album.ID,
-				Name: album.Title,
-				Date: album.ReleaseDate,
-				Sub:  album.Artist.ArtistName,
-			})
+		if len(albums) == 0 {
+			break
+		}
+
+		accumulateLidarrAlbumStats(state, artistIDs, albums, now)
+
+		if len(albums) < lidarrAlbumPageSize || (totalRecords > 0 && page*lidarrAlbumPageSize >= totalRecords) {
+			break
 		}
 	}
 
-	if state.Tracks > 0 {
-		state.Percent /= float64(state.Tracks)
-	} else {
-		state.Percent = 100
-	}
-
-	state.Artists = len(artistIDs)
+	finalizeLidarrAlbumStats(state, artistIDs)
+	state.Elapsed.Duration = time.Since(start)
 	sort.Sort(dateSorter(state.Next))
 	state.Next.Shrink(showNext)
 
+	var err error
 	if state.Latest, err = c.getLidarrHistory(ctx, app); err != nil {
 		return state, fmt.Errorf("instance %d: %w", instance, err)
 	}
@@ -124,4 +121,72 @@ func (c *Cmd) getLidarrHistory(ctx context.Context, app *apps.Lidarr) ([]*Sortab
 	}
 
 	return table, nil
+}
+
+type lidarrAlbumPage struct {
+	TotalRecords int              `json:"totalRecords"`
+	Records      []*lidarr.Album  `json:"records"`
+}
+
+func (c *Cmd) getLidarrAlbumPageContext( //nolint:unparam
+	ctx context.Context,
+	app *apps.Lidarr,
+	page, pageSize int,
+) ([]*lidarr.Album, int, error) {
+	params := make(url.Values)
+	params.Set("page", starr.Str(page))
+	params.Set("pageSize", starr.Str(pageSize))
+	params.Set("sortKey", "id")
+	params.Set("sortDirection", string(starr.SortAscend))
+
+	resp := &lidarrAlbumPage{}
+	err := app.GetInto(ctx, starr.Request{
+		URI:   path.Join(lidarr.APIver, "album"),
+		Query: params,
+	}, resp)
+
+	return resp.Records, resp.TotalRecords, err
+}
+
+func applyLidarrAlbumStats(state *State, albums []*lidarr.Album, now func() time.Time) {
+	artistIDs := make(map[int64]struct{})
+
+	accumulateLidarrAlbumStats(state, artistIDs, albums, now())
+	finalizeLidarrAlbumStats(state, artistIDs)
+}
+
+func accumulateLidarrAlbumStats(state *State, artistIDs map[int64]struct{}, albums []*lidarr.Album, now time.Time) {
+	for _, album := range albums {
+		have := false
+		state.Albums++
+
+		if album.Statistics != nil {
+			artistIDs[album.ArtistID] = struct{}{}
+			state.Percent += album.Statistics.PercentOfTracks
+			state.Size += int64(album.Statistics.SizeOnDisk)
+			state.Tracks += int64(album.Statistics.TotalTrackCount)
+			state.Missing += int64(album.Statistics.TrackCount - album.Statistics.TrackFileCount)
+			have = album.Statistics.TrackCount-album.Statistics.TrackFileCount < 1
+			state.OnDisk += int64(album.Statistics.TrackFileCount)
+		}
+
+		if album.ReleaseDate.After(now) && album.Monitored && !have {
+			state.Next = append(state.Next, &Sortable{
+				id:   album.ID,
+				Name: album.Title,
+				Date: album.ReleaseDate,
+				Sub:  album.Artist.ArtistName,
+			})
+		}
+	}
+}
+
+func finalizeLidarrAlbumStats(state *State, artistIDs map[int64]struct{}) {
+	if state.Tracks > 0 {
+		state.Percent /= float64(state.Tracks)
+	} else {
+		state.Percent = 100
+	}
+
+	state.Artists = len(artistIDs)
 }

--- a/pkg/triggers/dashboard/lidarr_test.go
+++ b/pkg/triggers/dashboard/lidarr_test.go
@@ -1,0 +1,170 @@
+package dashboard
+
+import (
+	"testing"
+	"time"
+
+	"golift.io/starr/lidarr"
+)
+
+func TestApplyLidarrAlbumStatsAggregatesCounts(t *testing.T) {
+	now := time.Date(2026, 2, 16, 0, 0, 0, 0, time.UTC)
+	state := &State{Next: []*Sortable{}}
+
+	albums := []*lidarr.Album{
+		{
+			ID:         1,
+			ArtistID:   100,
+			Title:      "Future Missing",
+			Monitored:  true,
+			ReleaseDate: now.Add(24 * time.Hour),
+			Artist:     &lidarr.Artist{ArtistName: "Artist A"},
+			Statistics: &lidarr.Statistics{
+				PercentOfTracks: 50,
+				SizeOnDisk:      100,
+				TotalTrackCount: 10,
+				TrackCount:      10,
+				TrackFileCount:  8,
+			},
+		},
+		{
+			ID:         2,
+			ArtistID:   100,
+			Title:      "Future Complete",
+			Monitored:  true,
+			ReleaseDate: now.Add(48 * time.Hour),
+			Artist:     &lidarr.Artist{ArtistName: "Artist A"},
+			Statistics: &lidarr.Statistics{
+				PercentOfTracks: 100,
+				SizeOnDisk:      200,
+				TotalTrackCount: 5,
+				TrackCount:      5,
+				TrackFileCount:  5,
+			},
+		},
+		{
+			ID:          3,
+			ArtistID:    200,
+			Title:       "Future No Stats",
+			Monitored:   true,
+			ReleaseDate: now.Add(72 * time.Hour),
+			Artist:      &lidarr.Artist{ArtistName: "Artist B"},
+		},
+	}
+
+	applyLidarrAlbumStats(state, albums, func() time.Time { return now })
+
+	if state.Albums != 3 {
+		t.Fatalf("expected Albums=3, got %d", state.Albums)
+	}
+
+	if state.Artists != 1 {
+		t.Fatalf("expected Artists=1 (only stats-backed artists), got %d", state.Artists)
+	}
+
+	if state.Tracks != 15 {
+		t.Fatalf("expected Tracks=15, got %d", state.Tracks)
+	}
+
+	if state.Missing != 2 {
+		t.Fatalf("expected Missing=2, got %d", state.Missing)
+	}
+
+	if state.OnDisk != 13 {
+		t.Fatalf("expected OnDisk=13, got %d", state.OnDisk)
+	}
+
+	if state.Size != 300 {
+		t.Fatalf("expected Size=300, got %d", state.Size)
+	}
+
+	if state.Percent != 10 {
+		t.Fatalf("expected Percent=10, got %v", state.Percent)
+	}
+
+	if len(state.Next) != 2 {
+		t.Fatalf("expected 2 upcoming albums, got %d", len(state.Next))
+	}
+}
+
+func TestApplyLidarrAlbumStatsSetsPercentTo100WhenNoTracks(t *testing.T) {
+	now := time.Date(2026, 2, 16, 0, 0, 0, 0, time.UTC)
+	state := &State{Next: []*Sortable{}}
+
+	albums := []*lidarr.Album{
+		{
+			ID:          1,
+			ArtistID:    100,
+			Title:       "No Stats",
+			Monitored:   true,
+			ReleaseDate: now.Add(24 * time.Hour),
+			Artist:      &lidarr.Artist{ArtistName: "Artist A"},
+		},
+	}
+
+	applyLidarrAlbumStats(state, albums, func() time.Time { return now })
+
+	if state.Tracks != 0 {
+		t.Fatalf("expected Tracks=0, got %d", state.Tracks)
+	}
+
+	if state.Percent != 100 {
+		t.Fatalf("expected Percent=100 when no tracks are present, got %v", state.Percent)
+	}
+}
+
+func TestAccumulateLidarrAlbumStatsAcrossPages(t *testing.T) {
+	now := time.Date(2026, 2, 16, 0, 0, 0, 0, time.UTC)
+	state := &State{Next: []*Sortable{}}
+	artistIDs := map[int64]struct{}{}
+
+	accumulateLidarrAlbumStats(state, artistIDs, []*lidarr.Album{
+		{
+			ID:          1,
+			ArtistID:    100,
+			Title:       "Page One",
+			Monitored:   true,
+			ReleaseDate: now.Add(24 * time.Hour),
+			Artist:      &lidarr.Artist{ArtistName: "Artist A"},
+			Statistics: &lidarr.Statistics{
+				PercentOfTracks: 50,
+				SizeOnDisk:      100,
+				TotalTrackCount: 10,
+				TrackCount:      10,
+				TrackFileCount:  8,
+			},
+		},
+	}, now)
+
+	accumulateLidarrAlbumStats(state, artistIDs, []*lidarr.Album{
+		{
+			ID:          2,
+			ArtistID:    200,
+			Title:       "Page Two",
+			Monitored:   true,
+			ReleaseDate: now.Add(48 * time.Hour),
+			Artist:      &lidarr.Artist{ArtistName: "Artist B"},
+			Statistics: &lidarr.Statistics{
+				PercentOfTracks: 100,
+				SizeOnDisk:      200,
+				TotalTrackCount: 5,
+				TrackCount:      5,
+				TrackFileCount:  5,
+			},
+		},
+	}, now)
+
+	finalizeLidarrAlbumStats(state, artistIDs)
+
+	if state.Albums != 2 {
+		t.Fatalf("expected Albums=2, got %d", state.Albums)
+	}
+
+	if state.Artists != 2 {
+		t.Fatalf("expected Artists=2, got %d", state.Artists)
+	}
+
+	if state.Percent != 10 {
+		t.Fatalf("expected Percent=10, got %v", state.Percent)
+	}
+}


### PR DESCRIPTION
## Summary
- switch dashboard Lidarr state collection from one large `GetAlbumContext(ctx, "")` call to paged album requests
- process each page immediately and aggregate stats incrementally
- keep compatibility fallback to legacy full-album fetch if paged response is unavailable
- refactor album-stat logic into helper functions for easier testing

## Why
Issue #846 reports high memory usage and CPU spikes on large Lidarr libraries (example: ~53k albums). Pulling all albums into a single payload can create large short-lived allocations. Paging reduces peak memory pressure during dashboard state collection.

## Testing
- added unit tests in `pkg/triggers/dashboard/lidarr_test.go`:
  - `TestApplyLidarrAlbumStatsAggregatesCounts`
  - `TestApplyLidarrAlbumStatsSetsPercentTo100WhenNoTracks`
  - `TestAccumulateLidarrAlbumStatsAcrossPages`
- ran:
  - `go test ./pkg/triggers/dashboard`
  - result: `ok github.com/Notifiarr/notifiarr/pkg/triggers/dashboard`

## Notes
- behavior remains compatible for older Lidarr instances via fallback to existing full-album call on first-page paging failure.

Closes #846