### PR TITLE
chore(github): add issue form templates with issue types

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,85 @@
+name: Bug Report
+description: File a bug report to help us improve the Notifiarr client
+title: "Bug - "
+labels: ["bug", "triage"]
+type: Bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Bug Report
+        Thanks for taking the time to fill out this bug report!
+        Please fill out the information below as detailed as possible.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description of the bug
+      description: A clear and concise description of what the bug is.
+      placeholder: Tell us what happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+      placeholder: Tell us what should have happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+
+  - type: input
+    id: client-version
+    attributes:
+      label: Notifiarr Client Version
+      description: |
+        What version of the Notifiarr client are you running?
+        You can find it in the web UI footer or by running `notifiarr --version`.
+      placeholder: "v0.8.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: How are you running the Notifiarr client?
+      options:
+        - Docker
+        - Linux (package)
+        - Windows
+        - macOS
+        - FreeBSD
+        - Synology
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: |
+        Paste any relevant client log output. This will be automatically formatted, so no need for backticks.
+      render: shell
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here (screenshots, config snippets, etc.).
+      placeholder: Any additional information...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Notifiarr Discord
+    url: https://notifiarr.com/discord
+    about: For support, questions, and general help, please join our Discord server.
+  - name: Notifiarr Wiki
+    url: https://notifiarr.wiki
+    about: Client installation, configuration, and troubleshooting documentation.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,46 @@
+name: Feature Request
+description: Suggest an idea or enhancement for the Notifiarr client
+title: "FR - "
+labels: ["enhancement", "triage"]
+type: Feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Feature Request
+        Thanks for taking the time to suggest a new feature!
+        Please fill out the information below as detailed as possible.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Description
+      description: Is your feature request related to a problem? Please describe.
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like to see implemented.
+      placeholder: It would be great if...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe any alternative solutions or features you've considered.
+      placeholder: I've thought about...
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context, screenshots, or examples about the feature request.
+      placeholder: Any additional information...


### PR DESCRIPTION
Adds GitHub issue form templates to the Notifiarr client repo (there were none).

- **bug_report.yml** — `type: Bug`, labels `bug`/`triage`, fields for description, expected behavior, repro steps, client version, platform, logs.
- **feature_request.yml** — `type: Feature`, labels `enhancement`/`triage`.
- **config.yml** — disables blank issues; routes support to [Discord](https://notifiarr.com/discord) and the [Wiki](https://notifiarr.wiki).

Both forms set the org-level issue type via the new top-level `type:` key (Notifiarr org has Bug/Feature/Task defined).