### PR TITLE
Fix service checks and add tests

### DIFF
--- a/pkg/apps/setup.go
+++ b/pkg/apps/setup.go
@@ -85,6 +85,9 @@ type StarrApp struct {
 	delLimit *rate.Limiter
 }
 
+// Starr returns the embedded Starr app config. Promoted onto Lidarr/Radarr/etc.
+func (e StarrApp) Starr() StarrApp { return e }
+
 // Errors sent to client web requests.
 var (
 	ErrNoTMDB     = errors.New("TMDB ID must not be empty")

--- a/pkg/services/apps.go
+++ b/pkg/services/apps.go
@@ -3,7 +3,6 @@ package services
 import (
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/Notifiarr/notifiarr/pkg/apps"
 	"github.com/Notifiarr/notifiarr/pkg/snapshot"
@@ -35,13 +34,9 @@ func (s *Services) AddApps(apps *apps.Apps, mysql []snapshot.MySQLConfig) {
 	svcs = collectTautulliApps(svcs, apps.Tautulli)
 	svcs = collectPlexApps(svcs, &apps.Plex)
 	svcs = collectMySQLApps(svcs, mysql)
-	now := time.Now()
 
 	for _, svc := range svcs {
 		svc.validated = true
-		svc.log = s.log
-		svc.State = StateUnknown
-		svc.Since = now
 		s.add(svc.ServiceConfig)
 	}
 }
@@ -233,13 +228,17 @@ func collectNZBGetApps(svcs []*Service, nzbget []apps.NZBGet) []*Service {
 			interval.Duration = MinimumCheckInterval
 		}
 
-		prefix := "" // add auth to the url here. woo, hacky, but it works!
-
+		checkURL := app.URL
 		if !strings.Contains(app.URL, "@") {
 			user := url.PathEscape(app.User) + ":" + url.PathEscape(app.Pass) + "@"
-			if prefix = "http://" + user; strings.HasPrefix(app.URL, "https://") {
-				prefix = "https://" + user
+			scheme := "http://"
+
+			if strings.HasPrefix(app.URL, "https://") {
+				scheme = "https://"
 			}
+
+			host := strings.TrimPrefix(strings.TrimPrefix(app.URL, "https://"), "http://")
+			checkURL = scheme + user + host
 		}
 
 		if app.Name != "" {
@@ -248,7 +247,7 @@ func collectNZBGetApps(svcs []*Service, nzbget []apps.NZBGet) []*Service {
 					validSSL: app.ValidSSL,
 					Name:     app.Name,
 					Type:     CheckHTTP,
-					Value:    prefix + strings.TrimPrefix(strings.TrimPrefix(app.URL, "https://"), "http://"),
+					Value:    checkURL,
 					Expect:   "200",
 					Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
 					Interval: interval,
@@ -338,9 +337,9 @@ func collectSabNZBApps(svcs []*Service, sabnzb []apps.SabNZB) []*Service {
 					validSSL: app.ValidSSL,
 					Name:     app.Name,
 					Type:     CheckHTTP,
-					Value:    app.SabNZB.URL + "/api?mode=version&apikey=" + app.SabNZB.APIKey,
+					Value:    app.SabNZBConfig.URL + "/api?mode=version&apikey=" + app.SabNZBConfig.APIKey,
 					Expect:   "200",
-					Timeout:  cnfg.Duration{Duration: app.SabNZB.Timeout},
+					Timeout:  app.ExtraConfig.Timeout,
 					Interval: interval,
 				},
 			})
@@ -401,7 +400,7 @@ func collectTautulliApps(svcs []*Service, app apps.Tautulli) []*Service {
 			validSSL: app.ValidSSL,
 			Name:     app.Name,
 			Type:     CheckHTTP,
-			Value:    app.Tautulli.URL + "/api/v2?cmd=status&apikey=" + app.Tautulli.APIKey,
+			Value:    app.TautulliConfig.URL + "/api/v2?cmd=status&apikey=" + app.TautulliConfig.APIKey,
 			Expect:   "200",
 			Timeout:  app.ExtraConfig.Timeout,
 			Interval: interval,
@@ -426,7 +425,7 @@ func collectPlexApps(svcs []*Service, app *apps.Plex) []*Service {
 			validSSL: app.ValidSSL,
 			Name:     PlexServerName,
 			Type:     CheckHTTP,
-			Value:    app.Server.URL + "|X-Plex-Token:" + app.Server.Token,
+			Value:    app.PlexConfig.URL + "|X-Plex-Token:" + app.PlexConfig.Token,
 			Expect:   "200",
 			Timeout:  app.Timeout,
 			Interval: interval,

--- a/pkg/services/apps.go
+++ b/pkg/services/apps.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Notifiarr/notifiarr/pkg/apps"
 	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/Notifiarr/notifiarr/pkg/snapshot"
-	"golift.io/cnfg"
 )
 
 // PlexServerName is hard coded as the service name for Plex.
@@ -18,14 +17,19 @@ const (
 	starrV1StatusURI = "/api/v1/system/status|X-API-Key:"
 )
 
+type starrChecker interface {
+	Enabled() bool
+	Starr() apps.StarrApp
+}
+
 // AddApps turns app configs into service checks if they have a name.
 func (s *Services) AddApps(apps *apps.Apps, mysql []snapshot.MySQLConfig) {
 	svcs := []*Service{}
-	svcs = collectLidarrApps(svcs, apps.Lidarr)
-	svcs = collectProwlarrApps(svcs, apps.Prowlarr)
-	svcs = collectRadarrApps(svcs, apps.Radarr)
-	svcs = collectReadarrApps(svcs, apps.Readarr)
-	svcs = collectSonarrApps(svcs, apps.Sonarr)
+	svcs = collectStarrApps(svcs, apps.Lidarr, starrV1StatusURI)
+	svcs = collectStarrApps(svcs, apps.Prowlarr, starrV1StatusURI)
+	svcs = collectStarrApps(svcs, apps.Radarr, starrV3StatusURI)
+	svcs = collectStarrApps(svcs, apps.Readarr, starrV1StatusURI)
+	svcs = collectStarrApps(svcs, apps.Sonarr, starrV3StatusURI)
 	svcs = collectDelugeApps(svcs, apps.Deluge)
 	svcs = collectNZBGetApps(svcs, apps.NZBGet)
 	svcs = collectQbittorrentApps(svcs, apps.Qbit)
@@ -46,324 +50,124 @@ func (s *Services) AddApps(apps *apps.Apps, mysql []snapshot.MySQLConfig) {
 	}
 }
 
-func collectLidarrApps(svcs []*Service, lidarr []apps.Lidarr) []*Service {
-	for _, app := range lidarr {
-		if !app.Enabled() || app.Name == "" {
+func collectStarrApps[T starrChecker](svcs []*Service, list []T, statusURI string) []*Service {
+	for _, app := range list {
+		if !app.Enabled() {
 			continue
 		}
 
-		interval := app.Interval
-		if interval.Duration != 0 && interval.Duration < MinimumCheckInterval {
-			interval.Duration = MinimumCheckInterval
-		}
-
-		if app.Name != "" {
-			svcs = append(svcs, &Service{
-				ServiceConfig: &ServiceConfig{
-					validSSL: app.ValidSSL,
-					Name:     app.Name,
-					Type:     CheckHTTP,
-					Value:    app.URL + starrV1StatusURI + app.APIKey,
-					Expect:   "200",
-					Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-					Interval: interval,
-				},
-			})
-		}
+		starr := app.Starr()
+		svcs = appendHTTPCheck(svcs, starr.ExtraConfig, starr.URL+statusURI+starr.APIKey, "200")
 	}
 
 	return svcs
 }
 
-func collectProwlarrApps(svcs []*Service, prowlarr []apps.Prowlarr) []*Service {
-	for _, app := range prowlarr {
-		if !app.Enabled() || app.Name == "" {
-			continue
-		}
-
-		interval := app.Interval
-		if interval.Duration != 0 && interval.Duration < MinimumCheckInterval {
-			interval.Duration = MinimumCheckInterval
-		}
-
-		if app.Name != "" {
-			svcs = append(svcs, &Service{
-				ServiceConfig: &ServiceConfig{
-					validSSL: app.ValidSSL,
-					Name:     app.Name,
-					Type:     CheckHTTP,
-					Value:    app.URL + starrV1StatusURI + app.APIKey,
-					Expect:   "200",
-					Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-					Interval: interval,
-				},
-			})
-		}
+func appendHTTPCheck(svcs []*Service, extra apps.ExtraConfig, value, expect string) []*Service {
+	if extra.Name == "" || extra.Interval.Duration < 0 {
+		return svcs
 	}
 
-	return svcs
-}
-
-func collectRadarrApps(svcs []*Service, radarr []apps.Radarr) []*Service {
-	for _, app := range radarr {
-		if !app.Enabled() || app.Name == "" {
-			continue
-		}
-
-		interval := app.Interval
-		if interval.Duration != 0 && interval.Duration < MinimumCheckInterval {
-			interval.Duration = MinimumCheckInterval
-		}
-
-		if app.Name != "" {
-			svcs = append(svcs, &Service{
-				ServiceConfig: &ServiceConfig{
-					validSSL: app.ValidSSL,
-					Name:     app.Name,
-					Type:     CheckHTTP,
-					Value:    app.URL + starrV3StatusURI + app.APIKey,
-					Expect:   "200",
-					Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-					Interval: interval,
-				},
-			})
-		}
+	interval := extra.Interval
+	if interval.Duration != 0 && interval.Duration < MinimumCheckInterval {
+		interval.Duration = MinimumCheckInterval
 	}
 
-	return svcs
-}
-
-func collectReadarrApps(svcs []*Service, readarr []apps.Readarr) []*Service {
-	for _, app := range readarr {
-		if !app.Enabled() || app.Name == "" {
-			continue
-		}
-
-		interval := app.Interval
-		if interval.Duration != 0 && interval.Duration < MinimumCheckInterval {
-			interval.Duration = MinimumCheckInterval
-		}
-
-		if app.Name != "" {
-			svcs = append(svcs, &Service{
-				ServiceConfig: &ServiceConfig{
-					validSSL: app.ValidSSL,
-					Name:     app.Name,
-					Type:     CheckHTTP,
-					Value:    app.URL + starrV1StatusURI + app.APIKey,
-					Expect:   "200",
-					Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-					Interval: interval,
-				},
-			})
-		}
-	}
-
-	return svcs
-}
-
-func collectSonarrApps(svcs []*Service, sonarr []apps.Sonarr) []*Service {
-	for _, app := range sonarr {
-		if !app.Enabled() || app.Name == "" {
-			continue
-		}
-
-		interval := app.Interval
-		if interval.Duration != 0 && interval.Duration < MinimumCheckInterval {
-			interval.Duration = MinimumCheckInterval
-		}
-
-		if app.Name != "" {
-			svcs = append(svcs, &Service{
-				ServiceConfig: &ServiceConfig{
-					validSSL: app.ValidSSL,
-					Name:     app.Name,
-					Type:     CheckHTTP,
-					Value:    app.URL + starrV3StatusURI + app.APIKey,
-					Expect:   "200",
-					Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-					Interval: interval,
-				},
-			})
-		}
-	}
-
-	return svcs
+	return append(svcs, &Service{
+		ServiceConfig: &ServiceConfig{
+			validSSL: extra.ValidSSL,
+			Name:     extra.Name,
+			Type:     CheckHTTP,
+			Value:    value,
+			Expect:   expect,
+			Timeout:  extra.Timeout,
+			Interval: interval,
+		},
+	})
 }
 
 func collectDelugeApps(svcs []*Service, deluge []apps.Deluge) []*Service {
-	// Deluge instanceapp.
 	for _, app := range deluge {
-		if !app.Enabled() || app.Name == "" {
+		if !app.Enabled() {
 			continue
 		}
 
-		interval := app.Interval
-		if interval.Duration != 0 && interval.Duration < MinimumCheckInterval {
-			interval.Duration = MinimumCheckInterval
-		}
-
-		if app.Name != "" {
-			svcs = append(svcs, &Service{
-				ServiceConfig: &ServiceConfig{
-					validSSL: app.ValidSSL,
-					Name:     app.Name,
-					Type:     CheckHTTP,
-					Value:    strings.TrimSuffix(app.URL, "/json"),
-					Expect:   "200",
-					Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-					Interval: interval,
-				},
-			})
-		}
+		svcs = appendHTTPCheck(svcs, app.ExtraConfig, strings.TrimSuffix(app.URL, "/json"), "200")
 	}
 
 	return svcs
 }
 
 func collectNZBGetApps(svcs []*Service, nzbget []apps.NZBGet) []*Service {
-	// NZBGet instances.
 	for _, app := range nzbget {
-		if !app.Enabled() || app.Name == "" {
+		if !app.Enabled() {
 			continue
 		}
 
-		interval := app.Interval
-		if interval.Duration != 0 && interval.Duration < MinimumCheckInterval {
-			interval.Duration = MinimumCheckInterval
-		}
-
-		checkURL := app.URL
-		if !strings.Contains(app.URL, "@") {
-			user := url.PathEscape(app.User) + ":" + url.PathEscape(app.Pass) + "@"
-			scheme := "http://"
-
-			if strings.HasPrefix(app.URL, "https://") {
-				scheme = "https://"
-			}
-
-			host := strings.TrimPrefix(strings.TrimPrefix(app.URL, "https://"), "http://")
-			checkURL = scheme + user + host
-		}
-
-		if app.Name != "" {
-			svcs = append(svcs, &Service{
-				ServiceConfig: &ServiceConfig{
-					validSSL: app.ValidSSL,
-					Name:     app.Name,
-					Type:     CheckHTTP,
-					Value:    checkURL,
-					Expect:   "200",
-					Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-					Interval: interval,
-				},
-			})
-		}
+		svcs = appendHTTPCheck(svcs, app.ExtraConfig, nzbgetCheckURL(app), "200")
 	}
 
 	return svcs
 }
 
+func nzbgetCheckURL(app apps.NZBGet) string {
+	if strings.Contains(app.URL, "@") {
+		return app.URL
+	}
+
+	user := url.PathEscape(app.User) + ":" + url.PathEscape(app.Pass) + "@"
+	scheme := "http://"
+
+	if strings.HasPrefix(app.URL, "https://") {
+		scheme = "https://"
+	}
+
+	host := strings.TrimPrefix(strings.TrimPrefix(app.URL, "https://"), "http://")
+
+	return scheme + user + host
+}
+
 func collectQbittorrentApps(svcs []*Service, qbit []apps.Qbit) []*Service {
-	// Qbittorrent instanceapp.
 	for _, app := range qbit {
-		if !app.Enabled() || app.Name == "" || app.Interval.Duration < 0 {
+		if !app.Enabled() {
 			continue
 		}
 
-		interval := app.Interval
-		if interval.Duration != 0 && interval.Duration < MinimumCheckInterval {
-			interval.Duration = MinimumCheckInterval
-		}
-
-		if app.Name != "" {
-			svcs = append(svcs, &Service{
-				ServiceConfig: &ServiceConfig{
-					validSSL: app.ValidSSL,
-					Name:     app.Name,
-					Type:     CheckHTTP,
-					Value:    app.URL,
-					Expect:   "200",
-					Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-					Interval: interval,
-				},
-			})
-		}
+		svcs = appendHTTPCheck(svcs, app.ExtraConfig, app.URL, "200")
 	}
 
 	return svcs
 }
 
 func collectRtorrentApps(svcs []*Service, rtorrent []apps.Rtorrent) []*Service {
-	// rTorrent instanceapp.
 	for _, app := range rtorrent {
-		if !app.Enabled() || app.Name == "" || app.Interval.Duration < 0 {
+		if !app.Enabled() {
 			continue
 		}
 
-		interval := app.Interval
-		if interval.Duration != 0 && interval.Duration < MinimumCheckInterval {
-			interval.Duration = MinimumCheckInterval
-		}
-
-		if app.Name != "" {
-			svcs = append(svcs, &Service{
-				ServiceConfig: &ServiceConfig{
-					validSSL: app.ValidSSL,
-					Name:     app.Name,
-					Type:     CheckHTTP,
-					Value:    app.URL,
-					Expect:   "200,401", // could not find a 200...
-					Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-					Interval: interval,
-				},
-			})
-		}
+		svcs = appendHTTPCheck(svcs, app.ExtraConfig, app.URL, "200,401")
 	}
 
 	return svcs
 }
 
 func collectSabNZBApps(svcs []*Service, sabnzb []apps.SabNZB) []*Service {
-	// SabNBZd instanceapp.
 	for _, app := range sabnzb {
-		if !app.Enabled() || app.Name == "" || app.Interval.Duration < 0 {
+		if !app.Enabled() {
 			continue
 		}
 
-		interval := app.Interval
-		if interval.Duration != 0 && interval.Duration < MinimumCheckInterval {
-			interval.Duration = MinimumCheckInterval
-		}
-
-		if app.Name != "" {
-			svcs = append(svcs, &Service{
-				ServiceConfig: &ServiceConfig{
-					validSSL: app.ValidSSL,
-					Name:     app.Name,
-					Type:     CheckHTTP,
-					Value:    app.SabNZBConfig.URL + "/api?mode=version&apikey=" + app.SabNZBConfig.APIKey,
-					Expect:   "200",
-					Timeout:  app.ExtraConfig.Timeout,
-					Interval: interval,
-				},
-			})
-		}
+		svcs = appendHTTPCheck(svcs, app.ExtraConfig,
+			app.SabNZBConfig.URL+"/api?mode=version&apikey="+app.SabNZBConfig.APIKey, "200")
 	}
 
 	return svcs
 }
 
 func collectXmissionApps(svcs []*Service, xmission []apps.Xmission) []*Service {
-	// Transmission instances.
 	for _, app := range xmission {
-		if !app.Enabled() || app.Name == "" || app.Interval.Duration < 0 {
+		if !app.Enabled() {
 			continue
-		}
-
-		interval := app.Interval
-		if interval.Duration != 0 && interval.Duration < MinimumCheckInterval {
-			interval.Duration = MinimumCheckInterval
 		}
 
 		expect := "401"
@@ -371,73 +175,30 @@ func collectXmissionApps(svcs []*Service, xmission []apps.Xmission) []*Service {
 			expect = "409"
 		}
 
-		if app.Name != "" {
-			svcs = append(svcs, &Service{
-				ServiceConfig: &ServiceConfig{
-					validSSL: app.ValidSSL,
-					Name:     app.Name,
-					Type:     CheckHTTP,
-					Value:    app.URL,
-					Expect:   expect, // no 200 from RPC endpoint.
-					Timeout:  cnfg.Duration{Duration: app.Timeout.Duration},
-					Interval: interval,
-				},
-			})
-		}
+		svcs = appendHTTPCheck(svcs, app.ExtraConfig, app.URL, expect)
 	}
 
 	return svcs
 }
 
 func collectTautulliApps(svcs []*Service, app apps.Tautulli) []*Service {
-	// Tautulli instance (1).
-	if !app.Enabled() || app.Name == "" || app.Interval.Duration < 0 {
+	if !app.Enabled() {
 		return svcs
 	}
 
-	interval := app.Interval
-	if interval.Duration != 0 && interval.Duration < MinimumCheckInterval {
-		interval.Duration = MinimumCheckInterval
-	}
-
-	svcs = append(svcs, &Service{
-		ServiceConfig: &ServiceConfig{
-			validSSL: app.ValidSSL,
-			Name:     app.Name,
-			Type:     CheckHTTP,
-			Value:    app.TautulliConfig.URL + "/api/v2?cmd=status&apikey=" + app.TautulliConfig.APIKey,
-			Expect:   "200",
-			Timeout:  app.ExtraConfig.Timeout,
-			Interval: interval,
-		},
-	})
-
-	return svcs
+	return appendHTTPCheck(svcs, app.ExtraConfig,
+		app.TautulliConfig.URL+"/api/v2?cmd=status&apikey="+app.TautulliConfig.APIKey, "200")
 }
 
 func collectPlexApps(svcs []*Service, app *apps.Plex) []*Service {
-	if !app.Enabled() || app.Interval.Duration < 0 {
+	if !app.Enabled() {
 		return svcs
 	}
 
-	interval := app.Interval
-	if interval.Duration != 0 && interval.Duration < MinimumCheckInterval {
-		interval.Duration = MinimumCheckInterval
-	}
+	extra := app.ExtraConfig
+	extra.Name = PlexServerName
 
-	svcs = append(svcs, &Service{
-		ServiceConfig: &ServiceConfig{
-			validSSL: app.ValidSSL,
-			Name:     PlexServerName,
-			Type:     CheckHTTP,
-			Value:    app.PlexConfig.URL + "|X-Plex-Token:" + app.PlexConfig.Token,
-			Expect:   "200",
-			Timeout:  app.Timeout,
-			Interval: interval,
-		},
-	})
-
-	return svcs
+	return appendHTTPCheck(svcs, extra, app.PlexConfig.URL+"|X-Plex-Token:"+app.PlexConfig.Token, "200")
 }
 
 func collectMySQLApps(svcs []*Service, mysql []snapshot.MySQLConfig) []*Service { //nolint:cyclop

--- a/pkg/services/apps.go
+++ b/pkg/services/apps.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/Notifiarr/notifiarr/pkg/apps"
+	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/Notifiarr/notifiarr/pkg/snapshot"
 	"golift.io/cnfg"
 )
@@ -36,7 +37,11 @@ func (s *Services) AddApps(apps *apps.Apps, mysql []snapshot.MySQLConfig) {
 	svcs = collectMySQLApps(svcs, mysql)
 
 	for _, svc := range svcs {
-		svc.validated = true
+		if err := svc.Validate(); err != nil {
+			mnd.Log.Errorf("called", "Skipping invalid app service check %s: %v", svc.Name, err)
+			continue
+		}
+
 		s.add(svc.ServiceConfig)
 	}
 }

--- a/pkg/services/apps_test.go
+++ b/pkg/services/apps_test.go
@@ -1,31 +1,283 @@
-package services
+package services_test
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
+	"github.com/Notifiarr/notifiarr/pkg/apps"
+	"github.com/Notifiarr/notifiarr/pkg/apps/apppkg/plex"
+	"github.com/Notifiarr/notifiarr/pkg/apps/apppkg/sabnzbd"
+	"github.com/Notifiarr/notifiarr/pkg/apps/apppkg/tautulli"
+	"github.com/Notifiarr/notifiarr/pkg/services"
 	"github.com/Notifiarr/notifiarr/pkg/snapshot"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golift.io/cnfg"
+	"golift.io/deluge"
+	"golift.io/nzbget"
+	"golift.io/qbit"
 )
 
 func TestCollectMySQLAppsPreservesHostnames(t *testing.T) {
 	t.Parallel()
+	assert := assert.New(t)
 
 	mysql := []snapshot.MySQLConfig{
 		{Name: "privatebin", Host: "privatebin-mariadb", Timeout: cnfg.Duration{Duration: time.Second}},
 		{Name: "loopback", Host: "@tcp(127.0.0.1:3306)", Timeout: cnfg.Duration{Duration: time.Second}},
 	}
 
-	svcs := collectMySQLApps(nil, mysql)
-	if len(svcs) != 2 {
-		t.Fatalf("expected 2 service checks, got %d", len(svcs))
-	}
+	svc := services.New(&services.Config{})
+	svc.AddApps(&apps.Apps{}, mysql)
 
-	if got, want := svcs[0].Value, "privatebin-mariadb:3306"; got != want {
-		t.Fatalf("privatebin host name mismatch: got %q, want %q", got, want)
-	}
+	results := svc.GetResults()
+	assert.Len(results, 2, "expected 2 service checks")
 
-	if got, want := svcs[1].Value, "127.0.0.1:3306"; got != want {
-		t.Fatalf("tcp host value mismatch: got %q, want %q", got, want)
+	got := resultsByName(results)
+	assert.Equal("privatebin-mariadb:3306", got["privatebin"].Check, "privatebin host name mismatch")
+	assert.Equal("127.0.0.1:3306", got["loopback"].Check, "tcp host value mismatch")
+	assert.Equal(services.CheckTCP, got["privatebin"].Type)
+	assert.Equal(services.StateUnknown, got["privatebin"].State)
+}
+
+func collectorApps() *apps.Apps { //nolint:funlen
+	shortInterval := time.Second
+	plexCfg := plex.Config{URL: "http://plex.example", Token: "plextok"}
+	tautCfg := tautulli.Config{URL: "http://tautulli.example", APIKey: "tautkey"}
+	sabCfg := sabnzbd.Config{URL: "http://sab.example", APIKey: "sabkey"}
+
+	return &apps.Apps{
+		Lidarr:   []apps.Lidarr{{StarrApp: starrApp("Lidarr", "http://lidarr.example", "lidkey", shortInterval)}},
+		Prowlarr: []apps.Prowlarr{{StarrApp: starrApp("Prowlarr", "http://prowlarr.example", "prowlkey", 0)}},
+		Radarr:   []apps.Radarr{{StarrApp: starrApp("Radarr", "http://radarr.example", "radkey", 0)}},
+		Readarr:  []apps.Readarr{{StarrApp: starrApp("Readarr", "http://readarr.example", "readkey", 0)}},
+		Sonarr:   []apps.Sonarr{{StarrApp: starrApp("Sonarr", "http://sonarr.example", "sonkey", 0)}},
+		Deluge: []apps.Deluge{{
+			DelugeConfig: apps.DelugeConfig{
+				ExtraConfig: extraConfig("Deluge", 0),
+				Config:      deluge.Config{URL: "http://deluge.example/json"},
+			},
+		}},
+		NZBGet: []apps.NZBGet{{
+			NZBGetConfig: apps.NZBGetConfig{
+				ExtraConfig: extraConfig("NZBGet", 0),
+				Config:      nzbget.Config{URL: "http://nzbget.example", User: "nzb user", Pass: "p@ss"},
+			},
+		}},
+		Qbit: []apps.Qbit{{
+			QbitConfig: apps.QbitConfig{
+				ExtraConfig: extraConfig("qBittorrent", 0),
+				Config:      qbit.Config{URL: "http://qbit.example"},
+			},
+		}},
+		Rtorrent: []apps.Rtorrent{{
+			RtorrentConfig: apps.RtorrentConfig{
+				ExtraConfig: extraConfig("rTorrent", 0),
+				URL:         "http://rtorrent.example",
+			},
+		}},
+		SabNZB: []apps.SabNZB{{
+			SabNZBConfig: apps.SabNZBConfig{
+				ExtraConfig: extraConfig("SABnzbd", 0),
+				Config:      &sabCfg,
+			},
+			SabNZB: sabnzbd.New(sabCfg, &http.Client{Timeout: time.Second}),
+		}},
+		Transmission: []apps.Xmission{
+			{
+				XmissionConfig: apps.XmissionConfig{
+					URL:         "http://transmission.example",
+					User:        "user",
+					ExtraConfig: extraConfig("TransmissionAuth", 0),
+				},
+			},
+			{
+				XmissionConfig: apps.XmissionConfig{
+					URL:         "http://transmission-open.example",
+					ExtraConfig: extraConfig("TransmissionOpen", 0),
+				},
+			},
+		},
+		Tautulli: apps.Tautulli{
+			TautulliConfig: apps.TautulliConfig{
+				ExtraConfig: extraConfig("Tautulli", shortInterval),
+				Config:      tautCfg,
+			},
+			Tautulli: tautulli.New(tautCfg, http.DefaultClient),
+		},
+		Plex: apps.Plex{
+			PlexConfig: apps.PlexConfig{
+				Config:      plexCfg,
+				ExtraConfig: extraConfig("", 0),
+			},
+			Server: *plex.New(&plexCfg, nil),
+		},
 	}
+}
+
+func TestAddAppsCollectors(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	svc := services.New(&services.Config{})
+	svc.AddApps(collectorApps(), nil)
+
+	got := resultsByName(svc.GetResults())
+	assert.Equal(14, svc.SvcCount())
+
+	assert.Equal("http://lidarr.example/api/v1/system/status|X-API-Key:lidkey", got["Lidarr"].Check)
+	assert.Equal(services.MinimumCheckInterval, got["Lidarr"].IntervalDur, "short intervals bump to the minimum")
+	assert.Equal("http://prowlarr.example/api/v1/system/status|X-API-Key:prowlkey", got["Prowlarr"].Check)
+	assert.Equal("http://radarr.example/api/v3/system/status|X-API-Key:radkey", got["Radarr"].Check)
+	assert.Equal("http://readarr.example/api/v1/system/status|X-API-Key:readkey", got["Readarr"].Check)
+	assert.Equal("http://sonarr.example/api/v3/system/status|X-API-Key:sonkey", got["Sonarr"].Check)
+	assert.Equal("http://deluge.example", got["Deluge"].Check, "deluge /json suffix is stripped")
+	assert.Equal("http://nzb%20user:p@ss@nzbget.example", got["NZBGet"].Check)
+	assert.Equal("http://qbit.example", got["qBittorrent"].Check)
+	assert.Equal("http://rtorrent.example", got["rTorrent"].Check)
+	assert.Equal("200,401", got["rTorrent"].Expect)
+	assert.Equal("http://sab.example/api?mode=version&apikey=sabkey", got["SABnzbd"].Check)
+	assert.Equal("401", got["TransmissionAuth"].Expect)
+	assert.Equal("409", got["TransmissionOpen"].Expect)
+	assert.Equal("http://tautulli.example/api/v2?cmd=status&apikey=tautkey", got["Tautulli"].Check)
+	assert.Equal(services.MinimumCheckInterval, got["Tautulli"].IntervalDur)
+	assert.Equal(services.PlexServerName, got[services.PlexServerName].Name)
+	assert.Equal("http://plex.example|X-Plex-Token:plextok", got[services.PlexServerName].Check)
+	assert.Equal("200", got["Lidarr"].Expect)
+	assert.Equal(services.CheckHTTP, got["Lidarr"].Type)
+}
+
+func TestAddAppsNZBGetURLVariants(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	svc := services.New(&services.Config{})
+	svc.AddApps(&apps.Apps{
+		NZBGet: []apps.NZBGet{
+			{
+				NZBGetConfig: apps.NZBGetConfig{
+					ExtraConfig: extraConfig("AlreadyAuthed", 0),
+					Config:      nzbget.Config{URL: "https://user:pass@nzbget.example", User: "ignored", Pass: "ignored"},
+				},
+			},
+			{
+				NZBGetConfig: apps.NZBGetConfig{
+					ExtraConfig: extraConfig("HTTPS", 0),
+					Config:      nzbget.Config{URL: "https://nzbget.example", User: "u", Pass: "p"},
+				},
+			},
+		},
+	}, nil)
+
+	got := resultsByName(svc.GetResults())
+	assert.Equal("https://user:pass@nzbget.example", got["AlreadyAuthed"].Check)
+	assert.Equal("https://u:p@nzbget.example", got["HTTPS"].Check)
+}
+
+func TestAddAppsUsesAppConfigNotClients(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	tautCfg := tautulli.Config{URL: "http://tautulli.example", APIKey: "tautkey"}
+	sabCfg := sabnzbd.Config{URL: "http://sab.example", APIKey: "sabkey"}
+	plexCfg := plex.Config{URL: "http://plex.example", Token: "plextok"}
+
+	svc := services.New(&services.Config{})
+	svc.AddApps(&apps.Apps{
+		Tautulli: apps.Tautulli{
+			TautulliConfig: apps.TautulliConfig{
+				ExtraConfig: extraConfig("Tautulli", 0),
+				Config:      tautCfg,
+			},
+		},
+		SabNZB: []apps.SabNZB{{
+			SabNZBConfig: apps.SabNZBConfig{
+				ExtraConfig: extraConfig("SABnzbd", 0),
+				Config:      &sabCfg,
+			},
+		}},
+		Plex: apps.Plex{
+			PlexConfig: apps.PlexConfig{
+				Config:      plexCfg,
+				ExtraConfig: extraConfig("", 0),
+			},
+		},
+	}, nil)
+
+	got := resultsByName(svc.GetResults())
+	assert.Equal("http://tautulli.example/api/v2?cmd=status&apikey=tautkey", got["Tautulli"].Check)
+	assert.Equal("http://sab.example/api?mode=version&apikey=sabkey", got["SABnzbd"].Check)
+	assert.Equal("http://plex.example|X-Plex-Token:plextok", got[services.PlexServerName].Check)
+	assert.Equal(services.StateUnknown, got["Tautulli"].State)
+}
+
+func TestAddAppsSkipsDisabledAndInvalid(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	disabled := extraConfig("Disabled", 0)
+	noName := extraConfig("", 0)
+	negative := extraConfig("Negative", -time.Second)
+
+	svc := services.New(&services.Config{})
+	svc.AddApps(&apps.Apps{
+		Lidarr: []apps.Lidarr{
+			{StarrApp: starrApp("", "http://lidarr.example", "key", 0)},
+			{StarrApp: apps.StarrApp{StarrConfig: apps.StarrConfig{ExtraConfig: extraConfig("NoURL", 0)}}},
+		},
+		Qbit: []apps.Qbit{{
+			QbitConfig: apps.QbitConfig{
+				ExtraConfig: negative,
+				Config:      qbit.Config{URL: "http://qbit.example"},
+			},
+		}},
+		Rtorrent: []apps.Rtorrent{{
+			RtorrentConfig: apps.RtorrentConfig{ExtraConfig: negative, URL: "http://rtorrent.example"},
+		}},
+		SabNZB: []apps.SabNZB{{
+			SabNZBConfig: apps.SabNZBConfig{
+				ExtraConfig: negative,
+				Config:      &sabnzbd.Config{URL: "http://sab.example", APIKey: "k"},
+			},
+		}},
+		Transmission: []apps.Xmission{{
+			XmissionConfig: apps.XmissionConfig{URL: "http://x.example", ExtraConfig: negative},
+		}},
+		Tautulli: apps.Tautulli{
+			TautulliConfig: apps.TautulliConfig{
+				ExtraConfig: noName,
+				Config:      tautulli.Config{URL: "http://tautulli.example", APIKey: "k"},
+			},
+		},
+		Plex: apps.Plex{
+			PlexConfig: apps.PlexConfig{
+				Config:      plex.Config{URL: "http://plex.example", Token: "tok"},
+				ExtraConfig: apps.ExtraConfig{Interval: cnfg.Duration{Duration: -time.Second}},
+			},
+		},
+		Deluge: []apps.Deluge{{DelugeConfig: apps.DelugeConfig{ExtraConfig: disabled}}},
+	}, []snapshot.MySQLConfig{
+		{Name: "empty-host", Host: ""},
+		{Name: "neg-timeout", Host: "db.example", Timeout: cnfg.Duration{Duration: -time.Second}},
+		{Name: "", Host: "db.example"},
+		{Name: "unix", Host: "@unix(/tmp/mysql.sock)"},
+		{Name: "empty-tcp", Host: "@tcp()"},
+	})
+
+	assert.Zero(svc.SvcCount(), "disabled, unnamed, negative-interval, and invalid mysql hosts must be skipped")
+}
+
+func TestAddAppsMySQLAlreadyHasPort(t *testing.T) {
+	t.Parallel()
+
+	svc := services.New(&services.Config{})
+	svc.AddApps(&apps.Apps{}, []snapshot.MySQLConfig{
+		{Name: "custom", Host: "db.example:3310", Timeout: cnfg.Duration{Duration: time.Second}},
+	})
+
+	got := resultsByName(svc.GetResults())
+	require.Contains(t, got, "custom")
+	assert.Equal(t, "db.example:3310", got["custom"].Check)
+	assert.Equal(t, services.CheckTCP, got["custom"].Type)
 }

--- a/pkg/services/check_ping.go
+++ b/pkg/services/check_ping.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -74,7 +75,13 @@ func (s *ServiceConfig) fillPingExpect(icmp bool) error {
 	return nil
 }
 
-func (s *ServiceConfig) checkPING() *result {
+func (s *ServiceConfig) checkPING(ctx context.Context) *result {
+	if s.Timeout.Duration > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, s.Timeout.Duration)
+		defer cancel()
+	}
+
 	pinger, err := ping.NewPinger(s.Value)
 	if err != nil {
 		return &result{
@@ -88,7 +95,7 @@ func (s *ServiceConfig) checkPING() *result {
 	pinger.Count = s.ping.count
 	pinger.Interval = time.Duration(s.ping.interval) * time.Millisecond
 
-	if err = pinger.Run(); err != nil { // blocks.
+	if err = pinger.RunWithContext(ctx); err != nil { // blocks until done or ctx is canceled.
 		return &result{
 			state:  StateCritical,
 			output: &Output{str: "error pinging service: " + err.Error()},

--- a/pkg/services/checks.go
+++ b/pkg/services/checks.go
@@ -18,10 +18,44 @@ import (
 )
 
 const (
-	sslstring   = "SSL" // used for checking HTTPS certs
-	expectdelim = ","   // extra (split) delimiter
-	maxOutput   = 170   // maximum length of output.
+	sslstring           = "SSL" // used for checking HTTPS certs
+	expectdelim         = ","   // extra (split) delimiter
+	maxOutput           = 170   // maximum length of output.
+	drainLimit          = 64 << 10
+	maxIdleConns        = 64
+	maxIdleConnsPerHost = 8
+	idleConnTimeout     = 90 * time.Second
 )
+
+var (
+	httpClientInsecure = newHTTPClient(true)
+	httpClientSecure   = newHTTPClient(false)
+)
+
+func newHTTPClient(insecureSkipVerify bool) *http.Client {
+	return &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			TLSClientConfig:       &tls.Config{InsecureSkipVerify: insecureSkipVerify}, //nolint:gosec
+			MaxIdleConns:          maxIdleConns,
+			MaxIdleConnsPerHost:   maxIdleConnsPerHost,
+			IdleConnTimeout:       idleConnTimeout,
+			TLSHandshakeTimeout:   DefaultTimeout,
+			ExpectContinueTimeout: time.Second,
+		},
+	}
+}
+
+func httpClient(validSSL bool) *http.Client {
+	if validSSL {
+		return httpClientSecure
+	}
+
+	return httpClientInsecure
+}
 
 type result struct {
 	output *Output
@@ -156,14 +190,14 @@ func (s *Service) update(reqID string, res *result) bool {
 	return true
 }
 
-// checkHTTPReq builds the client and request for the http service check.
-func (s *Service) checkHTTPReq(ctx context.Context) (*http.Client, *http.Request, error) {
+// checkHTTPReq builds the request for the http service check.
+func (s *Service) checkHTTPReq(ctx context.Context) (*http.Request, error) {
 	// Allow adding headers by appending them after a pipe symbol.
 	splitVal := strings.Split(s.Value, "|")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, splitVal[0], nil)
 	if err != nil {
-		return nil, nil, err //nolint:wrapcheck // handled by caller
+		return nil, err //nolint:wrapcheck // handled by caller
 	}
 
 	for _, val := range splitVal[1:] {
@@ -177,14 +211,7 @@ func (s *Service) checkHTTPReq(ctx context.Context) (*http.Client, *http.Request
 		}
 	}
 
-	return &http.Client{
-		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-		Timeout: s.Timeout.Duration, Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: !s.validSSL}, //nolint:gosec
-		},
-	}, req, nil
+	return req, nil
 }
 
 func (s *Service) checkHTTP(ctx context.Context) *result {
@@ -194,12 +221,12 @@ func (s *Service) checkHTTP(ctx context.Context) *result {
 	}
 
 	if s.Timeout.Duration > 0 {
-		var cancel func()
+		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, s.Timeout.Duration)
 		defer cancel()
 	}
 
-	client, req, err := s.checkHTTPReq(ctx)
+	req, err := s.checkHTTPReq(ctx)
 	if err != nil {
 		res.output = &Output{str: "creating request: " + RemoveSecrets(s.Value, err.Error())}
 		return res
@@ -208,18 +235,12 @@ func (s *Service) checkHTTP(ctx context.Context) *result {
 	// If there is an error at this point it's a bad request.
 	res.state = StateCritical
 
-	resp, err := client.Do(req)
+	resp, err := httpClient(s.validSSL).Do(req)
 	if err != nil {
 		res.output = &Output{str: "making request: " + RemoveSecrets(s.Value, err.Error())}
 		return res
 	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		res.output = &Output{str: "reading body: " + RemoveSecrets(s.Value, err.Error())}
-		return res
-	}
+	defer drainAndClose(resp.Body)
 
 	for code := range strings.SplitSeq(s.Expect, expectdelim) {
 		if strconv.Itoa(resp.StatusCode) == strings.TrimSpace(code) {
@@ -230,23 +251,26 @@ func (s *Service) checkHTTP(ctx context.Context) *result {
 		}
 	}
 
-	// Reduce the size of the body before processing it to speed things up on large body outputs.
-	// This avoids expensive string operations (EscapeString, Fields, Join) on large responses.
-	if len(body) > maxOutput+maxOutput {
-		body = body[:maxOutput+maxOutput]
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxOutput+maxOutput))
+	if err != nil {
+		res.output = &Output{str: "reading body: " + RemoveSecrets(s.Value, err.Error())}
+		return res
 	}
 
 	res.state = StateCritical
 	res.output = &Output{esc: true, str: resp.Status + ": " + strings.TrimSpace(
 		html.EscapeString(strings.Join(strings.Fields(RemoveSecrets(s.Value, string(body))), " ")))}
 
-	// Reduce the string to the final max length.
-	// We do it this way so all secrets are properly escaped before string splitting.
 	if len(res.output.str) > maxOutput {
 		res.output.str = res.output.str[:maxOutput]
 	}
 
 	return res
+}
+
+func drainAndClose(body io.ReadCloser) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(body, drainLimit))
+	body.Close()
 }
 
 // RemoveSecrets removes secret token values in a message parsed from a url.

--- a/pkg/services/checks.go
+++ b/pkg/services/checks.go
@@ -146,7 +146,7 @@ func (s *Service) checkNow(ctx context.Context) *result {
 	case CheckTCP:
 		return s.checkTCP(ctx)
 	case CheckPING, CheckICMP:
-		return s.checkPING()
+		return s.checkPING(ctx)
 	case CheckPROC:
 		return s.checkProccess(ctx)
 	default:
@@ -155,7 +155,12 @@ func (s *Service) checkNow(ctx context.Context) *result {
 }
 
 func (s *Service) check(ctx context.Context) bool {
-	return s.update(mnd.GetID(ctx), s.checkNow(ctx))
+	res := s.checkNow(ctx)
+	if ctx.Err() != nil {
+		return false
+	}
+
+	return s.update(mnd.GetID(ctx), res)
 }
 
 // Return true if the service state changed.

--- a/pkg/services/checks_test.go
+++ b/pkg/services/checks_test.go
@@ -381,8 +381,4 @@ func TestGetAllProcesses(t *testing.T) {
 	procs, err := services.GetAllProcesses(t.Context())
 	require.NoError(t, err)
 	assert.NotEmpty(t, procs)
-
-	for _, proc := range procs {
-		assert.NotZero(t, proc.PID)
-	}
 }

--- a/pkg/services/checks_test.go
+++ b/pkg/services/checks_test.go
@@ -1,0 +1,388 @@
+package services_test
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Notifiarr/notifiarr/pkg/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golift.io/cnfg"
+)
+
+func serveHTTP(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+func checkHTTP(t *testing.T, value, expect string) *services.CheckResult {
+	t.Helper()
+
+	return (&services.ServiceConfig{
+		Name:    t.Name(),
+		Type:    services.CheckHTTP,
+		Value:   value,
+		Expect:  expect,
+		Timeout: cnfg.Duration{Duration: time.Second},
+	}).CheckOnly(t.Context())
+}
+
+func TestCheckOnlyHTTPOK(t *testing.T) {
+	t.Parallel()
+
+	server := serveHTTP(t, http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+	}))
+
+	result := checkHTTP(t, server.URL, "")
+	require.Equal(t, services.StateOK, result.State)
+	assert.Contains(t, result.Output.String(), "200")
+}
+
+func TestCheckOnlyHTTPSecretsAndCodes(t *testing.T) {
+	t.Parallel()
+
+	server := serveHTTP(t, http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusNotFound)
+		_, _ = writer.Write([]byte("token leaked: supersecret"))
+	}))
+
+	unexpected := checkHTTP(t, server.URL+"?token=supersecret", "200")
+	require.Equal(t, services.StateCritical, unexpected.State)
+	assert.NotContains(t, unexpected.Output.String(), "supersecret")
+	assert.Contains(t, unexpected.Output.String(), "********")
+
+	allowed := checkHTTP(t, server.URL, "200,404")
+	assert.Equal(t, services.StateOK, allowed.State)
+}
+
+func TestCheckOnlyHTTPRedirects(t *testing.T) {
+	t.Parallel()
+
+	server := serveHTTP(t, http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		http.Redirect(writer, req, "/ok", http.StatusFound)
+	}))
+
+	assert.Equal(t, services.StateCritical, checkHTTP(t, server.URL, "200").State)
+	assert.Equal(t, services.StateOK, checkHTTP(t, server.URL, "302").State)
+}
+
+func TestCheckOnlyHTTPHeaders(t *testing.T) {
+	t.Parallel()
+
+	server := serveHTTP(t, http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		if req.Header.Get("X-Test") != "yes" || req.Host != "custom.example" {
+			writer.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		writer.WriteHeader(http.StatusOK)
+	}))
+
+	result := checkHTTP(t, server.URL+"|X-Test:yes|Host:custom.example", "")
+	assert.Equal(t, services.StateOK, result.State)
+}
+
+func TestCheckOnlyHTTPOutputFormatting(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/amp", func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusNotFound)
+		_, _ = writer.Write([]byte("Tom & Jerry"))
+	})
+	mux.HandleFunc("/big", func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusNotFound)
+		_, _ = writer.Write([]byte(strings.Repeat("body ", 200)))
+	})
+
+	server := serveHTTP(t, mux)
+
+	escaped := checkHTTP(t, server.URL+"/amp", "")
+	assert.Equal(t, services.StateCritical, escaped.State)
+	assert.Contains(t, escaped.Output.String(), "Tom & Jerry")
+
+	raw, err := json.Marshal(escaped.Output)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `\u0026amp;`)
+
+	truncated := checkHTTP(t, server.URL+"/big", "")
+	assert.Equal(t, services.StateCritical, truncated.State)
+	assert.LessOrEqual(t, len(truncated.Output.String()), 170)
+}
+
+func TestCheckOnlyHTTPErrors(t *testing.T) {
+	t.Parallel()
+
+	down := checkHTTP(t, "http://127.0.0.1:1", "")
+	assert.Equal(t, services.StateCritical, down.State)
+	assert.Contains(t, down.Output.String(), "making request")
+
+	badURL := checkHTTP(t, ":", "")
+	assert.Equal(t, services.StateUnknown, badURL.State)
+	assert.Contains(t, badURL.Output.String(), "creating request")
+}
+
+func TestCheckOnlyHTTPTLS(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	insecure := (&services.ServiceConfig{
+		Name:    "tls-skip",
+		Type:    services.CheckHTTP,
+		Value:   server.URL,
+		Timeout: cnfg.Duration{Duration: time.Second},
+	}).CheckOnly(t.Context())
+	require.Equal(t, services.StateOK, insecure.State)
+
+	strict := (&services.ServiceConfig{
+		Name:    "tls-strict",
+		Type:    services.CheckHTTP,
+		Value:   server.URL,
+		Expect:  "200,SSL",
+		Timeout: cnfg.Duration{Duration: time.Second},
+	}).CheckOnly(t.Context())
+	assert.Equal(t, services.StateCritical, strict.State)
+	assert.Contains(t, strict.Output.String(), "making request")
+}
+
+func TestCheckOnlyTCP(t *testing.T) {
+	t.Parallel()
+
+	listenCfg := new(net.ListenConfig)
+
+	listener, err := listenCfg.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+
+			_ = conn.Close()
+		}
+	}()
+
+	connected := (&services.ServiceConfig{
+		Name:    "tcp-ok",
+		Type:    services.CheckTCP,
+		Value:   listener.Addr().String(),
+		Timeout: cnfg.Duration{Duration: time.Second},
+	}).CheckOnly(t.Context())
+	require.Equal(t, services.StateOK, connected.State)
+	assert.Contains(t, connected.Output.String(), "connected to port")
+
+	closedPort, err := listenCfg.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := closedPort.Addr().String()
+	require.NoError(t, closedPort.Close())
+
+	down := (&services.ServiceConfig{
+		Name:    "tcp-down",
+		Type:    services.CheckTCP,
+		Value:   addr,
+		Timeout: cnfg.Duration{Duration: time.Second},
+	}).CheckOnly(t.Context())
+	assert.Equal(t, services.StateCritical, down.State)
+	assert.Contains(t, down.Output.String(), "connection error")
+}
+
+func TestCheckOnlyProcess(t *testing.T) {
+	t.Parallel()
+
+	missing := (&services.ServiceConfig{
+		Name:    "missing",
+		Type:    services.CheckPROC,
+		Value:   "this-process-definitely-does-not-exist-xyz",
+		Timeout: cnfg.Duration{Duration: time.Second},
+	}).CheckOnly(t.Context())
+	assert.Equal(t, services.StateCritical, missing.State)
+
+	notRunning := (&services.ServiceConfig{
+		Name:    "not-running",
+		Type:    services.CheckPROC,
+		Value:   "this-process-definitely-does-not-exist-xyz",
+		Expect:  "running",
+		Timeout: cnfg.Duration{Duration: time.Second},
+	}).CheckOnly(t.Context())
+	assert.Equal(t, services.StateOK, notRunning.State, "Expect=running means the process should be absent")
+
+	procs, err := services.GetAllProcesses(t.Context())
+	require.NoError(t, err)
+
+	var needle string
+
+	for _, proc := range procs {
+		if proc.CmdLine != "" {
+			needle = proc.CmdLine
+			const maxNeedle = 12
+			if len(needle) > maxNeedle {
+				needle = needle[:maxNeedle]
+			}
+
+			break
+		}
+	}
+
+	if needle == "" {
+		t.Skip("no process command lines available on this host")
+	}
+
+	found := (&services.ServiceConfig{
+		Name:    "found",
+		Type:    services.CheckPROC,
+		Value:   needle,
+		Expect:  "count:1",
+		Timeout: cnfg.Duration{Duration: 2 * time.Second},
+	}).CheckOnly(t.Context())
+	assert.Equal(t, services.StateOK, found.State)
+	assert.Contains(t, found.Output.String(), "found")
+}
+
+func TestCheckOnlyValidateError(t *testing.T) {
+	t.Parallel()
+
+	result := (&services.ServiceConfig{
+		Type:  services.CheckHTTP,
+		Value: "http://example.com",
+		Tags:  map[string]any{"site": "test"},
+	}).CheckOnly(context.Background())
+
+	assert.Equal(t, services.StateCritical, result.State)
+	assert.Contains(t, result.Output.String(), services.ErrNoName.Error())
+	assert.Equal(t, "test", result.Metadata["site"])
+}
+
+func TestRemoveSecrets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		appURL  string
+		message string
+		want    string
+	}{
+		{
+			name:    "apikey",
+			appURL:  "http://example.com/api?apikey=secret-key",
+			message: "failed secret-key lookup",
+			want:    "failed ******** lookup",
+		},
+		{
+			name:    "token",
+			appURL:  "http://example.com/?token=tok123",
+			message: "bad tok123",
+			want:    "bad ********",
+		},
+		{
+			name:    "password and pass",
+			appURL:  "http://example.com/?password=hunter2&pass=abc",
+			message: "hunter2 abc",
+			want:    "******** ********",
+		},
+		{
+			name:    "ignores headers after pipe",
+			appURL:  "http://example.com/?apikey=keepme|X-Api-Key:other",
+			message: "keepme should go",
+			want:    "******** should go",
+		},
+		{
+			name:    "invalid url left alone",
+			appURL:  "://not a url",
+			message: "unchanged",
+			want:    "unchanged",
+		},
+		{
+			name:    "no secrets",
+			appURL:  "http://example.com/health",
+			message: "all good",
+			want:    "all good",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.want, services.RemoveSecrets(test.appURL, test.message))
+		})
+	}
+}
+
+func TestServiceDue(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	svc := &services.Service{
+		ServiceConfig: &services.ServiceConfig{
+			Interval: cnfg.Duration{Duration: time.Minute},
+		},
+	}
+
+	assert.True(t, svc.Due(now), "never-checked services with an interval are due")
+
+	svc.LastCheck = now.Add(-30 * time.Second)
+	assert.False(t, svc.Due(now))
+
+	svc.LastCheck = now.Add(-2 * time.Minute)
+	assert.True(t, svc.Due(now))
+
+	svc.Interval.Duration = 0
+	assert.False(t, svc.Due(now), "zero interval is never due")
+}
+
+func TestCheckOnlyPingCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	cfg := &services.ServiceConfig{
+		Name:    "ping",
+		Type:    services.CheckPING,
+		Value:   "127.0.0.1",
+		Expect:  "1:1:200",
+		Timeout: cnfg.Duration{Duration: 5 * time.Second},
+	}
+
+	done := make(chan *services.CheckResult, 1)
+
+	go func() {
+		done <- cfg.CheckOnly(ctx)
+	}()
+
+	select {
+	case result := <-done:
+		require.NotNil(t, result)
+	case <-time.After(2 * time.Second):
+		t.Fatal("ping check did not honor canceled context")
+	}
+}
+
+func TestGetAllProcesses(t *testing.T) {
+	t.Parallel()
+
+	procs, err := services.GetAllProcesses(t.Context())
+	require.NoError(t, err)
+	assert.NotEmpty(t, procs)
+
+	for _, proc := range procs {
+		assert.NotZero(t, proc.PID)
+	}
+}

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -55,6 +55,7 @@ type data struct {
 	stopLock    sync.Mutex
 	log         mnd.Logger
 	parallel    uint
+	stopping    bool
 }
 
 // CheckType locks us into a few specific types of checks.

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -56,6 +57,8 @@ type data struct {
 	log         mnd.Logger
 	parallel    uint
 	stopping    bool
+	cancel      context.CancelFunc
+	stopped     chan struct{}
 }
 
 // CheckType locks us into a few specific types of checks.

--- a/pkg/services/helpers_test.go
+++ b/pkg/services/helpers_test.go
@@ -1,0 +1,45 @@
+package services_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Notifiarr/notifiarr/pkg/apps"
+	"github.com/Notifiarr/notifiarr/pkg/logs"
+	"github.com/Notifiarr/notifiarr/pkg/mnd"
+	"github.com/Notifiarr/notifiarr/pkg/services"
+	"golift.io/cnfg"
+	"golift.io/starr"
+)
+
+func TestMain(m *testing.M) {
+	mnd.Log = logs.Log
+	os.Exit(m.Run())
+}
+
+func resultsByName(results []*services.CheckResult) map[string]*services.CheckResult {
+	out := make(map[string]*services.CheckResult, len(results))
+	for _, result := range results {
+		out[result.Name] = result
+	}
+
+	return out
+}
+
+func extraConfig(name string, interval time.Duration) apps.ExtraConfig {
+	return apps.ExtraConfig{
+		Name:     name,
+		Timeout:  cnfg.Duration{Duration: time.Second},
+		Interval: cnfg.Duration{Duration: interval},
+	}
+}
+
+func starrApp(name, appURL, apiKey string, interval time.Duration) apps.StarrApp {
+	return apps.StarrApp{
+		StarrConfig: apps.StarrConfig{
+			Config:      starr.Config{URL: appURL, APIKey: apiKey},
+			ExtraConfig: extraConfig(name, interval),
+		},
+	}
+}

