### PR TITLE
Honor container TZ in client logs

### DIFF
--- a/init/docker/Dockerfile.alpine
+++ b/init/docker/Dockerfile.alpine
@@ -41,7 +41,7 @@ FROM alpine
 # Copy the binary.
 COPY --from=builder /tmp/notifiarr /
 # Other tools. (iostat is the wrong version on Alpine.)
-RUN apk add ipmitool smartmontools zfs sysstat && \
+RUN apk add ipmitool smartmontools zfs sysstat tzdata && \
     rm -f /bin/iostat
 # Defaults.
 ENV TZ=UTC

--- a/init/docker/Dockerfile.cuda
+++ b/init/docker/Dockerfile.cuda
@@ -50,7 +50,7 @@ FROM nvidia/cuda:13.3.1-base-ubuntu24.04
 COPY --from=builder /tmp/notifiarr /
 # Other tools.
 RUN DEBIAN_FRONTEND=noninteractive apt update \
-    && apt install -y smartmontools ipmitool zfsutils-linux sysstat libncurses6 \
+    && apt install -y smartmontools ipmitool zfsutils-linux sysstat libncurses6 tzdata \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
 # For LSI Avago Broadcom MegaCli.

--- a/init/docker/Dockerfile.ubuntu
+++ b/init/docker/Dockerfile.ubuntu
@@ -47,7 +47,7 @@ FROM ubuntu:24.04
 COPY --from=builder /tmp/notifiarr /
 # Other tools.
 RUN DEBIAN_FRONTEND=noninteractive apt update \
-    && apt install -y smartmontools ipmitool zfsutils-linux sysstat libncurses6 \
+    && apt install -y smartmontools ipmitool zfsutils-linux sysstat libncurses6 tzdata \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
 # For LSI Avago Broadcom MegaCli.

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"log"
 	"runtime/debug"
+	_ "time/tzdata" // so TZ= works without distro tzdata (Alpine/Docker).
 
 	"github.com/Notifiarr/notifiarr/pkg/client"
 	"github.com/Notifiarr/notifiarr/pkg/mnd"


### PR DESCRIPTION
## Summary
- Alpine (the default `latest` image) did not install `tzdata`, so Go could not load `TZ` and log timestamps stayed UTC even when Unraid/TrueNAS set the timezone ([#1258](https://github.com/Notifiarr/notifiarr/issues/1258)).
- Install `tzdata` in the Docker images and embed `time/tzdata` in the binary so `TZ=` works without distro zoneinfo.

## Test plan
- [ ] Run the Alpine image with `-e TZ=America/New_York` and confirm log timestamps are local, not UTC.
- [ ] Default `TZ=UTC` still logs UTC.
- [ ] Ubuntu/CUDA images still start and honor `TZ`.

Fixes #1258


Made with [Cursor](https://cursor.com)