### PR TITLE
Fix Trust Profile password vs header fields

### DIFF
--- a/frontend/src/api/profile.svelte.ts
+++ b/frontend/src/api/profile.svelte.ts
@@ -78,18 +78,27 @@ class ConfigProfile {
   }
 
   /** Use trustProfile to update the authZ/authN configuration on the backend and reload. */
-  public async trustProfile(form: ProfilePost) {
+  public async trustProfile(form: ProfilePost): Promise<boolean> {
     this.status = get(_)('phrases.SavingConfiguration')
     this.error = ''
+    this.formError = ''
     this.updated = null
-    form.password = CryptoJS.MD5(form.password).toString()
-    form.newPass = CryptoJS.MD5(form.newPass).toString()
 
-    const { ok, body } = await postUi('profile', JSON.stringify(form), false)
+    const payload = { ...form }
+    if (payload.password) payload.password = CryptoJS.MD5(payload.password).toString()
+    if (payload.newPass) payload.newPass = CryptoJS.MD5(payload.newPass).toString()
 
-    if (!ok) this.formError = this.error = body
-    else await this.waitForReload()
+    const { ok, body } = await postUi('profile', JSON.stringify(payload), false)
+
+    if (!ok) {
+      this.status = ''
+      this.formError = this.error = body
+      return false
+    }
+
+    await this.waitForReload()
     this.status = ''
+    return true
   }
 
   /** Use writeConfig to update a partial configuration on the backend and reload. */

--- a/frontend/src/includes/locale/en.json
+++ b/frontend/src/includes/locale/en.json
@@ -418,7 +418,7 @@
     "phrase": {
       "ShowMoreDesc": "Three authentication types are currently supported. Auth Proxy and No Password are only available if the current request comes from a valid, configured upstream IP address.",
       "PasswordOnlyUsed": "Username and Password are only used if Authentication Type is set to Password.",
-      "HeaderOnlyUsed": "Auth Header is only used if Authentication Type is <b>not</b> set to Password.",
+      "HeaderOnlyUsed": "Auth Header is only used if Authentication Type is set to Header or No Password.",
       "AuthTypeChange": "If Authentication Type changes, log out to complete the process.",
       "ProfileUpdated": "Profile updated successfully {timeDuration} ago!",
       "EnterCurrentPassword": "Enter your current password to make changes.",

--- a/frontend/src/pages/profile/Index.svelte
+++ b/frontend/src/pages/profile/Index.svelte
@@ -19,6 +19,7 @@
   import Footer from '../../includes/Footer.svelte'
   import { onMount } from 'svelte'
   import Header from './Header.svelte'
+  import { nav } from '../../navigation/nav.svelte'
 
   // Form state, this is what we're sending to the backend.
   const form = $state({
@@ -27,15 +28,23 @@
     authType: $profile?.upstreamType || Auth.password,
     upstreams: $profile?.config.upstreams?.join(' ') || '',
     newPass: '',
-    header: $profile?.config.uiPassword.startsWith('webauth:')
-      ? $profile?.config.uiPassword.split(':')[1]
-      : '',
+    header: $profile?.upstreamHeader || '',
   })
+
+  // Native <select> may stringify enum values; keep comparisons numeric.
+  const authType = $derived(Number(form.authType) as Auth)
+  const origUpstreams = $derived($profile?.config.upstreams?.join(' ') || '')
+  const reservedUser = $derived(
+    form.username == 'webauth' ||
+      form.username == 'noauth' ||
+      form.username == 'website' ||
+      form.username.includes(':'),
+  )
 
   async function submit(e: Event) {
     e.preventDefault()
-    await profile.trustProfile(form)
-    form.newPass = form.password = ''
+    const ok = await profile.trustProfile({ ...form, authType })
+    if (ok) form.newPass = form.password = ''
   }
 
   function addit(e: Event) {
@@ -46,31 +55,34 @@
   }
 
   // Clear the status messages when the component unmounts.
-  onMount(() => () => profile.clearStatus())
+  onMount(() => () => {
+    profile.clearStatus()
+    nav.formChanged = false
+  })
+
+  $effect(() => {
+    nav.formChanged =
+      authType !== $profile?.upstreamType ||
+      form.upstreams !== origUpstreams ||
+      form.header !== ($profile?.upstreamHeader || '') ||
+      form.username !== ($profile?.username || '') ||
+      !!form.newPass
+  })
 
   const saveDisabled = $derived(
-    // If current auth type is password/website, make sure their password is entered.
+    // Current password/website auth requires the current password to save.
     ([Auth.password, Auth.website].includes($profile?.upstreamType) &&
       (!form.password || form.password.length < 5)) ||
-      // If selected auth type is password and they entered a new password, make sure it's at least 9 characters.
-      (form.authType === Auth.password && form.newPass && form.newPass.length < 9) ||
-      // If they changed the auth type to password from something else, make sure they entered a new password.
-      (form.authType === Auth.password &&
+      // New local password must be at least 9 characters when provided.
+      (authType === Auth.password && form.newPass.length > 0 && form.newPass.length < 9) ||
+      // Switching to password requires a new password and a usable username.
+      (authType === Auth.password &&
         $profile?.upstreamType !== Auth.password &&
         form.newPass.length < 9) ||
-      // Make sure they picked a header if header auth type is selected.
-      (form.authType === Auth.header && !form.header) ||
-      // Make sure they didn't enter a username that's not allowed.
-      form.username == 'webauth' ||
-      form.username == 'noauth' ||
-      form.username == 'website' ||
-      form.username.includes(':') ||
-      // Make sure the auth type changed, or upstreams changed.
-      (form.authType === Auth.noauth &&
-        $profile?.upstreamType === Auth.noauth &&
-        form.upstreams === $profile?.upstreamIp) ||
-      // Enable the save button.
-      false,
+      (authType === Auth.password && (!form.username || reservedUser)) ||
+      // Header auth requires a header; noauth may omit it.
+      (authType === Auth.header && !form.header) ||
+      !nav.formChanged,
   )
 </script>
 
@@ -112,7 +124,7 @@
 
     <!-- Authentication Section -->
     <h4>{$_('profile.title.Authentication')}</h4>
-    {#if [Auth.password, Auth.website].includes(form.authType)}
+    {#if authType === Auth.header || authType === Auth.noauth}
       <Row>
         <Col md={8}>
           <Input id="profile.header" type="select" bind:value={form.header}>
@@ -135,7 +147,7 @@
           </Input>
         </Col>
       </Row>
-    {:else if form.authType !== Auth.website}
+    {:else if authType === Auth.password}
       <Row>
         <Col md={8}>
           <Input

--- a/pkg/client/gui_profile.go
+++ b/pkg/client/gui_profile.go
@@ -265,6 +265,7 @@ func (c *Client) handleProfilePost(response http.ResponseWriter, request *http.R
 	case post.AuthType == configfile.AuthWebsite:
 		logs.Log.Printf(mnd.GetID(request.Context()),
 			"[gui '%s' requested] Enabled WebUI website authentication.", currUser)
+		c.setSession(currUser, response, request)
 		http.Error(response, "Enabled WebUI website authentication.", http.StatusOK)
 		c.reloadAppNow()
 	default:

--- a/pkg/client/gui_profile.go
+++ b/pkg/client/gui_profile.go
@@ -262,6 +262,11 @@ func (c *Client) handleProfilePost(response http.ResponseWriter, request *http.R
 		logs.Log.Printf(mnd.GetID(request.Context()), "[gui '%s' requested] Disabled WebUI authentication.", currUser)
 		http.Error(response, "Disabled WebUI authentication.", http.StatusOK)
 		c.reloadAppNow()
+	case post.AuthType == configfile.AuthWebsite:
+		logs.Log.Printf(mnd.GetID(request.Context()),
+			"[gui '%s' requested] Enabled WebUI website authentication.", currUser)
+		http.Error(response, "Enabled WebUI website authentication.", http.StatusOK)
+		c.reloadAppNow()
 	default:
 		logs.Log.Printf(mnd.GetID(request.Context()),
 			"[gui '%s' requested] Enabled WebUI proxy authentication, header: %s", currUser, post.Header)


### PR DESCRIPTION
## Summary
- The Trust Profile page showed the auth-header picker when Password was selected, and username/new-password when Header was selected ([#1255](https://github.com/Notifiarr/notifiarr/issues/1255)).
- Saving no longer MD5-hashes an empty new password (which could replace the stored password with the hash of `""`).
- Website credential auth is handled as its own save path instead of logging as proxy auth.

## Test plan
- [ ] With Password auth: Trust Profile shows username + new password + current password; changing the password works and you can log in with the new one.
- [ ] With Header auth: Trust Profile shows the header picker, not password fields; saving a header works.
- [ ] Website Credentials: no header/password-new fields; save still works when current password is provided.
- [ ] No Password: header picker is optional; save is enabled when upstreams/header actually change.

Fixes #1255


Made with [Cursor](https://cursor.com)