### PR TITLE
fix(lint): preallocate slices to fix prealloc linter warnings

### DIFF
--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -139,7 +139,7 @@ func (s *Services) applyLocalOverrides(plexName string) {
 // loadServiceStates brings service states from the website into the fold.
 // In other words, states are stored in the website's database.
 func (s *Services) loadServiceStates(reqID string) {
-	names := []string{}
+	names := make([]string, 0, len(s.services))
 	for name := range s.services {
 		names = append(names, valuePrefix+name)
 	}

--- a/pkg/triggers/commands/setup.go
+++ b/pkg/triggers/commands/setup.go
@@ -65,7 +65,7 @@ func (c *Command) Run(input *common.ActionInput) {
 
 // List returns a list of active triggers that can be executed.
 func (a *Action) List() []*cmdconfig.Config {
-	output := []*cmdconfig.Config{}
+	output := make([]*cmdconfig.Config, 0, len(a.cmd.cmdlist))
 
 	for _, c := range a.cmd.cmdlist {
 		config := c.Config

--- a/pkg/triggers/common/scheduler/scheduler.go
+++ b/pkg/triggers/common/scheduler/scheduler.go
@@ -126,7 +126,7 @@ func (c *CronJob) fix() { //nolint:cyclop
 }
 
 func (a AtTimes) AtTimes() func() []gocron.AtTime {
-	output := []gocron.AtTime{}
+	output := make([]gocron.AtTime, 0, len(a))
 
 	for _, times := range a {
 		output = append(output, gocron.NewAtTime(times[fieldHours], times[fieldMinutes], times[fieldSeconds]))


### PR DESCRIPTION
## Summary
- Use `make()` with capacity hints instead of empty slice literals for slices appended to in loops with known sizes
- Fixes 3 `prealloc` linter warnings in `services.go`, `setup.go`, and `scheduler.go`

## Test plan
- [x] `golangci-lint run` passes with 0 issues
- [x] `go test ./...` passes