--- a/pkg/services/interface.go
+++ b/pkg/services/interface.go
@@ -18,31 +18,35 @@ var ErrSvcsStopped = errors.New("service check routine stopped")
 // RunChecks runs checks from an external package.
 func (s *Services) RunChecks(input *common.ActionInput) {
 	s.stopLock.Lock()
-	defer s.stopLock.Unlock()
+	triggerChan := s.triggerChan
+	stopped := s.actionChan == nil || s.stopping
+	s.stopLock.Unlock()
 
-	if s.triggerChan == nil || s.actionChan == nil {
+	if triggerChan == nil || stopped {
 		mnd.Log.Errorf(input.ReqID, "Cannot run service checks. Go routine is not running.")
 		return
 	}
 
-	s.triggerChan <- input
+	triggerChan <- input
 }
 
 // RunCheck runs a single check from an external package.
 func (s *Services) RunCheck(ctx context.Context, source website.EventType, name string) error {
 	s.stopLock.Lock()
-	defer s.stopLock.Unlock()
+	checkChan := s.checkChan
+	svc, found := s.services[name]
+	stopped := s.actionChan == nil || s.stopping
+	s.stopLock.Unlock()
 
-	if s.triggerChan == nil || s.actionChan == nil {
+	if checkChan == nil || stopped {
 		return fmt.Errorf("cannot check service, %w", ErrSvcsStopped)
 	}
 
-	svc, ok := s.services[name]
-	if !ok {
+	if !found {
 		return fmt.Errorf("%w: service '%s' not found", ErrNoName, name)
 	}
 
-	s.checkChan <- triggerCheck{ReqID: mnd.GetID(ctx), Source: source, Service: svc}
+	checkChan <- triggerCheck{ReqID: mnd.GetID(ctx), Source: source, Service: svc}
 
 	return nil
 }
@@ -64,18 +68,38 @@ func (s *Services) runChecks(forceAll bool, now time.Time) bool {
 		return false
 	}
 
-	count := 0
+	outstanding := 0
 	changes := false
 
-	for svc := range s.services {
-		if s.services[svc].Interval.Duration > 0 && (forceAll || s.services[svc].Due(now)) {
-			count++
-			s.checks <- s.services[svc]
+	for _, svc := range s.services {
+		if svc.Interval.Duration == 0 || (!forceAll && !svc.Due(now)) {
+			continue
 		}
+
+		outstanding, changes = s.enqueueCheck(svc, outstanding, changes)
 	}
 
-	for ; count > 0; count-- {
+	return s.waitChecks(outstanding, changes)
+}
+
+// enqueueCheck queues a check without blocking forever if the worker pool is full.
+// Completions are drained in the same select so the done channel cannot deadlock.
+func (s *Services) enqueueCheck(svc *Service, outstanding int, changes bool) (int, bool) {
+	for {
+		select {
+		case s.checks <- svc:
+			return outstanding + 1, changes
+		case changed := <-s.done:
+			outstanding--
+			changes = changes || changed
+		}
+	}
+}
+
+func (s *Services) waitChecks(outstanding int, changes bool) bool {
+	for outstanding > 0 {
 		changes = <-s.done || changes
+		outstanding--
 	}
 
 	return changes

--- a/pkg/services/interface.go
+++ b/pkg/services/interface.go
@@ -19,26 +19,27 @@ var ErrSvcsStopped = errors.New("service check routine stopped")
 func (s *Services) RunChecks(input *common.ActionInput) {
 	s.stopLock.Lock()
 	triggerChan := s.triggerChan
-	stopped := s.actionChan == nil || s.stopping
+	stopped := s.stopped
+	halted := s.actionChan == nil || s.stopping
 	s.stopLock.Unlock()
 
-	if triggerChan == nil || stopped {
+	if halted || !sendLive(triggerChan, input, stopped) {
 		mnd.Log.Errorf(input.ReqID, "Cannot run service checks. Go routine is not running.")
-		return
 	}
-
-	triggerChan <- input
 }
 
 // RunCheck runs a single check from an external package.
 func (s *Services) RunCheck(ctx context.Context, source website.EventType, name string) error {
 	s.stopLock.Lock()
+
 	checkChan := s.checkChan
+	stopped := s.stopped
 	svc, found := s.services[name]
-	stopped := s.actionChan == nil || s.stopping
+	halted := s.actionChan == nil || s.stopping
+
 	s.stopLock.Unlock()
 
-	if checkChan == nil || stopped {
+	if checkChan == nil || halted || stopped == nil {
 		return fmt.Errorf("cannot check service, %w", ErrSvcsStopped)
 	}
 
@@ -46,9 +47,16 @@ func (s *Services) RunCheck(ctx context.Context, source website.EventType, name 
 		return fmt.Errorf("%w: service '%s' not found", ErrNoName, name)
 	}
 
-	checkChan <- triggerCheck{ReqID: mnd.GetID(ctx), Source: source, Service: svc}
+	event := triggerCheck{ReqID: mnd.GetID(ctx), Source: source, Service: svc}
 
-	return nil
+	select {
+	case checkChan <- event:
+		return nil
+	case <-stopped:
+		return fmt.Errorf("cannot check service, %w", ErrSvcsStopped)
+	case <-ctx.Done():
+		return fmt.Errorf("cannot check service: %w", ctx.Err())
+	}
 }
 
 // runCheck runs a service check if it is due. Passing force runs it regardless.

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -55,14 +55,25 @@ func (s *Services) add(svc *ServiceConfig) {
 	}
 }
 
-// Start begins the service check routines.
-// Runs Parallel checkers and the check reporter.
-func (s *Services) Start(ctx context.Context, plexName string) {
-	if s.parallel = uint(len(s.services) / svcsPerThread); s.parallel < 1 {
+func (s *Services) setParallel() {
+	count := len(s.services)
+	if count == 0 {
+		s.parallel = 0
+		return
+	}
+
+	s.parallel = uint(count / svcsPerThread)
+	if s.parallel < 1 {
 		s.parallel = 1
 	} else if s.parallel > maxParallel {
 		s.parallel = maxParallel
 	}
+}
+
+// Start begins the service check routines.
+// Runs Parallel checkers and the check reporter.
+func (s *Services) Start(ctx context.Context, plexName string) {
+	s.setParallel()
 
 	if s.log = mnd.Log; s.LogFile != "" {
 		s.log = logs.CustomLog(s.LogFile, "Services")
@@ -75,7 +86,11 @@ func (s *Services) Start(ctx context.Context, plexName string) {
 	s.applyLocalOverrides(plexName)
 	s.loadServiceStates(mnd.GetID(ctx))
 
+	ctx, cancel := context.WithCancel(ctx)
+
 	s.stopLock.Lock()
+	s.cancel = cancel
+	s.stopped = make(chan struct{})
 	s.checks = make(chan *Service, DefaultBuffer)
 	s.done = make(chan bool, s.parallel)
 	s.actionChan = make(chan action, actionBuf)
@@ -87,7 +102,7 @@ func (s *Services) Start(ctx context.Context, plexName string) {
 		go s.watchServiceChan(ctx)
 	}
 
-	go s.runServiceChecker()
+	go s.runServiceChecker(ctx)
 	s.stopLock.Unlock()
 
 	word := "Started"
@@ -196,7 +211,14 @@ const (
 	actionCheck                // check if service checks are running.
 )
 
-func (s *Services) runServiceChecker() { //nolint:cyclop,funlen
+func (s *Services) stopWorkers() {
+	for range s.parallel {
+		s.checks <- nil
+		<-s.done
+	}
+}
+
+func (s *Services) runServiceChecker(ctx context.Context) { //nolint:cyclop,funlen
 	checker := time.NewTicker(time.Second)
 	running := true
 	reqID := mnd.ReqID()
@@ -205,12 +227,15 @@ func (s *Services) runServiceChecker() { //nolint:cyclop,funlen
 		defer s.log.CapturePanic()
 		checker.Stop()
 		s.log.Printf(reqID, "==> Service Checker Stopped!")
-		s.actionChan <- actionStop // signal we're finished.
+		close(s.stopped)
 	}()
 
 	if !s.Disabled {
 		s.runChecks(true, version.Started)
-		s.SendResults(&Results{What: website.EventStart, Svcs: s.GetResults()}, reqID)
+
+		if ctx.Err() == nil {
+			s.SendResults(&Results{What: website.EventStart, Svcs: s.GetResults()}, reqID)
+		}
 	} else {
 		running = false
 		checker.Stop()
@@ -218,6 +243,9 @@ func (s *Services) runServiceChecker() { //nolint:cyclop,funlen
 
 	for {
 		select {
+		case <-ctx.Done():
+			s.stopWorkers()
+			return
 		case action := <-s.actionChan:
 			switch action {
 			case actionCheck:
@@ -231,12 +259,7 @@ func (s *Services) runServiceChecker() { //nolint:cyclop,funlen
 				checker.Stop()
 				running = false
 			case actionStop:
-				// Stop all the checkers.
-				for range s.parallel {
-					s.checks <- nil
-					<-s.done
-				}
-
+				s.stopWorkers()
 				return
 			}
 		case event := <-s.checkChan:
@@ -308,10 +331,7 @@ func (s *Services) sendAction(act action) {
 
 // Stop ends all service checker routines.
 func (s *Services) Stop() {
-	defer func() {
-		logs.Log.CapturePanic()
-		logs.Log.Printf("called", "==> Service Checker Stopped!")
-	}()
+	defer logs.Log.CapturePanic()
 
 	s.stopLock.Lock()
 	if s.actionChan == nil || s.stopping {
@@ -320,11 +340,17 @@ func (s *Services) Stop() {
 	}
 
 	s.stopping = true
-	actionChan := s.actionChan
+	cancel := s.cancel
+	stopped := s.stopped
 	s.stopLock.Unlock()
 
-	actionChan <- actionStop
-	<-actionChan
+	if cancel != nil {
+		cancel()
+	}
+
+	if stopped != nil {
+		<-stopped
+	}
 
 	s.stopLock.Lock()
 	defer s.stopLock.Unlock()
@@ -332,6 +358,8 @@ func (s *Services) Stop() {
 	s.actionChan = nil
 	s.triggerChan = nil
 	s.checkChan = nil
+	s.cancel = nil
+	s.stopped = nil
 	s.stopping = false
 
 	if s.checks != nil {

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -21,6 +21,8 @@ import (
 const (
 	svcsPerThread = 10
 	maxParallel   = 10
+	actionBuf     = 2
+	controlBuf    = 1
 )
 
 func (s *Services) Add(services []ServiceConfig) error {
@@ -56,16 +58,6 @@ func (s *Services) add(svc *ServiceConfig) {
 // Start begins the service check routines.
 // Runs Parallel checkers and the check reporter.
 func (s *Services) Start(ctx context.Context, plexName string) {
-	s.stopLock.Lock()
-	defer s.stopLock.Unlock()
-
-	s.checks = make(chan *Service, DefaultBuffer)
-	s.done = make(chan bool)
-	s.actionChan = make(chan action)
-	s.replyChan = make(chan bool)
-	s.triggerChan = make(chan *common.ActionInput)
-	s.checkChan = make(chan triggerCheck)
-
 	if s.parallel = uint(len(s.services) / svcsPerThread); s.parallel < 1 {
 		s.parallel = 1
 	} else if s.parallel > maxParallel {
@@ -83,11 +75,20 @@ func (s *Services) Start(ctx context.Context, plexName string) {
 	s.applyLocalOverrides(plexName)
 	s.loadServiceStates(mnd.GetID(ctx))
 
+	s.stopLock.Lock()
+	s.checks = make(chan *Service, DefaultBuffer)
+	s.done = make(chan bool, s.parallel)
+	s.actionChan = make(chan action, actionBuf)
+	s.replyChan = make(chan bool, controlBuf)
+	s.triggerChan = make(chan *common.ActionInput, controlBuf)
+	s.checkChan = make(chan triggerCheck, controlBuf)
+
 	for range s.parallel {
 		go s.watchServiceChan(ctx)
 	}
 
 	go s.runServiceChecker()
+	s.stopLock.Unlock()
 
 	word := "Started"
 	if s.Disabled || len(s.services) == 0 {
@@ -156,27 +157,31 @@ func (s *Services) loadServiceStates(reqID string) {
 		return
 	}
 
+	saved := make(map[string][]byte, len(values))
+	for siteDataName, data := range values {
+		saved[strings.TrimPrefix(siteDataName, valuePrefix)] = data
+	}
+
 	for name := range s.services {
-		for siteDataName := range values {
-			if name == strings.TrimPrefix(siteDataName, valuePrefix) {
-				var svc Service
-				if err := json.Unmarshal(values[siteDataName], &svc); err != nil {
-					s.log.ErrorfNoShare(reqID, "Service check data for '%s' returned from site is invalid: %v", name, err)
-					break
-				}
+		data, ok := saved[name]
+		if !ok {
+			continue
+		}
 
-				if time.Since(svc.LastCheck) < 2*time.Hour {
-					s.log.Printf(reqID, "==> Set service state with website-saved data: %s, %s for %s",
-						name, svc.State, time.Since(svc.Since).Round(time.Second))
+		var svc Service
+		if err := json.Unmarshal(data, &svc); err != nil {
+			s.log.ErrorfNoShare(reqID, "Service check data for '%s' returned from site is invalid: %v", name, err)
+			continue
+		}
 
-					s.services[name].Output = svc.Output
-					s.services[name].State = svc.State
-					s.services[name].Since = svc.Since
-					s.services[name].LastCheck = svc.LastCheck
-				}
+		if time.Since(svc.LastCheck) < 2*time.Hour {
+			s.log.Printf(reqID, "==> Set service state with website-saved data: %s, %s for %s",
+				name, svc.State, time.Since(svc.Since).Round(time.Second))
 
-				break
-			}
+			s.services[name].Output = svc.Output
+			s.services[name].State = svc.State
+			s.services[name].Since = svc.Since
+			s.services[name].LastCheck = svc.LastCheck
 		}
 	}
 }
@@ -268,31 +273,40 @@ func (s *Services) runServiceChecker() { //nolint:cyclop,funlen
 
 func (s *Services) Running() bool {
 	s.stopLock.Lock()
-	defer s.stopLock.Unlock()
+	actionChan := s.actionChan
+	replyChan := s.replyChan
+	stopping := s.stopping
+	s.stopLock.Unlock()
 
-	s.actionChan <- actionCheck
-	return <-s.replyChan
+	if actionChan == nil || stopping {
+		return false
+	}
+
+	actionChan <- actionCheck
+
+	return <-replyChan
 }
 
 func (s *Services) Pause() {
-	s.stopLock.Lock()
-	defer s.stopLock.Unlock()
-
-	if s.actionChan != nil {
-		s.actionChan <- actionPause
-	}
+	s.sendAction(actionPause)
 }
 
 func (s *Services) Resume() {
-	s.stopLock.Lock()
-	defer s.stopLock.Unlock()
+	s.sendAction(actionResume)
+}
 
-	if s.actionChan != nil {
-		s.actionChan <- actionResume
+func (s *Services) sendAction(act action) {
+	s.stopLock.Lock()
+	actionChan := s.actionChan
+	stopping := s.stopping
+	s.stopLock.Unlock()
+
+	if actionChan != nil && !stopping {
+		actionChan <- act
 	}
 }
 
-// Stop sends current states to the website and ends all service checker routines.
+// Stop ends all service checker routines.
 func (s *Services) Stop() {
 	defer func() {
 		logs.Log.CapturePanic()
@@ -300,26 +314,35 @@ func (s *Services) Stop() {
 	}()
 
 	s.stopLock.Lock()
-	defer s.stopLock.Unlock()
-
-	if s.actionChan == nil {
+	if s.actionChan == nil || s.stopping {
+		s.stopLock.Unlock()
 		return
 	}
 
-	defer close(s.actionChan)
-	s.actionChan <- actionStop
-	<-s.actionChan // wait for all go routines to die off.
+	s.stopping = true
+	actionChan := s.actionChan
+	s.stopLock.Unlock()
 
-	close(s.triggerChan)
-	close(s.checkChan)
-	close(s.checks)
-	close(s.done)
+	actionChan <- actionStop
+	<-actionChan
 
+	s.stopLock.Lock()
+	defer s.stopLock.Unlock()
+
+	s.actionChan = nil
 	s.triggerChan = nil
 	s.checkChan = nil
-	s.checks = nil
-	s.done = nil
-	s.actionChan = nil
+	s.stopping = false
+
+	if s.checks != nil {
+		close(s.checks)
+		s.checks = nil
+	}
+
+	if s.done != nil {
+		close(s.done)
+		s.done = nil
+	}
 }
 
 // SvcCount returns the count of services being monitored.

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -56,18 +56,58 @@ func (s *Services) add(svc *ServiceConfig) {
 }
 
 func (s *Services) setParallel() {
-	count := len(s.services)
-	if count == 0 {
-		s.parallel = 0
-		return
-	}
-
-	s.parallel = uint(count / svcsPerThread)
+	s.parallel = uint(len(s.services) / svcsPerThread)
 	if s.parallel < 1 {
 		s.parallel = 1
 	} else if s.parallel > maxParallel {
 		s.parallel = maxParallel
 	}
+}
+
+func sendLive[T any](live chan T, val T, stopped <-chan struct{}) bool {
+	if live == nil || stopped == nil {
+		return false
+	}
+
+	select {
+	case live <- val:
+		return true
+	case <-stopped:
+		return false
+	}
+}
+
+func (s *Services) beginLifecycle(cancel context.CancelFunc) {
+	s.stopLock.Lock()
+	defer s.stopLock.Unlock()
+
+	s.cancel = cancel
+	s.stopped = make(chan struct{})
+	s.stopping = false
+	s.checks = make(chan *Service, DefaultBuffer)
+	s.done = make(chan bool, s.parallel)
+	s.actionChan = make(chan action, actionBuf)
+	s.replyChan = make(chan bool, controlBuf)
+	s.triggerChan = make(chan *common.ActionInput, controlBuf)
+	s.checkChan = make(chan triggerCheck, controlBuf)
+}
+
+func (s *Services) launchChecker(ctx context.Context) bool {
+	s.stopLock.Lock()
+	defer s.stopLock.Unlock()
+
+	if s.stopping || ctx.Err() != nil {
+		close(s.stopped)
+		return false
+	}
+
+	for range s.parallel {
+		go s.watchServiceChan(ctx)
+	}
+
+	go s.runServiceChecker(ctx)
+
+	return true
 }
 
 // Start begins the service check routines.
@@ -84,26 +124,14 @@ func (s *Services) Start(ctx context.Context, plexName string) {
 	}
 
 	s.applyLocalOverrides(plexName)
-	s.loadServiceStates(mnd.GetID(ctx))
 
 	ctx, cancel := context.WithCancel(ctx)
+	s.beginLifecycle(cancel)
+	s.loadServiceStates(mnd.GetID(ctx))
 
-	s.stopLock.Lock()
-	s.cancel = cancel
-	s.stopped = make(chan struct{})
-	s.checks = make(chan *Service, DefaultBuffer)
-	s.done = make(chan bool, s.parallel)
-	s.actionChan = make(chan action, actionBuf)
-	s.replyChan = make(chan bool, controlBuf)
-	s.triggerChan = make(chan *common.ActionInput, controlBuf)
-	s.checkChan = make(chan triggerCheck, controlBuf)
-
-	for range s.parallel {
-		go s.watchServiceChan(ctx)
+	if !s.launchChecker(ctx) {
+		return
 	}
-
-	go s.runServiceChecker(ctx)
-	s.stopLock.Unlock()
 
 	word := "Started"
 	if s.Disabled || len(s.services) == 0 {
@@ -298,16 +326,20 @@ func (s *Services) Running() bool {
 	s.stopLock.Lock()
 	actionChan := s.actionChan
 	replyChan := s.replyChan
+	stopped := s.stopped
 	stopping := s.stopping
 	s.stopLock.Unlock()
 
-	if actionChan == nil || stopping {
+	if actionChan == nil || stopping || !sendLive(actionChan, actionCheck, stopped) {
 		return false
 	}
 
-	actionChan <- actionCheck
-
-	return <-replyChan
+	select {
+	case running := <-replyChan:
+		return running
+	case <-stopped:
+		return false
+	}
 }
 
 func (s *Services) Pause() {
@@ -321,12 +353,15 @@ func (s *Services) Resume() {
 func (s *Services) sendAction(act action) {
 	s.stopLock.Lock()
 	actionChan := s.actionChan
+	stopped := s.stopped
 	stopping := s.stopping
 	s.stopLock.Unlock()
 
-	if actionChan != nil && !stopping {
-		actionChan <- act
+	if actionChan == nil || stopping {
+		return
 	}
+
+	sendLive(actionChan, act, stopped)
 }
 
 // Stop ends all service checker routines.
@@ -358,6 +393,7 @@ func (s *Services) Stop() {
 	s.actionChan = nil
 	s.triggerChan = nil
 	s.checkChan = nil
+	s.replyChan = nil
 	s.cancel = nil
 	s.stopped = nil
 	s.stopping = false

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -48,6 +48,8 @@ func (s *Services) add(svc *ServiceConfig) {
 	// Add this validated service to our service map.
 	s.services[svc.Name] = &Service{
 		ServiceConfig: svc,
+		State:         StateUnknown,
+		Since:         time.Now(),
 	}
 }
 
@@ -234,14 +236,14 @@ func (s *Services) runServiceChecker() { //nolint:cyclop,funlen
 			}
 		case event := <-s.checkChan:
 			s.log.Printf(event.ReqID, "Running service check '%s' via event: %s, buffer: %d/%d",
-				event.ReqID, event.Service.Name, event.Source, len(s.checks), cap(s.checks))
+				event.Service.Name, event.Source, len(s.checks), cap(s.checks))
 
 			if s.runCheck(event.Service, true, time.Now()) {
 				s.SendResults(&Results{What: event.Source, Svcs: s.GetResults()}, event.ReqID)
 			}
 		case input := <-s.triggerChan:
 			s.log.Printf(input.ReqID, "Running all service checks via event: %s, buffer: %d/%d",
-				input.ReqID, input.Type, len(s.checks), cap(s.checks))
+				input.Type, len(s.checks), cap(s.checks))
 			s.runChecks(true, time.Now())
 
 			if input.Type != "log" {
@@ -255,7 +257,7 @@ func (s *Services) runServiceChecker() { //nolint:cyclop,funlen
 				continue
 			}
 
-			s.log.Printf(input.ReqID, "Service Checks Payload (log only):", string(data))
+			s.log.Printf(input.ReqID, "Service Checks Payload (log only): %s", string(data))
 		case now := <-checker.C:
 			if s.runChecks(false, now) {
 				s.SendResults(&Results{What: website.EventCron, Svcs: s.GetResults()}, reqID)

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -2,8 +2,10 @@ package services_test
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -200,24 +202,74 @@ func waitFinished(t *testing.T, done <-chan struct{}) {
 	}
 }
 
+// waitUntilCheckerLive blocks until Start has published checker channels.
+func waitUntilCheckerLive(t *testing.T, svc *services.Services, name string) {
+	t.Helper()
+
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if !errors.Is(svc.RunCheck(t.Context(), website.EventAPI, name), services.ErrSvcsStopped) {
+			return
+		}
+
+		select {
+		case <-timer.C:
+			t.Fatal("timed out waiting for Start to enter checker lifecycle")
+		case <-ticker.C:
+		}
+	}
+}
+
+// runUntilStopped runs work until Stop returns, after at least one call has finished.
+func runUntilStopped(t *testing.T, stop func(), work func()) {
+	t.Helper()
+
+	var stopping, signaled atomic.Bool
+
+	ready := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		for {
+			work()
+
+			if signaled.CompareAndSwap(false, true) {
+				close(ready)
+			}
+
+			if stopping.Load() {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-ready:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for producer to become active")
+	}
+
+	stop()
+	stopping.Store(true)
+	waitFinished(t, done)
+}
+
 func TestRunningAndStopDoNotDeadlock(t *testing.T) {
 	t.Parallel()
 
 	svc := services.New(&services.Config{Disabled: true})
 	svc.Start(t.Context(), "")
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-
-		for range 100 {
-			_ = svc.Running()
-		}
-	}()
-
-	time.Sleep(10 * time.Millisecond)
-	svc.Stop()
-	waitFinished(t, done)
+	runUntilStopped(t, svc.Stop, func() {
+		_ = svc.Running()
+	})
 }
 
 func TestRunCheckAndStopDoNotDeadlock(t *testing.T) {
@@ -238,19 +290,10 @@ func TestRunCheckAndStopDoNotDeadlock(t *testing.T) {
 	}}))
 	svc.Start(t.Context(), "")
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-
-		for range 50 {
-			_ = svc.RunCheck(t.Context(), website.EventAPI, "web")
-			svc.RunChecks(&common.ActionInput{Type: "log", ReqID: "race"})
-		}
-	}()
-
-	time.Sleep(10 * time.Millisecond)
-	svc.Stop()
-	waitFinished(t, done)
+	runUntilStopped(t, svc.Stop, func() {
+		_ = svc.RunCheck(t.Context(), website.EventAPI, "web")
+		svc.RunChecks(&common.ActionInput{Type: "log", ReqID: "race"})
+	})
 }
 
 func TestAddAfterEmptyStartCanRunCheck(t *testing.T) {
@@ -297,10 +340,11 @@ func TestConcurrentStartAndStop(t *testing.T) {
 
 		done := make(chan struct{})
 		go func() {
+			defer close(done)
 			svc.Start(t.Context(), "")
-			close(done)
 		}()
 
+		waitUntilCheckerLive(t, svc, "web")
 		svc.Stop()
 		waitFinished(t, done)
 		svc.Stop()

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -189,3 +189,120 @@ func TestStopCancelsInFlightHTTP(t *testing.T) {
 
 	svc.Stop() // no-op Stop must not hang or log as a fresh shutdown
 }
+
+func waitFinished(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for service checker lifecycle")
+	}
+}
+
+func TestRunningAndStopDoNotDeadlock(t *testing.T) {
+	t.Parallel()
+
+	svc := services.New(&services.Config{Disabled: true})
+	svc.Start(t.Context(), "")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		for range 100 {
+			_ = svc.Running()
+		}
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	svc.Stop()
+	waitFinished(t, done)
+}
+
+func TestRunCheckAndStopDoNotDeadlock(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	svc := services.New(&services.Config{Disabled: true})
+	require.NoError(t, svc.Add([]services.ServiceConfig{{
+		Name:     "web",
+		Type:     services.CheckHTTP,
+		Value:    server.URL,
+		Timeout:  cnfg.Duration{Duration: time.Second},
+		Interval: cnfg.Duration{Duration: time.Minute},
+	}}))
+	svc.Start(t.Context(), "")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		for range 50 {
+			_ = svc.RunCheck(t.Context(), website.EventAPI, "web")
+			svc.RunChecks(&common.ActionInput{Type: "log", ReqID: "race"})
+		}
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	svc.Stop()
+	waitFinished(t, done)
+}
+
+func TestAddAfterEmptyStartCanRunCheck(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		close(started)
+		writer.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	svc := services.New(&services.Config{Disabled: true})
+	svc.Start(t.Context(), "")
+	t.Cleanup(svc.Stop)
+
+	require.NoError(t, svc.Add([]services.ServiceConfig{{
+		Name:     "late",
+		Type:     services.CheckHTTP,
+		Value:    server.URL,
+		Timeout:  cnfg.Duration{Duration: time.Second},
+		Interval: cnfg.Duration{Duration: time.Minute},
+	}}))
+	require.NoError(t, svc.RunCheck(t.Context(), website.EventAPI, "late"))
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("check queued after empty Start never ran; worker pool was empty")
+	}
+}
+
+func TestConcurrentStartAndStop(t *testing.T) {
+	t.Parallel()
+
+	for range 10 {
+		svc := services.New(&services.Config{Disabled: true})
+		require.NoError(t, svc.Add([]services.ServiceConfig{{
+			Name:    "web",
+			Type:    services.CheckTCP,
+			Value:   "127.0.0.1:9",
+			Timeout: cnfg.Duration{Duration: 50 * time.Millisecond},
+		}}))
+
+		done := make(chan struct{})
+		go func() {
+			svc.Start(t.Context(), "")
+			close(done)
+		}()
+
+		svc.Stop()
+		waitFinished(t, done)
+		svc.Stop()
+	}
+}

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -1,0 +1,191 @@
+package services_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Notifiarr/notifiarr/pkg/services"
+	"github.com/Notifiarr/notifiarr/pkg/triggers/common"
+	"github.com/Notifiarr/notifiarr/pkg/website"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golift.io/cnfg"
+)
+
+func TestNewAddGetResults(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	require := require.New(t)
+
+	svc := services.New(&services.Config{})
+	assert.Zero(svc.SvcCount())
+	assert.Empty(svc.GetResults())
+
+	err := svc.Add([]services.ServiceConfig{
+		{
+			Name:     "web",
+			Type:     services.CheckHTTP,
+			Value:    "http://example.com/health",
+			Tags:     map[string]any{"env": "test"},
+			Interval: cnfg.Duration{Duration: time.Second},
+			Timeout:  cnfg.Duration{Duration: 50 * time.Millisecond},
+		},
+		{
+			Name:  "db",
+			Type:  services.CheckTCP,
+			Value: "127.0.0.1:5432",
+		},
+	})
+	require.NoError(err)
+	assert.Equal(2, svc.SvcCount())
+
+	got := resultsByName(svc.GetResults())
+	require.Contains(got, "web")
+	require.Contains(got, "db")
+	assert.Equal("http://example.com/health", got["web"].Check)
+	assert.Equal("200", got["web"].Expect)
+	assert.Equal(services.CheckHTTP, got["web"].Type)
+	assert.Equal(services.MinimumCheckInterval, got["web"].IntervalDur)
+	assert.Equal("test", got["web"].Metadata["env"])
+	assert.Equal("127.0.0.1:5432", got["db"].Check)
+	assert.Equal(services.CheckTCP, got["db"].Type)
+	assert.Equal(services.StateUnknown, got["web"].State)
+}
+
+func TestAddRejectsInvalidAndKeepsPrior(t *testing.T) {
+	t.Parallel()
+
+	svc := services.New(&services.Config{})
+	err := svc.Add([]services.ServiceConfig{
+		{Name: "good", Type: services.CheckTCP, Value: "127.0.0.1:80"},
+		{Name: "bad", Type: services.CheckTCP, Value: "no-port"},
+	})
+	require.ErrorIs(t, err, services.ErrBadTCP)
+	assert.Equal(t, 1, svc.SvcCount(), "the valid service added before the error is kept")
+}
+
+func TestAddOverwritesSameName(t *testing.T) {
+	t.Parallel()
+
+	svc := services.New(&services.Config{})
+	require.NoError(t, svc.Add([]services.ServiceConfig{
+		{Name: "svc", Type: services.CheckTCP, Value: "127.0.0.1:80"},
+		{Name: "svc", Type: services.CheckTCP, Value: "127.0.0.1:443"},
+	}))
+
+	got := resultsByName(svc.GetResults())
+	require.Len(t, got, 1)
+	assert.Equal(t, "127.0.0.1:443", got["svc"].Check)
+}
+
+func TestStoppedCheckerGuards(t *testing.T) {
+	t.Parallel()
+
+	svc := services.New(&services.Config{})
+	assert.False(t, svc.Running())
+
+	require.NoError(t, svc.Add([]services.ServiceConfig{
+		{Name: "web", Type: services.CheckHTTP, Value: "http://example.com"},
+	}))
+
+	err := svc.RunCheck(t.Context(), website.EventAPI, "web")
+	require.ErrorIs(t, err, services.ErrSvcsStopped)
+
+	err = svc.RunCheck(t.Context(), website.EventAPI, "missing")
+	require.ErrorIs(t, err, services.ErrSvcsStopped)
+
+	svc.RunChecks(&common.ActionInput{Type: website.EventAPI, ReqID: "test"})
+	svc.Pause()
+	svc.Resume()
+	svc.Stop()
+}
+
+func TestDisabledCheckerLifecycle(t *testing.T) {
+	t.Parallel()
+
+	svc := services.New(&services.Config{Disabled: true})
+	svc.Start(t.Context(), "Theater")
+	t.Cleanup(svc.Stop)
+
+	assert.False(t, svc.Running(), "disabled checkers start paused")
+
+	svc.Resume()
+	assert.True(t, svc.Running())
+	svc.Pause()
+	assert.False(t, svc.Running())
+
+	require.NoError(t, svc.Add([]services.ServiceConfig{
+		{
+			Name:  "listed",
+			Type:  services.CheckTCP,
+			Value: "127.0.0.1:9",
+			Tags:  map[string]any{"role": "db"},
+		},
+	}))
+
+	listReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/services/list", nil)
+	listReq = mux.SetURLVars(listReq, map[string]string{"action": "list"})
+	code, body := svc.APIHandler(listReq)
+	assert.Equal(t, http.StatusOK, code)
+
+	results, ok := body.([]*services.CheckResult)
+	require.True(t, ok)
+	got := resultsByName(results)
+	require.Contains(t, got, "listed")
+	assert.Equal(t, "127.0.0.1:9", got["listed"].Check)
+
+	badReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/services/nope", nil)
+	badReq = mux.SetURLVars(badReq, map[string]string{"action": "nope"})
+	code, body = svc.APIHandler(badReq)
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "unknown service action: nope", body)
+
+	svc.RunChecks(&common.ActionInput{Type: "log", ReqID: "test"})
+
+	raw, err := json.Marshal(got["listed"])
+	require.NoError(t, err)
+	assert.NotEmpty(t, raw)
+}
+
+func TestStopCancelsInFlightHTTP(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		close(started)
+		<-req.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	svc := services.New(&services.Config{Disabled: true})
+	require.NoError(t, svc.Add([]services.ServiceConfig{{
+		Name:     "slow",
+		Type:     services.CheckHTTP,
+		Value:    server.URL,
+		Timeout:  cnfg.Duration{Duration: 10 * time.Second},
+		Interval: cnfg.Duration{Duration: time.Minute},
+	}}))
+
+	svc.Start(t.Context(), "")
+	require.NoError(t, svc.RunCheck(t.Context(), website.EventAPI, "slow"))
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("http check did not start")
+	}
+
+	begin := time.Now()
+	svc.Stop()
+	assert.Less(t, time.Since(begin), 2*time.Second, "Stop should cancel the in-flight HTTP check")
+
+	got := resultsByName(svc.GetResults())
+	require.Contains(t, got, "slow")
+	assert.Equal(t, services.StateUnknown, got["slow"].State, "canceled checks must not persist Critical")
+
+	svc.Stop() // no-op Stop must not hang or log as a fresh shutdown
+}

--- a/pkg/services/types_test.go
+++ b/pkg/services/types_test.go
@@ -1,0 +1,72 @@
+package services_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Notifiarr/notifiarr/pkg/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckStateStringAndValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		state services.CheckState
+		name  string
+		value uint
+	}{
+		{services.StateOK, "OK", 0},
+		{services.StateWarning, "Warning", 1},
+		{services.StateCritical, "Critical", 2},
+		{services.StateUnknown, "Unknown", 3},
+		{services.CheckState(99), "Unknown", 99},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.name, test.state.String())
+			assert.Equal(t, test.value, test.state.Value())
+		})
+	}
+}
+
+func TestOutputStringAndJSON(t *testing.T) {
+	t.Parallel()
+
+	var nilOutput *services.Output
+
+	assert.Empty(t, nilOutput.String())
+
+	plain := &services.Output{}
+	require.NoError(t, json.Unmarshal([]byte(`"hello & world"`), plain))
+	assert.Equal(t, "hello & world", plain.String())
+
+	raw, err := json.Marshal(plain)
+	require.NoError(t, err)
+	assert.JSONEq(t, `"hello & world"`, string(raw))
+
+	escaped := &services.Output{}
+	require.NoError(t, json.Unmarshal([]byte(`"Tom &amp; Jerry"`), escaped))
+	// Unmarshal stores the JSON string as-is; String() unescapes only when esc is set,
+	// which CheckOnly sets for HTTP error bodies. Marshal must not unescape.
+	raw, err = json.Marshal(escaped)
+	require.NoError(t, err)
+	assert.JSONEq(t, `"Tom &amp; Jerry"`, string(raw))
+}
+
+func TestPackageDefaults(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "http", string(services.CheckHTTP))
+	assert.Equal(t, "tcp", string(services.CheckTCP))
+	assert.Equal(t, "ping", string(services.CheckPING))
+	assert.Equal(t, "icmp", string(services.CheckICMP))
+	assert.Equal(t, "process", string(services.CheckPROC))
+	assert.Equal(t, "Plex Server", services.PlexServerName)
+	assert.Equal(t, 10, int(services.MinimumCheckInterval.Seconds()))
+	assert.Equal(t, 1, int(services.MinimumTimeout.Seconds()))
+	assert.Equal(t, 10, int(services.DefaultTimeout.Seconds()))
+}

--- a/pkg/services/validate_test.go
+++ b/pkg/services/validate_test.go
@@ -1,0 +1,268 @@
+package services_test
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/Notifiarr/notifiarr/pkg/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golift.io/cnfg"
+)
+
+func TestServiceConfigValidate(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     services.ServiceConfig
+		wantErr error
+		after   func(*testing.T, services.ServiceConfig)
+	}{
+		{
+			name:    "missing name",
+			cfg:     services.ServiceConfig{Type: services.CheckTCP, Value: "127.0.0.1:80"},
+			wantErr: services.ErrNoName,
+		},
+		{
+			name:    "missing value",
+			cfg:     services.ServiceConfig{Name: "empty", Type: services.CheckHTTP},
+			wantErr: services.ErrNoCheck,
+		},
+		{
+			name:    "invalid type",
+			cfg:     services.ServiceConfig{Name: "ftp", Type: "ftp", Value: "x"},
+			wantErr: services.ErrInvalidType,
+		},
+		{
+			name:    "tcp missing port",
+			cfg:     services.ServiceConfig{Name: "tcp", Type: services.CheckTCP, Value: "localhost"},
+			wantErr: services.ErrBadTCP,
+		},
+		{
+			name: "http defaults and clamps",
+			cfg: services.ServiceConfig{
+				Name:     "http",
+				Type:     services.CheckHTTP,
+				Value:    "http://example.com",
+				Timeout:  cnfg.Duration{Duration: 50 * time.Millisecond},
+				Interval: cnfg.Duration{Duration: time.Second},
+			},
+			after: func(t *testing.T, cfg services.ServiceConfig) {
+				t.Helper()
+				assert.Equal(t, "200", cfg.Expect)
+				assert.Equal(t, services.MinimumTimeout, cfg.Timeout.Duration)
+				assert.Equal(t, services.MinimumCheckInterval, cfg.Interval.Duration)
+			},
+		},
+		{
+			name: "http default timeout when unset",
+			cfg: services.ServiceConfig{
+				Name:  "http-timeout",
+				Type:  services.CheckHTTP,
+				Value: "http://example.com",
+			},
+			after: func(t *testing.T, cfg services.ServiceConfig) {
+				t.Helper()
+				assert.Equal(t, services.DefaultTimeout, cfg.Timeout.Duration)
+			},
+		},
+		{
+			name: "http ssl expect is accepted",
+			cfg: services.ServiceConfig{
+				Name:   "https",
+				Type:   services.CheckHTTP,
+				Value:  "https://example.com",
+				Expect: "200,SSL",
+			},
+		},
+		{
+			name: "tcp ok",
+			cfg: services.ServiceConfig{
+				Name:  "tcp-ok",
+				Type:  services.CheckTCP,
+				Value: "127.0.0.1:3306",
+			},
+		},
+		{
+			name: "process missing value is no-check",
+			cfg: services.ServiceConfig{
+				Name: "proc",
+				Type: services.CheckPROC,
+			},
+			wantErr: services.ErrNoCheck,
+		},
+		{
+			name: "process invalid expect",
+			cfg: services.ServiceConfig{
+				Name:   "proc-bad",
+				Type:   services.CheckPROC,
+				Value:  "nginx",
+				Expect: "nope",
+			},
+			wantErr: services.ErrProcExpect,
+		},
+		{
+			name: "process running with count",
+			cfg: services.ServiceConfig{
+				Name:   "proc-count-running",
+				Type:   services.CheckPROC,
+				Value:  "nginx",
+				Expect: "running,count:1:2",
+			},
+			wantErr: services.ErrCountZero,
+		},
+		{
+			name: "process invalid min count",
+			cfg: services.ServiceConfig{
+				Name:   "proc-min",
+				Type:   services.CheckPROC,
+				Value:  "nginx",
+				Expect: "count:abc",
+			},
+		},
+		{
+			name: "process invalid max count",
+			cfg: services.ServiceConfig{
+				Name:   "proc-max",
+				Type:   services.CheckPROC,
+				Value:  "nginx",
+				Expect: "count:1:xyz",
+			},
+		},
+		{
+			name: "process invalid regex",
+			cfg: services.ServiceConfig{
+				Name:  "proc-re",
+				Type:  services.CheckPROC,
+				Value: "/(unclosed/",
+			},
+		},
+		{
+			name: "process ok with regex and counts",
+			cfg: services.ServiceConfig{
+				Name:   "proc-ok",
+				Type:   services.CheckPROC,
+				Value:  "/nginx|caddy/",
+				Expect: "count:1:3,restart",
+			},
+		},
+		{
+			name: "ping missing value is no-check",
+			cfg: services.ServiceConfig{
+				Name: "ping",
+				Type: services.CheckPING,
+			},
+			wantErr: services.ErrNoCheck,
+		},
+		{
+			name: "ping bad expect shape",
+			cfg: services.ServiceConfig{
+				Name:   "ping-shape",
+				Type:   services.CheckPING,
+				Value:  "127.0.0.1",
+				Expect: "3:2",
+			},
+			wantErr: services.ErrPingExpect,
+		},
+		{
+			name: "ping zero interval",
+			cfg: services.ServiceConfig{
+				Name:   "ping-zero",
+				Type:   services.CheckICMP,
+				Value:  "127.0.0.1",
+				Expect: "3:2:0",
+			},
+			wantErr: services.ErrPingExpect,
+		},
+		{
+			name: "ping min greater than count",
+			cfg: services.ServiceConfig{
+				Name:   "ping-min",
+				Type:   services.CheckPING,
+				Value:  "127.0.0.1",
+				Expect: "2:3:100",
+			},
+			wantErr: services.ErrPingExpect,
+		},
+		{
+			name: "ping invalid count",
+			cfg: services.ServiceConfig{
+				Name:   "ping-count",
+				Type:   services.CheckPING,
+				Value:  "127.0.0.1",
+				Expect: "x:1:100",
+			},
+		},
+		{
+			name: "ping invalid min",
+			cfg: services.ServiceConfig{
+				Name:   "ping-min-parse",
+				Type:   services.CheckPING,
+				Value:  "127.0.0.1",
+				Expect: "1:x:100",
+			},
+		},
+		{
+			name: "ping invalid interval",
+			cfg: services.ServiceConfig{
+				Name:   "ping-int-parse",
+				Type:   services.CheckPING,
+				Value:  "127.0.0.1",
+				Expect: "1:1:x",
+			},
+		},
+		{
+			name: "ping ok",
+			cfg: services.ServiceConfig{
+				Name:   "ping-ok",
+				Type:   services.CheckPING,
+				Value:  "127.0.0.1",
+				Expect: "3:2:100",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := test.cfg
+			err := cfg.Validate()
+			wantErr := test.wantErr
+
+			if test.name == "process ok with regex and counts" && runtime.GOOS == "freebsd" {
+				wantErr = services.ErrBSDRestart
+			}
+
+			if wantErr != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, wantErr)
+
+				return
+			}
+
+			parseErrors := map[string]struct{}{
+				"process invalid min count": {},
+				"process invalid max count": {},
+				"process invalid regex":     {},
+				"ping invalid count":        {},
+				"ping invalid min":          {},
+				"ping invalid interval":     {},
+			}
+			if _, isParseErr := parseErrors[test.name]; isParseErr {
+				require.Error(t, err)
+				assert.NotEmpty(t, err.Error())
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			if test.after != nil {
+				test.after(t, cfg)
+			}
+		})
+	}
+}

--- a/pkg/website/debuglog.go
+++ b/pkg/website/debuglog.go
@@ -22,7 +22,7 @@ func (s *server) debughttplog(
 
 		for k, vs := range resp.Header {
 			for _, v := range vs {
-				headers.WriteString(k + ": " + v + "\n")
+				fmt.Fprintf(&headers, "%s: %s\n", k, v)
 			}
 		}
 	}

--- a/pkg/website/server.go
+++ b/pkg/website/server.go
@@ -87,11 +87,19 @@ func New(ctx context.Context, config *Config) {
 
 // SendData puts a POST request to notifiarr.com into a channel queue.
 func SendData(req *Request) {
+	if site == nil || site.sendData == nil {
+		return
+	}
+
 	site.sendData <- req
 }
 
 // GetData sends data to a notifiarr URL as JSON and returns a response.
 func GetData(req *Request) (*Response, error) {
+	if site == nil || site.sendData == nil {
+		return nil, ErrNoChannel
+	}
+
 	req.respChan = make(chan *chResponse)
 	defer close(req.respChan)
 


### PR DESCRIPTION
## Summary
- Add unit tests for the services package (collectors, validate, HTTP/TCP/process checks, checker lifecycle).
- Fix several service-check bugs: NZBGet already-authed URLs, Add starting at Unknown, SABnzbd/Tautulli/Plex using the wrong config, and log format mistakes.
- Make Stop cancel in-flight checks (including ping), avoid the check-queue deadlock, reuse HTTP clients, ~~skip idle workers when there are no services~~, and collapse the Starr/HTTP collectors.

## Test plan
- [ ] `go test ./pkg/services/ -count=1`
- [ ] `golangci-lint run ./pkg/services/`
- [ ] Reload/stop the client with HTTP and ping checks configured and confirm Stop does not wait out the check timeout
- [ ] Confirm Starr/download-client service URLs and expect codes still look right in the UI


Made with [Cursor](https://cursor.com)