### PR TITLE
fix: preserve MySQL hostnames in service checks

### DIFF
--- a/pkg/services/apps.go
+++ b/pkg/services/apps.go
@@ -455,7 +455,7 @@ func collectMySQLApps(svcs []*Service, mysql []snapshot.MySQLConfig) []*Service 
 			interval.Duration = MinimumCheckInterval
 		}
 
-		host := strings.TrimLeft(strings.TrimRight(app.Host, ")"), "@tcp(")
+		host := strings.TrimSuffix(strings.TrimPrefix(app.Host, "@tcp("), ")")
 		if app.Name == "" || host == "" || strings.HasPrefix(host, "@") {
 			continue
 		}

--- a/pkg/services/apps_test.go
+++ b/pkg/services/apps_test.go
@@ -1,0 +1,31 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Notifiarr/notifiarr/pkg/snapshot"
+	"golift.io/cnfg"
+)
+
+func TestCollectMySQLAppsPreservesHostnames(t *testing.T) {
+	t.Parallel()
+
+	mysql := []snapshot.MySQLConfig{
+		{Name: "privatebin", Host: "privatebin-mariadb", Timeout: cnfg.Duration{Duration: time.Second}},
+		{Name: "loopback", Host: "@tcp(127.0.0.1:3306)", Timeout: cnfg.Duration{Duration: time.Second}},
+	}
+
+	svcs := collectMySQLApps(nil, mysql)
+	if len(svcs) != 2 {
+		t.Fatalf("expected 2 service checks, got %d", len(svcs))
+	}
+
+	if got, want := svcs[0].Value, "privatebin-mariadb:3306"; got != want {
+		t.Fatalf("privatebin host name mismatch: got %q, want %q", got, want)
+	}
+
+	if got, want := svcs[1].Value, "127.0.0.1:3306"; got != want {
+		t.Fatalf("tcp host value mismatch: got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
This fixes a hostname regression in MySQL service checks. `@tcp(...)` values were being trimmed with a string cutset, which removed letters from valid hostnames like `privatebin-mariadb` and produced broken DNS lookups such as `rivatebin-mariadb`.

The fix strips only the explicit `@tcp(` prefix and trailing `)` suffix, preserving the actual hostname while still handling the existing TCP wrapper format. I also added a focused regression test covering both plain hostnames and `@tcp(...)` inputs.

Validation:
- `PATH=/tmp/go/bin:$PATH go test ./pkg/services ./pkg/cooldown`