### PR TITLE
Fix swagger comments after ApiResponse rename

### DIFF
--- a/frontend/public/api_swagger.json
+++ b/frontend/public/api_swagger.json
@@ -37,7 +37,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -102,7 +102,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -120,7 +120,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -144,7 +144,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -162,7 +162,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -180,7 +180,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -198,7 +198,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -253,7 +253,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -277,7 +277,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -332,7 +332,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -356,7 +356,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -374,7 +374,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -429,7 +429,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -453,7 +453,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -500,7 +500,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -527,7 +527,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -584,7 +584,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -602,7 +602,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -626,7 +626,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -673,7 +673,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -697,7 +697,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -756,7 +756,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -774,7 +774,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -798,7 +798,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -851,7 +851,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -875,7 +875,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -930,7 +930,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -954,7 +954,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1001,7 +1001,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1028,7 +1028,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1075,7 +1075,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1099,7 +1099,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1148,7 +1148,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1167,7 +1167,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1191,7 +1191,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1250,7 +1250,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1268,7 +1268,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1292,7 +1292,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1349,7 +1349,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1368,7 +1368,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1392,7 +1392,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1439,7 +1439,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1466,7 +1466,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1513,7 +1513,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1540,7 +1540,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1587,7 +1587,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1614,7 +1614,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1671,7 +1671,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1690,7 +1690,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1714,7 +1714,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1781,7 +1781,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1799,7 +1799,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1823,7 +1823,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1841,7 +1841,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1888,7 +1888,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1915,7 +1915,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1977,7 +1977,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -1998,7 +1998,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2022,7 +2022,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2101,7 +2101,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2131,7 +2131,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2178,7 +2178,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2206,7 +2206,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2260,7 +2260,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2287,7 +2287,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2334,7 +2334,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2361,7 +2361,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2415,7 +2415,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2440,7 +2440,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2502,7 +2502,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2527,7 +2527,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2594,7 +2594,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2612,7 +2612,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2636,7 +2636,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2695,7 +2695,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2713,7 +2713,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2737,7 +2737,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2774,7 +2774,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2839,7 +2839,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -2912,7 +2912,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3020,7 +3020,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3044,7 +3044,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3090,7 +3090,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3114,7 +3114,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3167,7 +3167,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3191,7 +3191,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3237,7 +3237,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3261,7 +3261,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3298,7 +3298,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3322,7 +3322,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3381,7 +3381,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3399,7 +3399,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3423,7 +3423,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3480,7 +3480,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3499,7 +3499,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3523,7 +3523,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3570,7 +3570,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3597,7 +3597,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3656,7 +3656,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3674,7 +3674,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3698,7 +3698,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3716,7 +3716,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3734,7 +3734,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3752,7 +3752,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3807,7 +3807,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3831,7 +3831,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3849,7 +3849,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3904,7 +3904,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3928,7 +3928,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -3975,7 +3975,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4002,7 +4002,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4059,7 +4059,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4077,7 +4077,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4101,7 +4101,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4148,7 +4148,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4172,7 +4172,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4231,7 +4231,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4249,7 +4249,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4273,7 +4273,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4326,7 +4326,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4350,7 +4350,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4405,7 +4405,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4435,7 +4435,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4490,7 +4490,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4520,7 +4520,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4567,7 +4567,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4594,7 +4594,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4654,7 +4654,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4672,7 +4672,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4696,7 +4696,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4755,7 +4755,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4779,7 +4779,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4826,7 +4826,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4853,7 +4853,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4908,7 +4908,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4932,7 +4932,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -4979,7 +4979,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5006,7 +5006,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5063,7 +5063,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5081,7 +5081,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5105,7 +5105,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5172,7 +5172,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5190,7 +5190,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5214,7 +5214,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5261,7 +5261,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5285,7 +5285,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5334,7 +5334,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5353,7 +5353,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5377,7 +5377,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5436,7 +5436,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5454,7 +5454,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5478,7 +5478,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5535,7 +5535,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5554,7 +5554,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5578,7 +5578,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5625,7 +5625,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5652,7 +5652,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5699,7 +5699,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5726,7 +5726,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5783,7 +5783,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5802,7 +5802,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5826,7 +5826,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5893,7 +5893,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5911,7 +5911,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5935,7 +5935,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -5953,7 +5953,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6006,7 +6006,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6024,7 +6024,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6048,7 +6048,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6095,7 +6095,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6122,7 +6122,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6169,7 +6169,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6193,7 +6193,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6240,7 +6240,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6267,7 +6267,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6327,7 +6327,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6348,7 +6348,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6372,7 +6372,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6451,7 +6451,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6481,7 +6481,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6528,7 +6528,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6556,7 +6556,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6610,7 +6610,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6637,7 +6637,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6684,7 +6684,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6711,7 +6711,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6765,7 +6765,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6790,7 +6790,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6852,7 +6852,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6877,7 +6877,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6944,7 +6944,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6962,7 +6962,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -6986,7 +6986,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7045,7 +7045,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7063,7 +7063,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7087,7 +7087,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7105,7 +7105,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7123,7 +7123,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7141,7 +7141,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7196,7 +7196,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7220,7 +7220,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7275,7 +7275,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7299,7 +7299,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7317,7 +7317,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7372,7 +7372,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7396,7 +7396,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7443,7 +7443,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7470,7 +7470,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7529,7 +7529,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7547,7 +7547,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7571,7 +7571,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7628,7 +7628,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7647,7 +7647,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7671,7 +7671,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7718,7 +7718,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7745,7 +7745,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7792,7 +7792,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7819,7 +7819,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7876,7 +7876,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7895,7 +7895,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7919,7 +7919,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -7992,7 +7992,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8016,7 +8016,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8034,7 +8034,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8081,7 +8081,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8108,7 +8108,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8187,7 +8187,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8217,7 +8217,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8264,7 +8264,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8292,7 +8292,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8346,7 +8346,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8373,7 +8373,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8420,7 +8420,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8447,7 +8447,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8501,7 +8501,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8526,7 +8526,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8588,7 +8588,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8613,7 +8613,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8680,7 +8680,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8698,7 +8698,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8722,7 +8722,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8781,7 +8781,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8799,7 +8799,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8823,7 +8823,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8860,7 +8860,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8933,7 +8933,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -8957,7 +8957,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9016,7 +9016,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9034,7 +9034,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9058,7 +9058,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9076,7 +9076,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9094,7 +9094,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9112,7 +9112,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9167,7 +9167,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9191,7 +9191,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9209,7 +9209,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9268,7 +9268,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9286,7 +9286,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9310,7 +9310,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9365,7 +9365,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9389,7 +9389,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9444,7 +9444,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9468,7 +9468,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9515,7 +9515,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9542,7 +9542,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9599,7 +9599,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9617,7 +9617,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9641,7 +9641,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9688,7 +9688,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9712,7 +9712,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9779,7 +9779,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9797,7 +9797,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9821,7 +9821,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9874,7 +9874,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9898,7 +9898,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9953,7 +9953,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -9983,7 +9983,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10038,7 +10038,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10062,7 +10062,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10117,7 +10117,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10144,7 +10144,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10191,7 +10191,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10218,7 +10218,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10275,7 +10275,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10293,7 +10293,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10317,7 +10317,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10384,7 +10384,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10402,7 +10402,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10426,7 +10426,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10473,7 +10473,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10500,7 +10500,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10547,7 +10547,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10571,7 +10571,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10620,7 +10620,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10639,7 +10639,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10663,7 +10663,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10722,7 +10722,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10740,7 +10740,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10764,7 +10764,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10821,7 +10821,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10840,7 +10840,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10864,7 +10864,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10911,7 +10911,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10938,7 +10938,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -10985,7 +10985,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11012,7 +11012,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11069,7 +11069,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11088,7 +11088,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11112,7 +11112,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11179,7 +11179,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11197,7 +11197,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11221,7 +11221,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11239,7 +11239,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11292,7 +11292,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11310,7 +11310,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11334,7 +11334,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11381,7 +11381,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11408,7 +11408,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11455,7 +11455,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11479,7 +11479,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11526,7 +11526,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11553,7 +11553,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11613,7 +11613,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11634,7 +11634,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11658,7 +11658,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11737,7 +11737,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11767,7 +11767,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11814,7 +11814,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11841,7 +11841,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11898,7 +11898,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11917,7 +11917,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11941,7 +11941,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -11988,7 +11988,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12012,7 +12012,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12079,7 +12079,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12097,7 +12097,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12121,7 +12121,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12139,7 +12139,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12192,7 +12192,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12210,7 +12210,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12234,7 +12234,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12281,7 +12281,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12309,7 +12309,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12363,7 +12363,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12390,7 +12390,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12449,7 +12449,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12467,7 +12467,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12491,7 +12491,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12538,7 +12538,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12565,7 +12565,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12619,7 +12619,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12644,7 +12644,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12706,7 +12706,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12731,7 +12731,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12786,7 +12786,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12810,7 +12810,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12862,7 +12862,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12883,7 +12883,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12941,7 +12941,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -12962,7 +12962,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13020,7 +13020,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13041,7 +13041,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13093,7 +13093,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13111,7 +13111,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13163,7 +13163,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13215,7 +13215,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13267,7 +13267,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13285,7 +13285,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13350,7 +13350,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13368,7 +13368,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13420,7 +13420,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13438,7 +13438,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13490,7 +13490,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13539,7 +13539,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13596,7 +13596,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13620,7 +13620,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13666,7 +13666,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13684,7 +13684,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13727,7 +13727,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13770,7 +13770,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13822,7 +13822,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13840,7 +13840,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13883,7 +13883,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13926,7 +13926,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -13978,7 +13978,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -14021,7 +14021,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -14064,7 +14064,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -14088,7 +14088,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -14125,7 +14125,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -14168,7 +14168,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -14220,7 +14220,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -14238,7 +14238,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -14262,7 +14262,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -14299,7 +14299,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -14342,7 +14342,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -14411,7 +14411,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/apps.ApiResponse"
+                                    "$ref": "#/definitions/apps.APIResponse"
                                 },
                                 {
                                     "type": "object",
@@ -14435,7 +14435,7 @@
         }
     },
     "definitions": {
-        "apps.ApiResponse": {
+        "apps.APIResponse": {
             "type": "object",
             "properties": {
                 "message": {
@@ -15286,7 +15286,8 @@
                         1000,
                         1000000,
                         1000000000,
-                        60000000000
+                        60000000000,
+                        3600000000000
                     ],
                     "x-enum-varnames": [
                         "minDuration",
@@ -15301,7 +15302,8 @@
                         "Microsecond",
                         "Millisecond",
                         "Second",
-                        "Minute"
+                        "Minute",
+                        "Hour"
                     ]
                 }
             }
@@ -19545,7 +19547,7 @@
             "properties": {
                 "body": {
                     "type": "object",
-                    "additionalProperties": true
+                    "additionalProperties": {}
                 },
                 "commandName": {
                     "type": "string"

--- a/frontend/public/ui_swagger.json
+++ b/frontend/public/ui_swagger.json
@@ -1822,6 +1822,12 @@
                 "activeTunnel": {
                     "type": "string"
                 },
+                "apiKeyError": {
+                    "type": "string"
+                },
+                "apiKeyValid": {
+                    "type": "boolean"
+                },
                 "arch": {
                     "type": "string"
                 },
@@ -2511,14 +2517,10 @@
                         1000000000,
                         60000000000,
                         3600000000000,
-                        -9223372036854775808,
-                        9223372036854775807,
                         1,
                         1000,
                         1000000,
-                        1000000000,
-                        60000000000,
-                        3600000000000
+                        1000000000
                     ],
                     "x-enum-varnames": [
                         "minDuration",
@@ -2529,14 +2531,10 @@
                         "Second",
                         "Minute",
                         "Hour",
-                        "minDuration",
-                        "maxDuration",
                         "Nanosecond",
                         "Microsecond",
                         "Millisecond",
-                        "Second",
-                        "Minute",
-                        "Hour"
+                        "Second"
                     ]
                 }
             }
@@ -3595,36 +3593,6 @@
                 1048576,
                 524288,
                 2401763328,
-                511,
-                2147483648,
-                1073741824,
-                536870912,
-                268435456,
-                134217728,
-                67108864,
-                33554432,
-                16777216,
-                8388608,
-                4194304,
-                2097152,
-                1048576,
-                524288,
-                2401763328,
-                511,
-                2147483648,
-                1073741824,
-                536870912,
-                268435456,
-                134217728,
-                67108864,
-                33554432,
-                16777216,
-                8388608,
-                4194304,
-                2097152,
-                1048576,
-                524288,
-                2401763328,
                 511
             ],
             "x-enum-comments": {
@@ -3658,39 +3626,9 @@
                 "t: sticky",
                 "?: non-regular file; nothing else is known about this file",
                 "",
-                "Unix permission bits, 0o777",
-                "d: is a directory",
-                "a: append-only",
-                "l: exclusive use",
-                "T: temporary file; Plan 9 only",
-                "L: symbolic link",
-                "D: device file",
-                "p: named pipe (FIFO)",
-                "S: Unix domain socket",
-                "u: setuid",
-                "g: setgid",
-                "c: Unix character device, when ModeDevice is set",
-                "t: sticky",
-                "?: non-regular file; nothing else is known about this file",
-                "",
                 "Unix permission bits, 0o777"
             ],
             "x-enum-varnames": [
-                "ModeDir",
-                "ModeAppend",
-                "ModeExclusive",
-                "ModeTemporary",
-                "ModeSymlink",
-                "ModeDevice",
-                "ModeNamedPipe",
-                "ModeSocket",
-                "ModeSetuid",
-                "ModeSetgid",
-                "ModeCharDevice",
-                "ModeSticky",
-                "ModeIrregular",
-                "ModeType",
-                "ModePerm",
                 "ModeDir",
                 "ModeAppend",
                 "ModeExclusive",

--- a/pkg/apps/apppkg/plex/handlers.go
+++ b/pkg/apps/apppkg/plex/handlers.go
@@ -17,8 +17,8 @@ import (
 //	@Summary		Retrieve Plex sessions.
 //	@Tags			Plex
 //	@Produce		json
-//	@Success		200	{object}	apps.ApiResponse{message=Sessions}	"contains app info included appStatus"
-//	@Failure		500	{object}	apps.ApiResponse{message=string}	"Plex error"
+//	@Success		200	{object}	apps.APIResponse{message=Sessions}	"contains app info included appStatus"
+//	@Failure		500	{object}	apps.APIResponse{message=string}	"Plex error"
 //	@Failure		404	{object}	string								"bad token or api key"
 //	@Router			/plex/1/sessions [get]
 //	@Security		ApiKeyAuth
@@ -60,8 +60,8 @@ func (s *Server) HandleSessions(r *http.Request) (int, any) {
 //	@Produce		json
 //	@Param			sessionId	query		string								true	"Plex session ID"
 //	@Param			reason		query		string								true	"Reason the session is being terminated. Sent to the user."
-//	@Success		200			{object}	apps.ApiResponse{message=string}	"success"
-//	@Failure		500			{object}	apps.ApiResponse{message=string}	"Plex error"
+//	@Success		200			{object}	apps.APIResponse{message=string}	"success"
+//	@Failure		500			{object}	apps.APIResponse{message=string}	"Plex error"
 //	@Failure		404			{object}	string								"bad token or api key"
 //	@Router			/plex/1/kill [get]
 //	@Security		ApiKeyAuth
@@ -88,8 +88,8 @@ func (s *Server) HandleKillSession(r *http.Request) (int, any) {
 //	@Summary		Retrieve the Plex Library Directory.
 //	@Tags			Plex
 //	@Produce		json
-//	@Success		200	{object}	apps.ApiResponse{message=SectionDirectory}	"Plex Library Directory"
-//	@Failure		500	{object}	apps.ApiResponse{message=string}			"Plex error"
+//	@Success		200	{object}	apps.APIResponse{message=SectionDirectory}	"Plex Library Directory"
+//	@Failure		500	{object}	apps.APIResponse{message=string}			"Plex error"
 //	@Failure		404	{object}	string										"bad token or api key"
 //	@Router			/plex/1/directory [get]
 //	@Security		ApiKeyAuth
@@ -119,8 +119,8 @@ func (s *Server) HandleDirectory(req *http.Request) (int, any) {
 //	@Tags			Plex
 //	@Produce		json
 //	@Param			libraryKey	path		string								true	"Plex Library Section Key"
-//	@Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-//	@Failure		500			{object}	apps.ApiResponse{message=string}	"Plex error"
+//	@Success		200			{object}	apps.APIResponse{message=string}	"ok"
+//	@Failure		500			{object}	apps.APIResponse{message=string}	"Plex error"
 //	@Failure		404			{object}	string								"bad token or api key"
 //	@Router			/plex/1/emptytrash/{libraryKey} [get]
 //	@Security		ApiKeyAuth
@@ -143,8 +143,8 @@ func (s *Server) HandleEmptyTrash(r *http.Request) (int, any) {
 //	@Tags			Plex
 //	@Produce		json
 //	@Param			itemKey	path		string								true	"Plex Item Key"
-//	@Success		200		{object}	apps.ApiResponse{message=string}	"ok"
-//	@Failure		500		{object}	apps.ApiResponse{message=string}	"Plex error"
+//	@Success		200		{object}	apps.APIResponse{message=string}	"ok"
+//	@Failure		500		{object}	apps.APIResponse{message=string}	"Plex error"
 //	@Failure		404		{object}	string								"bad token or api key"
 //	@Router			/plex/1/markwatched/{itemKey} [get]
 //	@Security		ApiKeyAuth

--- a/pkg/apps/lidarr.go
+++ b/pkg/apps/lidarr.go
@@ -108,12 +108,12 @@ func (a *AppsConfig) setupLidarr() ([]Lidarr, error) {
 // @Param			instance	path	int64					true	"instance ID"
 // @Param			POST		body	lidarr.AddAlbumInput	true	"new item content"
 // @Accept			json
-// @Success		201	{object}	apps.ApiResponse{message=lidarr.Album}	"created"
-// @Failure		400	{object}	apps.ApiResponse{message=string}		"bad json payload"
-// @Failure		409	{object}	apps.ApiResponse{message=string}		"item already exists"
-// @Failure		422	{object}	apps.ApiResponse{message=string}		"no item ID provided"
-// @Failure		503	{object}	apps.ApiResponse{message=string}		"instance error during check"
-// @Failure		500	{object}	apps.ApiResponse{message=string}		"instance error during add"
+// @Success		201	{object}	apps.APIResponse{message=lidarr.Album}	"created"
+// @Failure		400	{object}	apps.APIResponse{message=string}		"bad json payload"
+// @Failure		409	{object}	apps.APIResponse{message=string}		"item already exists"
+// @Failure		422	{object}	apps.APIResponse{message=string}		"no item ID provided"
+// @Failure		503	{object}	apps.APIResponse{message=string}		"instance error during check"
+// @Failure		500	{object}	apps.APIResponse{message=string}		"instance error during add"
 // @Failure		404	{object}	string									"bad token or api key"
 // @Router			/lidarr/{instance}/add [post]
 // @Security		ApiKeyAuth
@@ -149,8 +149,8 @@ func lidarrAddAlbum(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64									true	"instance ID"
 // @Param			artistID	path		int64									true	"artist ID"
-// @Success		200			{object}	apps.ApiResponse{message=lidarr.Artist}	"ok"
-// @Failure		503			{object}	apps.ApiResponse{message=string}		"instance error"
+// @Success		200			{object}	apps.APIResponse{message=lidarr.Artist}	"ok"
+// @Failure		503			{object}	apps.APIResponse{message=string}		"instance error"
 // @Failure		404			{object}	string									"bad token or api key"
 // @Router			/lidarr/{instance}/artist/{artistID} [get]
 // @Security		ApiKeyAuth
@@ -185,9 +185,9 @@ func lidarrData(album *lidarr.Album) map[string]any {
 // @Produce		json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			mbid		path		int64								true	"music brains ID"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"not found"
-// @Failure		409			{object}	apps.ApiResponse{message=string}	"already exists"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"not found"
+// @Failure		409			{object}	apps.APIResponse{message=string}	"already exists"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/lidarr/{instance}/check/{mbid} [get]
 // @Security		ApiKeyAuth
@@ -210,8 +210,8 @@ func lidarrCheckAlbum(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64									true	"instance ID"
 // @Param			albumID		path		int64									true	"album ID"
-// @Success		200			{object}	apps.ApiResponse{message=lidarr.Album}	"ok"
-// @Failure		503			{object}	apps.ApiResponse{message=string}		"instance error"
+// @Success		200			{object}	apps.APIResponse{message=lidarr.Album}	"ok"
+// @Failure		503			{object}	apps.APIResponse{message=string}		"instance error"
 // @Failure		404			{object}	string									"bad token or api key"
 // @Router			/lidarr/{instance}/get/{albumID} [get]
 // @Security		ApiKeyAuth
@@ -232,8 +232,8 @@ func lidarrGetAlbum(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			albumID		path		int64								true	"album ID"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"status"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"status"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/lidarr/{instance}/command/search/{albumID} [get]
 // @Security		ApiKeyAuth
@@ -256,8 +256,8 @@ func lidarrTriggerSearchAlbum(req *http.Request) (int, any) {
 // @Tags			Lidarr
 // @Produce		json
 // @Param			instance	path		int64										true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=map[int64]string}	"map of ID to name"
-// @Failure		500			{object}	apps.ApiResponse{message=string}			"instance error"
+// @Success		200			{object}	apps.APIResponse{message=map[int64]string}	"map of ID to name"
+// @Failure		500			{object}	apps.APIResponse{message=string}			"instance error"
 // @Failure		404			{object}	string										"bad token or api key"
 // @Router			/lidarr/{instance}/metadataProfiles [get]
 // @Security		ApiKeyAuth
@@ -281,8 +281,8 @@ func lidarrMetadata(req *http.Request) (int, any) {
 // @Tags			Lidarr
 // @Produce		json
 // @Param			instance	path		int64									true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=lidarr.Naming}	"naming conventions"
-// @Failure		500			{object}	apps.ApiResponse{message=string}		"instance error"
+// @Success		200			{object}	apps.APIResponse{message=lidarr.Naming}	"naming conventions"
+// @Failure		500			{object}	apps.APIResponse{message=string}		"instance error"
 // @Failure		404			{object}	string									"bad token or api key"
 // @Router			/lidarr/{instance}/naming [get]
 // @Security		ApiKeyAuth
@@ -301,9 +301,9 @@ func lidarrGetNaming(req *http.Request) (int, any) {
 // @Produce		json
 // @Accept			json
 // @Param			PUT	body		lidarr.Naming						true	"naming conventions"
-// @Success		200	{object}	apps.ApiResponse{message=int64}		"naming ID"
-// @Failure		400	{object}	apps.ApiResponse{message=string}	"bad json input"
-// @Failure		500	{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200	{object}	apps.APIResponse{message=int64}		"naming ID"
+// @Failure		400	{object}	apps.APIResponse{message=string}	"bad json input"
+// @Failure		500	{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404	{object}	string								"bad token or api key"
 // @Router			/lidarr/{instance}/naming [put]
 // @Security		ApiKeyAuth
@@ -330,9 +330,9 @@ func lidarrUpdateNaming(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64												true	"instance ID"
 // @Param			POST		body		lidarr.CustomFormatInput							true	"New Custom Format content"
-// @Success		200			{object}	apps.ApiResponse{message=lidarr.CustomFormatOutput}	"custom format"
-// @Failure		400			{object}	apps.ApiResponse{message=string}					"invalid json provided"
-// @Failure		500			{object}	apps.ApiResponse{message=string}					"instance error"
+// @Success		200			{object}	apps.APIResponse{message=lidarr.CustomFormatOutput}	"custom format"
+// @Failure		400			{object}	apps.APIResponse{message=string}					"invalid json provided"
+// @Failure		500			{object}	apps.APIResponse{message=string}					"instance error"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/lidarr/{instance}/customformats [post]
 // @Security		ApiKeyAuth
@@ -357,8 +357,8 @@ func lidarrAddCustomFormat(req *http.Request) (int, any) {
 // @Tags			Lidarr
 // @Produce		json
 // @Param			instance	path		int64													true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]lidarr.CustomFormatOutput}	"custom formats"
-// @Failure		500			{object}	apps.ApiResponse{message=string}						"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]lidarr.CustomFormatOutput}	"custom formats"
+// @Failure		500			{object}	apps.APIResponse{message=string}						"instance error"
 // @Failure		404			{object}	string													"bad token or api key"
 // @Router			/lidarr/{instance}/customformats [get]
 // @Security		ApiKeyAuth
@@ -378,9 +378,9 @@ func lidarrGetCustomFormats(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64												true	"instance ID"
 // @Param			PUT			body		lidarr.CustomFormatInput							true	"Updated Custom Format content"
-// @Success		200			{object}	apps.ApiResponse{message=lidarr.CustomFormatOutput}	"custom format"
-// @Failure		400			{object}	apps.ApiResponse{message=string}					"invalid json provided"
-// @Failure		500			{object}	apps.ApiResponse{message=string}					"instance error"
+// @Success		200			{object}	apps.APIResponse{message=lidarr.CustomFormatOutput}	"custom format"
+// @Failure		400			{object}	apps.APIResponse{message=string}					"invalid json provided"
+// @Failure		500			{object}	apps.APIResponse{message=string}					"instance error"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/lidarr/{instance}/customformats/{formatID} [put]
 // @Security		ApiKeyAuth
@@ -404,8 +404,8 @@ func lidarrUpdateCustomFormat(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			formatID	path		int64								true	"Custom Format ID"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		500			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		500			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/lidarr/{instance}/customformats/{formatID} [delete]
 // @Security		ApiKeyAuth
@@ -425,8 +425,8 @@ func lidarrDeleteCustomFormat(req *http.Request) (int, any) {
 // @Tags			Lidarr
 // @Produce		json
 // @Param			instance	path		int64											true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=apps.deleteResponse}	"item delete counters"
-// @Failure		500			{object}	apps.ApiResponse{message=string}				"instance error"
+// @Success		200			{object}	apps.APIResponse{message=apps.deleteResponse}	"item delete counters"
+// @Failure		500			{object}	apps.APIResponse{message=string}				"instance error"
 // @Failure		404			{object}	string											"bad token or api key"
 // @Router			/lidarr/{instance}/customformats/all [delete]
 // @Security		ApiKeyAuth
@@ -465,9 +465,9 @@ func lidarrDeleteAllCustomFormats(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64													true	"instance ID"
 // @Param			PUT			body		[]lidarr.QualityDefinition								true	"Updated quality definitions"
-// @Success		200			{object}	apps.ApiResponse{message=[]lidarr.QualityDefinition}	"quality definitions return"
-// @Failure		400			{object}	apps.ApiResponse{message=string}						"invalid json provided"
-// @Failure		500			{object}	apps.ApiResponse{message=string}						"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]lidarr.QualityDefinition}	"quality definitions return"
+// @Failure		400			{object}	apps.APIResponse{message=string}						"invalid json provided"
+// @Failure		500			{object}	apps.APIResponse{message=string}						"instance error"
 // @Failure		404			{object}	string													"bad token or api key"
 // @Router			/lidarr/{instance}/qualitydefinition [put]
 // @Security		ApiKeyAuth
@@ -490,8 +490,8 @@ func lidarrUpdateQualityDefinition(req *http.Request) (int, any) {
 // @Tags			Lidarr
 // @Produce		json
 // @Param			instance	path		int64										true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=map[int64]string}	"map of ID to name"
-// @Failure		500			{object}	apps.ApiResponse{message=string}			"instance error"
+// @Success		200			{object}	apps.APIResponse{message=map[int64]string}	"map of ID to name"
+// @Failure		500			{object}	apps.APIResponse{message=string}			"instance error"
 // @Failure		404			{object}	string										"bad token or api key"
 // @Router			/lidarr/{instance}/qualityDefinitions [get]
 // @Security		ApiKeyAuth
@@ -516,8 +516,8 @@ func lidarrGetQualityDefinitions(req *http.Request) (int, any) {
 // @Tags			Lidarr
 // @Produce		json
 // @Param			instance	path		int64										true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=map[int64]string}	"map of ID to name"
-// @Failure		500			{object}	apps.ApiResponse{message=string}			"instance error"
+// @Success		200			{object}	apps.APIResponse{message=map[int64]string}	"map of ID to name"
+// @Failure		500			{object}	apps.APIResponse{message=string}			"instance error"
 // @Failure		404			{object}	string										"bad token or api key"
 // @Router			/lidarr/{instance}/qualityProfiles [get]
 // @Security		ApiKeyAuth
@@ -542,8 +542,8 @@ func lidarrQualityProfiles(req *http.Request) (int, any) {
 // @Tags			Lidarr
 // @Produce		json
 // @Param			instance	path		int64												true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]lidarr.QualityProfile}	"all profiles"
-// @Failure		500			{object}	apps.ApiResponse{message=string}					"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]lidarr.QualityProfile}	"all profiles"
+// @Failure		500			{object}	apps.APIResponse{message=string}					"instance error"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/lidarr/{instance}/qualityProfile [get]
 // @Security		ApiKeyAuth
@@ -564,9 +564,9 @@ func lidarrGetQualityProfile(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			POST		body		lidarr.QualityProfile				true	"new item content"
-// @Success		200			{object}	apps.ApiResponse{message=int64}		"new profile ID"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"json input error"
-// @Failure		500			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=int64}		"new profile ID"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"json input error"
+// @Failure		500			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/lidarr/{instance}/qualityProfile [post]
 // @Security		ApiKeyAuth
@@ -596,10 +596,10 @@ func lidarrAddQualityProfile(req *http.Request) (int, any) {
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			profileID	path		int64								true	"profile ID to update"
 // @Param			PUT			body		lidarr.QualityProfile				true	"updated item content"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"json input error"
-// @Failure		422			{object}	apps.ApiResponse{message=string}	"no profile ID"
-// @Failure		500			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"json input error"
+// @Failure		422			{object}	apps.APIResponse{message=string}	"no profile ID"
+// @Failure		500			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/lidarr/{instance}/qualityProfile/{profileID} [put]
 // @Security		ApiKeyAuth
@@ -631,8 +631,8 @@ func lidarrUpdateQualityProfile(req *http.Request) (int, any) {
 // @Tags			Lidarr
 // @Produce		json
 // @Param			instance	path		int64										true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=map[string]int64}	"map of path->space free"
-// @Failure		500			{object}	apps.ApiResponse{message=string}			"instance error"
+// @Success		200			{object}	apps.APIResponse{message=map[string]int64}	"map of path->space free"
+// @Failure		500			{object}	apps.APIResponse{message=string}			"instance error"
 // @Failure		404			{object}	string										"bad token or api key"
 // @Router			/lidarr/{instance}/rootFolder [get]
 // @Security		ApiKeyAuth
@@ -658,8 +658,8 @@ func lidarrRootFolders(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			query		path		string															true	"title search string"
 // @Param			instance	path		int64															true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]apps.lidarrSearchAlbum.albumData}	"minimal album data"
-// @Failure		503			{object}	apps.ApiResponse{message=string}								"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]apps.lidarrSearchAlbum.albumData}	"minimal album data"
+// @Failure		503			{object}	apps.APIResponse{message=string}								"instance error"
 // @Failure		404			{object}	string															"bad token or api key"
 // @Router			/lidarr/{instance}/search/{query} [get]
 // @Security		ApiKeyAuth
@@ -732,8 +732,8 @@ func albumSearch(query, title string, releases []*lidarr.Release) bool {
 // @Tags			Lidarr
 // @Produce		json
 // @Param			instance	path		int64									true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]starr.Tag}	"tags"
-// @Failure		503			{object}	apps.ApiResponse{message=string}		"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]starr.Tag}	"tags"
+// @Failure		503			{object}	apps.APIResponse{message=string}		"instance error"
 // @Failure		404			{object}	string									"bad token or api key"
 // @Router			/lidarr/{instance}/tag [get]
 // @Security		ApiKeyAuth
@@ -753,8 +753,8 @@ func lidarrGetTags(req *http.Request) (int, any) {
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			tagID		path		int64								true	"tag ID to update"
 // @Param			label		path		string								true	"new label"
-// @Success		200			{object}	apps.ApiResponse{message=int64}		"tag ID"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=int64}		"tag ID"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/lidarr/{instance}/tag/{tagID}/{label} [put]
 // @Security		ApiKeyAuth
@@ -775,8 +775,8 @@ func lidarrUpdateTag(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			label		path		string								true	"new tag's label"
-// @Success		200			{object}	apps.ApiResponse{message=int64}		"tag ID"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=int64}		"tag ID"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/lidarr/{instance}/tag/{label} [put]
 // @Security		ApiKeyAuth
@@ -797,9 +797,9 @@ func lidarrSetTag(req *http.Request) (int, any) {
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			moveFiles	query		int64								true	"move files? true/false"
 // @Param			PUT			body		lidarr.Album						true	"album content"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"bad json input"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"bad json input"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/lidarr/{instance}/update [put]
 // @Security		ApiKeyAuth
@@ -828,9 +828,9 @@ func lidarrUpdateAlbum(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			PUT			body		lidarr.Artist						true	"album content"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"bad json input"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"bad json input"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/lidarr/{instance}/updateartist [put]
 // @Security		ApiKeyAuth
@@ -855,8 +855,8 @@ func lidarrUpdateArtist(req *http.Request) (int, any) {
 // @Tags			Lidarr
 // @Produce		json
 // @Param			instance	path		int64													true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]lidarr.NotificationOutput}	"notifications"
-// @Failure		503			{object}	apps.ApiResponse{message=string}						"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]lidarr.NotificationOutput}	"notifications"
+// @Failure		503			{object}	apps.APIResponse{message=string}						"instance error"
 // @Failure		404			{object}	string													"bad token or api key"
 // @Router			/lidarr/{instance}/notifications [get]
 // @Security		ApiKeyAuth
@@ -887,8 +887,8 @@ func lidarrGetNotifications(req *http.Request) (int, any) {
 // @Param			blocklist			query		bool								false	"add item to blocklist?"
 // @Param			skipRedownload		query		bool								false	"skip downloading this again?"
 // @Param			changeCategory		query		bool								false	"tell download client to change categories?"
-// @Success		200					{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		500					{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200					{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		500					{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404					{object}	string								"bad token or api key"
 // @Failure		423					{object}	string								"rate limit reached"
 // @Router			/lidarr/{instance}/queue/{queueID} [delete]
@@ -919,9 +919,9 @@ func lidarrDeleteQueue(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			PUT			body		lidarr.NotificationInput			true	"notification content"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"bad json input"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"bad json input"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/lidarr/{instance}/notification [put]
 // @Security		ApiKeyAuth
@@ -948,9 +948,9 @@ func lidarrUpdateNotification(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			POST		body		lidarr.NotificationInput			true	"new item content"
-// @Success		200			{object}	apps.ApiResponse{message=int64}		"new notification ID"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"json input error"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=int64}		"new notification ID"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"json input error"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/lidarr/{instance}/notification [post]
 // @Security		ApiKeyAuth

--- a/pkg/apps/prowlarr.go
+++ b/pkg/apps/prowlarr.go
@@ -63,8 +63,8 @@ func (a *AppsConfig) setupProwlarr() ([]Prowlarr, error) {
 // @Tags			Prowlarr
 // @Produce		json
 // @Param			instance	path		int64													true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]prowlarr.NotificationOutput}	"notifications"
-// @Failure		503			{object}	apps.ApiResponse{message=string}						"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]prowlarr.NotificationOutput}	"notifications"
+// @Failure		503			{object}	apps.APIResponse{message=string}						"instance error"
 // @Failure		404			{object}	string													"bad token or api key"
 // @Router			/prowlarr/{instance}/notifications [get]
 // @Security		ApiKeyAuth
@@ -92,9 +92,9 @@ func prowlarrGetNotifications(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			PUT			body		prowlarr.NotificationInput			true	"notification content"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"bad json input"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"bad json input"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/prowlarr/{instance}/notification [put]
 // @Security		ApiKeyAuth
@@ -121,9 +121,9 @@ func prowlarrUpdateNotification(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			POST		body		prowlarr.NotificationInput			true	"new item content"
-// @Success		200			{object}	apps.ApiResponse{message=int64}		"new notification ID"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"json input error"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=int64}		"new notification ID"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"json input error"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/prowlarr/{instance}/notification [post]
 // @Security		ApiKeyAuth

--- a/pkg/apps/radarr.go
+++ b/pkg/apps/radarr.go
@@ -116,12 +116,12 @@ func (a *AppsConfig) setupRadarr() ([]Radarr, error) {
 // @Param			instance	path	int64					true	"instance ID"
 // @Param			POST		body	radarr.AddMovieInput	true	"new item content"
 // @Accept			json
-// @Success		201	{object}	apps.ApiResponse{message=radarr.Movie}	"created"
-// @Failure		400	{object}	apps.ApiResponse{message=string}		"bad json payload"
-// @Failure		409	{object}	apps.ApiResponse{message=string}		"item already exists"
-// @Failure		422	{object}	apps.ApiResponse{message=string}		"no item ID provided"
-// @Failure		503	{object}	apps.ApiResponse{message=string}		"instance error during check"
-// @Failure		500	{object}	apps.ApiResponse{message=string}		"instance error during add"
+// @Success		201	{object}	apps.APIResponse{message=radarr.Movie}	"created"
+// @Failure		400	{object}	apps.APIResponse{message=string}		"bad json payload"
+// @Failure		409	{object}	apps.APIResponse{message=string}		"item already exists"
+// @Failure		422	{object}	apps.APIResponse{message=string}		"no item ID provided"
+// @Failure		503	{object}	apps.APIResponse{message=string}		"instance error during check"
+// @Failure		500	{object}	apps.APIResponse{message=string}		"instance error during add"
 // @Failure		404	{object}	string									"bad token or api key"
 // @Router			/radarr/{instance}/add [post]
 // @Security		ApiKeyAuth
@@ -176,9 +176,9 @@ func radarrData(movie *radarr.Movie) map[string]any {
 // @Produce		json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			tmdbid		path		int64								true	"TMDB ID"
-// @Success		201			{object}	apps.ApiResponse{message=string}	"movie does not exist"
-// @Failure		409			{object}	apps.ApiResponse{message=string}	"item already exists"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		201			{object}	apps.APIResponse{message=string}	"movie does not exist"
+// @Failure		409			{object}	apps.APIResponse{message=string}	"item already exists"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/radarr/{instance}/check/{tmdbid} [get]
 // @Security		ApiKeyAuth
@@ -201,8 +201,8 @@ func radarrCheckMovie(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64									true	"instance ID"
 // @Param			movieID		path		int64									true	"Movie ID"
-// @Success		201			{object}	apps.ApiResponse{message=radarr.Movie}	"movie content"
-// @Failure		503			{object}	apps.ApiResponse{message=string}		"instance error"
+// @Success		201			{object}	apps.APIResponse{message=radarr.Movie}	"movie content"
+// @Failure		503			{object}	apps.APIResponse{message=string}		"instance error"
 // @Failure		404			{object}	string									"bad token or api key"
 // @Router			/radarr/{instance}/get/{movieID} [get]
 // @Security		ApiKeyAuth
@@ -223,8 +223,8 @@ func radarrGetMovie(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			movieID		path		int64								true	"Movie ID"
-// @Success		201			{object}	apps.ApiResponse{message=string}	"search status"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		201			{object}	apps.APIResponse{message=string}	"search status"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/radarr/{instance}/command/search/{movieID} [get]
 // @Security		ApiKeyAuth
@@ -247,8 +247,8 @@ func radarrCommandMoviesSearch(req *http.Request) (int, any) {
 // @Tags			Radarr
 // @Produce		json
 // @Param			instance	path		int64										true	"instance ID"
-// @Success		201			{object}	apps.ApiResponse{message=[]radarr.Movie}	"movies content"
-// @Failure		503			{object}	apps.ApiResponse{message=string}			"instance error"
+// @Success		201			{object}	apps.APIResponse{message=[]radarr.Movie}	"movies content"
+// @Failure		503			{object}	apps.APIResponse{message=string}			"instance error"
 // @Failure		404			{object}	string										"bad token or api key"
 // @Router			/radarr/{instance}/get [get]
 // @Security		ApiKeyAuth
@@ -266,8 +266,8 @@ func radarrGetAllMovies(req *http.Request) (int, any) {
 // @Tags			Radarr
 // @Produce		json
 // @Param			instance	path		int64												true	"instance ID"
-// @Success		201			{object}	apps.ApiResponse{message=[]radarr.QualityProfile}	"all profiles"
-// @Failure		500			{object}	apps.ApiResponse{message=string}					"instance error"
+// @Success		201			{object}	apps.APIResponse{message=[]radarr.QualityProfile}	"all profiles"
+// @Failure		500			{object}	apps.APIResponse{message=string}					"instance error"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/radarr/{instance}/qualityProfile [get]
 // @Security		ApiKeyAuth
@@ -286,8 +286,8 @@ func radarrQualityProfile(req *http.Request) (int, any) {
 // @Tags			Radarr
 // @Produce		json
 // @Param			instance	path		int64										true	"instance ID"
-// @Success		201			{object}	apps.ApiResponse{message=map[int64]string}	"map of ID to name"
-// @Failure		500			{object}	apps.ApiResponse{message=string}			"instance error"
+// @Success		201			{object}	apps.APIResponse{message=map[int64]string}	"map of ID to name"
+// @Failure		500			{object}	apps.APIResponse{message=string}			"instance error"
 // @Failure		404			{object}	string										"bad token or api key"
 // @Router			/radarr/{instance}/qualityProfiles [get]
 // @Security		ApiKeyAuth
@@ -314,9 +314,9 @@ func radarrQualityProfiles(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			POST		body		radarr.QualityProfile				true	"new item content"
-// @Success		200			{object}	apps.ApiResponse{message=int64}		"new profile ID"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"json input error"
-// @Failure		500			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=int64}		"new profile ID"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"json input error"
+// @Failure		500			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/radarr/{instance}/qualityProfile [post]
 // @Security		ApiKeyAuth
@@ -346,10 +346,10 @@ func radarrAddQualityProfile(req *http.Request) (int, any) {
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			profileID	path		int64								true	"profile ID to update"
 // @Param			PUT			body		radarr.QualityProfile				true	"updated item content"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"json input error"
-// @Failure		422			{object}	apps.ApiResponse{message=string}	"no profile ID"
-// @Failure		500			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"json input error"
+// @Failure		422			{object}	apps.APIResponse{message=string}	"no profile ID"
+// @Failure		500			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/radarr/{instance}/qualityProfile/{profileID} [put]
 // @Security		ApiKeyAuth
@@ -382,9 +382,9 @@ func radarrUpdateQualityProfile(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			profileID	path		int64								true	"profile ID to update"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"no profile ID"
-// @Failure		500			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"no profile ID"
+// @Failure		500			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/radarr/{instance}/qualityProfile/{profileID} [delete]
 // @Security		ApiKeyAuth
@@ -417,8 +417,8 @@ type deleteResponse struct {
 // @Tags			Radarr
 // @Produce		json
 // @Param			instance	path		int64											true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=apps.deleteResponse}	"delete status"
-// @Failure		500			{object}	apps.ApiResponse{message=string}				"instance error getting profiles"
+// @Success		200			{object}	apps.APIResponse{message=apps.deleteResponse}	"delete status"
+// @Failure		500			{object}	apps.APIResponse{message=string}				"instance error getting profiles"
 // @Failure		404			{object}	string											"bad token or api key"
 // @Router			/radarr/{instance}/qualityProfiles/all [delete]
 // @Security		ApiKeyAuth
@@ -456,8 +456,8 @@ func radarrDeleteAllQualityProfiles(req *http.Request) (int, any) {
 // @Tags			Radarr
 // @Produce		json
 // @Param			instance	path		int64										true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=map[string]int64}	"map of path->space free"
-// @Failure		500			{object}	apps.ApiResponse{message=string}			"instance error"
+// @Success		200			{object}	apps.APIResponse{message=map[string]int64}	"map of path->space free"
+// @Failure		500			{object}	apps.APIResponse{message=string}			"instance error"
 // @Failure		404			{object}	string										"bad token or api key"
 // @Router			/radarr/{instance}/rootFolder [get]
 // @Security		ApiKeyAuth
@@ -482,8 +482,8 @@ func radarrRootFolders(req *http.Request) (int, any) {
 // @Tags			Radarr
 // @Produce		json
 // @Param			instance	path		int64									true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=radarr.Naming}	"naming conventions"
-// @Failure		500			{object}	apps.ApiResponse{message=string}		"instance error"
+// @Success		200			{object}	apps.APIResponse{message=radarr.Naming}	"naming conventions"
+// @Failure		500			{object}	apps.APIResponse{message=string}		"instance error"
 // @Failure		404			{object}	string									"bad token or api key"
 // @Router			/radarr/{instance}/naming [get]
 // @Security		ApiKeyAuth
@@ -502,9 +502,9 @@ func radarrGetNaming(req *http.Request) (int, any) {
 // @Produce		json
 // @Accept			json
 // @Param			PUT	body		radarr.Naming						true	"naming conventions"
-// @Success		200	{object}	apps.ApiResponse{message=int64}		"naming ID"
-// @Failure		400	{object}	apps.ApiResponse{message=string}	"bad json input"
-// @Failure		500	{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200	{object}	apps.APIResponse{message=int64}		"naming ID"
+// @Failure		400	{object}	apps.APIResponse{message=string}	"bad json input"
+// @Failure		500	{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404	{object}	string								"bad token or api key"
 // @Router			/radarr/{instance}/naming [put]
 // @Security		ApiKeyAuth
@@ -530,8 +530,8 @@ func radarrUpdateNaming(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			query		path		string															true	"title search string"
 // @Param			instance	path		int64															true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]apps.radarrSearchMovie.movieData}	"minimal movie data"
-// @Failure		503			{object}	apps.ApiResponse{message=string}								"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]apps.radarrSearchMovie.movieData}	"minimal movie data"
+// @Failure		503			{object}	apps.APIResponse{message=string}								"instance error"
 // @Failure		404			{object}	string															"bad token or api key"
 // @Router			/radarr/{instance}/search/{query} [get]
 // @Security		ApiKeyAuth
@@ -610,8 +610,8 @@ func movieSearch(query string, titles []string, alts []*radarr.AlternativeTitle)
 // @Tags			Radarr
 // @Produce		json
 // @Param			instance	path		int64									true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]starr.Tag}	"tags"
-// @Failure		503			{object}	apps.ApiResponse{message=string}		"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]starr.Tag}	"tags"
+// @Failure		503			{object}	apps.APIResponse{message=string}		"instance error"
 // @Failure		404			{object}	string									"bad token or api key"
 // @Router			/radarr/{instance}/tag [get]
 // @Security		ApiKeyAuth
@@ -631,8 +631,8 @@ func radarrGetTags(req *http.Request) (int, any) {
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			tagID		path		int64								true	"tag ID to update"
 // @Param			label		path		string								true	"new label"
-// @Success		200			{object}	apps.ApiResponse{message=int64}		"tag ID"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=int64}		"tag ID"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/radarr/{instance}/tag/{tagID}/{label} [put]
 // @Security		ApiKeyAuth
@@ -653,8 +653,8 @@ func radarrUpdateTag(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			label		path		string								true	"new tag's label"
-// @Success		200			{object}	apps.ApiResponse{message=int64}		"tag ID"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=int64}		"tag ID"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/radarr/{instance}/tag/{label} [put]
 // @Security		ApiKeyAuth
@@ -675,9 +675,9 @@ func radarrSetTag(req *http.Request) (int, any) {
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			moveFiles	query		int64								true	"move files? true/false"
 // @Param			PUT			body		radarr.Movie						true	"movie content"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"bad json input"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"bad json input"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/radarr/{instance}/update [put]
 // @Security		ApiKeyAuth
@@ -707,9 +707,9 @@ func radarrUpdateMovie(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			POST		body		[]radarr.Exclusion					true	"movie content"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"invalid json provided"
-// @Failure		500			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"invalid json provided"
+// @Failure		500			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/radarr/{instance}/exclusions [post]
 // @Security		ApiKeyAuth
@@ -735,8 +735,8 @@ func radarrAddExclusions(req *http.Request) (int, any) {
 // @Tags			Radarr
 // @Produce		json
 // @Param			instance	path		int64											true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]radarr.Exclusion}	"exclusion list"
-// @Failure		500			{object}	apps.ApiResponse{message=string}				"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]radarr.Exclusion}	"exclusion list"
+// @Failure		500			{object}	apps.APIResponse{message=string}				"instance error"
 // @Failure		404			{object}	string											"bad token or api key"
 // @Router			/radarr/{instance}/exclusions [get]
 // @Security		ApiKeyAuth
@@ -755,8 +755,8 @@ func radarrGetExclusions(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance		path		int64								true	"instance ID"
 // @Param			exclusionIDs	path		[]int64								true	"exclusion IDs to delete, comma separated"
-// @Success		200				{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		500				{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200				{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		500				{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404				{object}	string								"bad token or api key"
 // @Router			/radarr/{instance}/exclusions/{exclusionIDs} [delete]
 // @Security		ApiKeyAuth
@@ -785,9 +785,9 @@ func radarrDelExclusions(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64												true	"instance ID"
 // @Param			POST		body		radarr.CustomFormatInput							true	"New Custom Format content"
-// @Success		200			{object}	apps.ApiResponse{message=radarr.CustomFormatOutput}	"custom format"
-// @Failure		400			{object}	apps.ApiResponse{message=string}					"invalid json provided"
-// @Failure		500			{object}	apps.ApiResponse{message=string}					"instance error"
+// @Success		200			{object}	apps.APIResponse{message=radarr.CustomFormatOutput}	"custom format"
+// @Failure		400			{object}	apps.APIResponse{message=string}					"invalid json provided"
+// @Failure		500			{object}	apps.APIResponse{message=string}					"instance error"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/radarr/{instance}/customformats [post]
 // @Security		ApiKeyAuth
@@ -812,8 +812,8 @@ func radarrAddCustomFormat(req *http.Request) (int, any) {
 // @Tags			Radarr
 // @Produce		json
 // @Param			instance	path		int64													true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]radarr.CustomFormatOutput}	"custom formats"
-// @Failure		500			{object}	apps.ApiResponse{message=string}						"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]radarr.CustomFormatOutput}	"custom formats"
+// @Failure		500			{object}	apps.APIResponse{message=string}						"instance error"
 // @Failure		404			{object}	string													"bad token or api key"
 // @Router			/radarr/{instance}/customformats [get]
 // @Security		ApiKeyAuth
@@ -833,9 +833,9 @@ func radarrGetCustomFormats(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64												true	"instance ID"
 // @Param			PUT			body		radarr.CustomFormatInput							true	"Updated Custom Format content"
-// @Success		200			{object}	apps.ApiResponse{message=radarr.CustomFormatOutput}	"custom format"
-// @Failure		400			{object}	apps.ApiResponse{message=string}					"invalid json provided"
-// @Failure		500			{object}	apps.ApiResponse{message=string}					"instance error"
+// @Success		200			{object}	apps.APIResponse{message=radarr.CustomFormatOutput}	"custom format"
+// @Failure		400			{object}	apps.APIResponse{message=string}					"invalid json provided"
+// @Failure		500			{object}	apps.APIResponse{message=string}					"instance error"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/radarr/{instance}/customformats/{formatID} [put]
 // @Security		ApiKeyAuth
@@ -859,8 +859,8 @@ func radarrUpdateCustomFormat(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			formatID	path		int64								true	"Custom Format ID"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		500			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		500			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/radarr/{instance}/customformats/{formatID} [delete]
 // @Security		ApiKeyAuth
@@ -880,8 +880,8 @@ func radarrDeleteCustomFormat(req *http.Request) (int, any) {
 // @Tags			Radarr
 // @Produce		json
 // @Param			instance	path		int64											true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=apps.deleteResponse}	"item delete counters"
-// @Failure		500			{object}	apps.ApiResponse{message=string}				"instance error"
+// @Success		200			{object}	apps.APIResponse{message=apps.deleteResponse}	"item delete counters"
+// @Failure		500			{object}	apps.APIResponse{message=string}				"instance error"
 // @Failure		404			{object}	string											"bad token or api key"
 // @Router			/radarr/{instance}/customformats/all [delete]
 // @Security		ApiKeyAuth
@@ -918,8 +918,8 @@ func radarrDeleteAllCustomFormats(req *http.Request) (int, any) {
 // @Tags			Radarr
 // @Produce		json
 // @Param			instance	path		int64												true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]radarr.ImportListOutput}	"list of import lists"
-// @Failure		500			{object}	apps.ApiResponse{message=string}					"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]radarr.ImportListOutput}	"list of import lists"
+// @Failure		500			{object}	apps.APIResponse{message=string}					"instance error"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/radarr/{instance}/importlist [get]
 // @Security		ApiKeyAuth
@@ -940,9 +940,9 @@ func radarrGetImportLists(req *http.Request) (int, any) {
 // @Param			instance	path		int64												true	"instance ID"
 // @Param			listID		path		int64												true	"Import List ID"
 // @Param			PUT			body		radarr.ImportListInput								true	"Updated Import List Content"
-// @Success		200			{object}	apps.ApiResponse{message=radarr.ImportListOutput}	"import list returns"
-// @Failure		400			{object}	apps.ApiResponse{message=string}					"invalid json provided"
-// @Failure		500			{object}	apps.ApiResponse{message=string}					"instance error"
+// @Success		200			{object}	apps.APIResponse{message=radarr.ImportListOutput}	"import list returns"
+// @Failure		400			{object}	apps.APIResponse{message=string}					"invalid json provided"
+// @Failure		500			{object}	apps.APIResponse{message=string}					"instance error"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/radarr/{instance}/importlist/{listID} [put]
 // @Security		ApiKeyAuth
@@ -969,9 +969,9 @@ func radarrUpdateImportList(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64												true	"instance ID"
 // @Param			POST		body		radarr.ImportListInput								true	"New Import List"
-// @Success		200			{object}	apps.ApiResponse{message=radarr.ImportListOutput}	"import list returns"
-// @Failure		400			{object}	apps.ApiResponse{message=string}					"invalid json provided"
-// @Failure		500			{object}	apps.ApiResponse{message=string}					"instance error"
+// @Success		200			{object}	apps.APIResponse{message=radarr.ImportListOutput}	"import list returns"
+// @Failure		400			{object}	apps.APIResponse{message=string}					"invalid json provided"
+// @Failure		500			{object}	apps.APIResponse{message=string}					"instance error"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/radarr/{instance}/importlist [post]
 // @Security		ApiKeyAuth
@@ -994,8 +994,8 @@ func radarrAddImportList(req *http.Request) (int, any) {
 // @Tags			Radarr
 // @Produce		json
 // @Param			instance	path		int64													true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]radarr.QualityDefinition}	"quality definitions list"
-// @Failure		500			{object}	apps.ApiResponse{message=string}						"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]radarr.QualityDefinition}	"quality definitions list"
+// @Failure		500			{object}	apps.APIResponse{message=string}						"instance error"
 // @Failure		404			{object}	string													"bad token or api key"
 // @Router			/radarr/{instance}/qualitydefinition [get]
 // @Security		ApiKeyAuth
@@ -1015,9 +1015,9 @@ func radarrGetQualityDefinitions(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64													true	"instance ID"
 // @Param			PUT			body		[]radarr.QualityDefinition								true	"Updated quality definitions"
-// @Success		200			{object}	apps.ApiResponse{message=[]radarr.QualityDefinition}	"quality definitions return"
-// @Failure		400			{object}	apps.ApiResponse{message=string}						"invalid json provided"
-// @Failure		500			{object}	apps.ApiResponse{message=string}						"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]radarr.QualityDefinition}	"quality definitions return"
+// @Failure		400			{object}	apps.APIResponse{message=string}						"invalid json provided"
+// @Failure		500			{object}	apps.APIResponse{message=string}						"instance error"
 // @Failure		404			{object}	string													"bad token or api key"
 // @Router			/radarr/{instance}/qualitydefinition [put]
 // @Security		ApiKeyAuth
@@ -1040,8 +1040,8 @@ func radarrUpdateQualityDefinition(req *http.Request) (int, any) {
 // @Tags			Radarr
 // @Produce		json
 // @Param			instance	path		int64													true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]radarr.NotificationOutput}	"notifications"
-// @Failure		503			{object}	apps.ApiResponse{message=string}						"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]radarr.NotificationOutput}	"notifications"
+// @Failure		503			{object}	apps.APIResponse{message=string}						"instance error"
 // @Failure		404			{object}	string													"bad token or api key"
 // @Router			/radarr/{instance}/notifications [get]
 // @Security		ApiKeyAuth
@@ -1069,9 +1069,9 @@ func radarrGetNotifications(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			PUT			body		radarr.NotificationInput			true	"notification content"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"bad json input"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"bad json input"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/radarr/{instance}/notification [put]
 // @Security		ApiKeyAuth
@@ -1098,9 +1098,9 @@ func radarrUpdateNotification(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			POST		body		radarr.NotificationInput			true	"new item content"
-// @Success		200			{object}	apps.ApiResponse{message=int64}		"new notification ID"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"json input error"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=int64}		"new notification ID"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"json input error"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/radarr/{instance}/notification [post]
 // @Security		ApiKeyAuth
@@ -1130,8 +1130,8 @@ func radarrAddNotification(req *http.Request) (int, any) {
 // @Param			blocklist			query		bool								false	"add item to blocklist?"
 // @Param			skipRedownload		query		bool								false	"skip downloading this again?"
 // @Param			changeCategory		query		bool								false	"tell download client to change categories?"
-// @Success		200					{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		500					{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200					{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		500					{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404					{object}	string								"bad token or api key"
 // @Failure		423					{object}	string								"rate limit reached"
 // @Router			/radarr/{instance}/queue/{queueID} [delete]
@@ -1161,8 +1161,8 @@ func radarrDeleteQueue(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			movieID		path		int64								true	"movie ID to delete"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		500			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		500			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Failure		423			{object}	string								"rate limit reached"
 // @Router			/radarr/{instance}/delete/{movieID} [post]
@@ -1191,8 +1191,8 @@ func radarrDeleteMovie(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			movieFileID	path		int64								true	"movie file ID to delete"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		500			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		500			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Failure		423			{object}	string								"rate limit reached"
 // @Router			/radarr/{instance}/delete/{movieFileID} [delete]

--- a/pkg/apps/readarr.go
+++ b/pkg/apps/readarr.go
@@ -92,12 +92,12 @@ func (a *AppsConfig) setupReadarr() ([]Readarr, error) {
 // @Param			instance	path	int64					true	"instance ID"
 // @Param			POST		body	readarr.AddBookInput	true	"new item content"
 // @Accept			json
-// @Success		201	{object}	apps.ApiResponse{message=readarr.Book}	"created"
-// @Failure		400	{object}	apps.ApiResponse{message=string}		"bad json payload"
-// @Failure		409	{object}	apps.ApiResponse{message=string}		"item already exists"
-// @Failure		422	{object}	apps.ApiResponse{message=string}		"no valid editions provided"
-// @Failure		503	{object}	apps.ApiResponse{message=string}		"instance error during check"
-// @Failure		500	{object}	apps.ApiResponse{message=string}		"instance error during add"
+// @Success		201	{object}	apps.APIResponse{message=readarr.Book}	"created"
+// @Failure		400	{object}	apps.APIResponse{message=string}		"bad json payload"
+// @Failure		409	{object}	apps.APIResponse{message=string}		"item already exists"
+// @Failure		422	{object}	apps.APIResponse{message=string}		"no valid editions provided"
+// @Failure		503	{object}	apps.APIResponse{message=string}		"instance error during check"
+// @Failure		500	{object}	apps.APIResponse{message=string}		"instance error during add"
 // @Failure		404	{object}	string									"bad token or api key"
 // @Router			/readarr/{instance}/add [post]
 // @Security		ApiKeyAuth
@@ -137,8 +137,8 @@ func readarrAddBook(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64										true	"instance ID"
 // @Param			authorID	path		int64										true	"author ID"
-// @Success		200			{object}	apps.ApiResponse{message=readarr.Author}	"author content"
-// @Failure		503			{object}	apps.ApiResponse{message=string}			"instance error"
+// @Success		200			{object}	apps.APIResponse{message=readarr.Author}	"author content"
+// @Failure		503			{object}	apps.APIResponse{message=string}			"instance error"
 // @Failure		404			{object}	string										"bad token or api key"
 // @Router			/readarr/{instance}/author/{authorID} [get]
 // @Security		ApiKeyAuth
@@ -175,9 +175,9 @@ func readarrData(book *readarr.Book) map[string]any {
 //	@Produce		json
 //	@Param			instance	path		int64								true	"instance ID"
 //	@Param			gridID		path		int64								true	"Good Reads ID"
-//	@Success		200			{object}	apps.ApiResponse{message=string}	"not found"
-//	@Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
-//	@Failure		409			{object}	apps.ApiResponse{message=string}	"already exists"
+//	@Success		200			{object}	apps.APIResponse{message=string}	"not found"
+//	@Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
+//	@Failure		409			{object}	apps.APIResponse{message=string}	"already exists"
 //	@Failure		404			{object}	string								"bad token or api key"
 //	@Router			/readarr/{instance}/check/{gridID} [get]
 //	@Security		ApiKeyAuth
@@ -200,8 +200,8 @@ func readarrCheckBook(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			bookID		path		int64								true	"Book ID"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"not found"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"not found"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/readarr/{instance}/get/{bookID} [get]
 // @Security		ApiKeyAuth
@@ -237,8 +237,8 @@ func readarrTriggerSearchBook(req *http.Request) (int, any) {
 //	@Tags			Readarr
 //	@Produce		json
 //	@Param			instance	path		int64										true	"instance ID"
-//	@Success		200			{object}	apps.ApiResponse{message=map[int64]string}	"map of ID to name"
-//	@Failure		500			{object}	apps.ApiResponse{message=string}			"instance error"
+//	@Success		200			{object}	apps.APIResponse{message=map[int64]string}	"map of ID to name"
+//	@Failure		500			{object}	apps.APIResponse{message=string}			"instance error"
 //	@Failure		404			{object}	string										"bad token or api key"
 //	@Router			/readarr/{instance}/metadataProfiles [get]
 //	@Security		ApiKeyAuth
@@ -264,8 +264,8 @@ func readarrMetaProfiles(req *http.Request) (int, any) {
 //	@Tags			Readarr
 //	@Produce		json
 //	@Param			instance	path		int64										true	"instance ID"
-//	@Success		200			{object}	apps.ApiResponse{message=map[int64]string}	"map of ID to name"
-//	@Failure		500			{object}	apps.ApiResponse{message=string}			"instance error"
+//	@Success		200			{object}	apps.APIResponse{message=map[int64]string}	"map of ID to name"
+//	@Failure		500			{object}	apps.APIResponse{message=string}			"instance error"
 //	@Failure		404			{object}	string										"bad token or api key"
 //	@Router			/readarr/{instance}/qualityProfiles [get]
 //	@Security		ApiKeyAuth
@@ -291,8 +291,8 @@ func readarrQualityProfiles(req *http.Request) (int, any) {
 //	@Tags			Readarr
 //	@Produce		json
 //	@Param			instance	path		int64												true	"instance ID"
-//	@Success		200			{object}	apps.ApiResponse{message=[]readarr.QualityProfile}	"all profiles"
-//	@Failure		500			{object}	apps.ApiResponse{message=string}					"instance error"
+//	@Success		200			{object}	apps.APIResponse{message=[]readarr.QualityProfile}	"all profiles"
+//	@Failure		500			{object}	apps.APIResponse{message=string}					"instance error"
 //	@Failure		404			{object}	string												"bad token or api key"
 //	@Router			/readarr/{instance}/qualityProfile [get]
 //	@Security		ApiKeyAuth
@@ -312,9 +312,9 @@ func readarrGetQualityProfile(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			POST		body		readarr.QualityProfile				true	"new item content"
-// @Success		200			{object}	apps.ApiResponse{message=int64}		"new profile ID"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"json input error"
-// @Failure		500			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=int64}		"new profile ID"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"json input error"
+// @Failure		500			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/readarr/{instance}/qualityProfile [post]
 // @Security		ApiKeyAuth
@@ -345,9 +345,9 @@ func readarrAddQualityProfile(req *http.Request) (int, any) {
 // @Param			profileID	path		int64								true	"profile ID to update"
 // @Param			PUT			body		readarr.QualityProfile				true	"updated item content"
 // @Success		200			{object}	string								"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"json input error"
-// @Failure		422			{object}	apps.ApiResponse{message=string}	"no profile ID"
-// @Failure		500			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"json input error"
+// @Failure		422			{object}	apps.APIResponse{message=string}	"no profile ID"
+// @Failure		500			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/readarr/{instance}/qualityProfile/{profileID} [put]
 // @Security		ApiKeyAuth
@@ -381,8 +381,8 @@ func readarrUpdateQualityProfile(req *http.Request) (int, any) {
 //	@Tags			Readarr
 //	@Produce		json
 //	@Param			instance	path		int64										true	"instance ID"
-//	@Success		200			{object}	apps.ApiResponse{message=map[string]int64}	"map of path->space free"
-//	@Failure		500			{object}	apps.ApiResponse{message=string}			"instance error"
+//	@Success		200			{object}	apps.APIResponse{message=map[string]int64}	"map of path->space free"
+//	@Failure		500			{object}	apps.APIResponse{message=string}			"instance error"
 //	@Failure		404			{object}	string										"bad token or api key"
 //	@Router			/readarr/{instance}/rootFolder [get]
 //	@Security		ApiKeyAuth
@@ -407,8 +407,8 @@ func readarrRootFolders(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			query		path		string														true	"title search string"
 // @Param			instance	path		int64														true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]apps.readarrSearchBook.bookData}	"minimal book data"
-// @Failure		503			{object}	apps.ApiResponse{message=string}							"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]apps.readarrSearchBook.bookData}	"minimal book data"
+// @Failure		503			{object}	apps.APIResponse{message=string}							"instance error"
 // @Failure		404			{object}	string														"bad token or api key"
 // @Router			/readarr/{instance}/search/{query} [get]
 // @Security		ApiKeyAuth
@@ -488,8 +488,8 @@ func bookSearch(query, title string, editions []*readarr.Edition) bool {
 // @Tags			Readarr
 // @Produce		json
 // @Param			instance	path		int64									true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]starr.Tag}	"tags"
-// @Failure		503			{object}	apps.ApiResponse{message=string}		"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]starr.Tag}	"tags"
+// @Failure		503			{object}	apps.APIResponse{message=string}		"instance error"
 // @Failure		404			{object}	string									"bad token or api key"
 // @Router			/readarr/{instance}/tag [get]
 // @Security		ApiKeyAuth
@@ -509,8 +509,8 @@ func readarrGetTags(req *http.Request) (int, any) {
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			tagID		path		int64								true	"tag ID to update"
 // @Param			label		path		string								true	"new label"
-// @Success		200			{object}	apps.ApiResponse{message=int64}		"tag ID"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=int64}		"tag ID"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/readarr/{instance}/tag/{tagID}/{label} [put]
 // @Security		ApiKeyAuth
@@ -531,8 +531,8 @@ func readarrUpdateTag(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			label		path		string								true	"new tag's label"
-// @Success		200			{object}	apps.ApiResponse{message=int64}		"tag ID"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=int64}		"tag ID"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/readarr/{instance}/tag/{label} [put]
 // @Security		ApiKeyAuth
@@ -553,9 +553,9 @@ func readarrSetTag(req *http.Request) (int, any) {
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			moveFiles	query		int64								true	"move files? true/false"
 // @Param			PUT			body		readarr.Book						true	"book content"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"bad json input"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"bad json input"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/readarr/{instance}/update [put]
 // @Security		ApiKeyAuth
@@ -584,9 +584,9 @@ func readarrUpdateBook(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			PUT			body		readarr.Author						true	"author content"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"bad json input"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"bad json input"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/readarr/{instance}/updateauthor [put]
 // @Security		ApiKeyAuth
@@ -611,8 +611,8 @@ func readarrUpdateAuthor(req *http.Request) (int, any) {
 // @Tags			Readarr
 // @Produce		json
 // @Param			instance	path		int64													true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]readarr.NotificationOutput}	"notifications"
-// @Failure		503			{object}	apps.ApiResponse{message=string}						"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]readarr.NotificationOutput}	"notifications"
+// @Failure		503			{object}	apps.APIResponse{message=string}						"instance error"
 // @Failure		404			{object}	string													"bad token or api key"
 // @Router			/readarr/{instance}/notifications [get]
 // @Security		ApiKeyAuth
@@ -640,9 +640,9 @@ func readarrGetNotifications(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			PUT			body		readarr.NotificationInput			true	"notification content"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"bad json input"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"bad json input"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/readarr/{instance}/notification [put]
 // @Security		ApiKeyAuth
@@ -669,9 +669,9 @@ func readarrUpdateNotification(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			POST		body		readarr.NotificationInput			true	"new item content"
-// @Success		200			{object}	apps.ApiResponse{message=int64}		"new notification ID"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"json input error"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=int64}		"new notification ID"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"json input error"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/readarr/{instance}/notification [post]
 // @Security		ApiKeyAuth
@@ -701,8 +701,8 @@ func readarrAddNotification(req *http.Request) (int, any) {
 // @Param			blocklist			query		bool								false	"add item to blocklist?"
 // @Param			skipRedownload		query		bool								false	"skip downloading this again?"
 // @Param			changeCategory		query		bool								false	"tell download client to change categories?"
-// @Success		200					{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		500					{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200					{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		500					{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404					{object}	string								"bad token or api key"
 // @Failure		423					{object}	string								"rate limit reached"
 // @Router			/readarr/{instance}/queue/{queueID} [delete]

--- a/pkg/apps/sonarr.go
+++ b/pkg/apps/sonarr.go
@@ -117,12 +117,12 @@ func (a *AppsConfig) setupSonarr() ([]Sonarr, error) {
 // @Accept			json
 // @Param			instance	path		int64									true	"instance ID"
 // @Param			POST		body		sonarr.AddSeriesInput					true	"new item content"
-// @Success		201			{object}	apps.ApiResponse{message=sonarr.Series}	"series content"
-// @Failure		400			{object}	apps.ApiResponse{message=string}		"bad json payload"
-// @Failure		409			{object}	apps.ApiResponse{message=string}		"item already exists"
-// @Failure		422			{object}	apps.ApiResponse{message=string}		"no item ID provided"
-// @Failure		503			{object}	apps.ApiResponse{message=string}		"instance error during check"
-// @Failure		500			{object}	apps.ApiResponse{message=string}		"instance error during add"
+// @Success		201			{object}	apps.APIResponse{message=sonarr.Series}	"series content"
+// @Failure		400			{object}	apps.APIResponse{message=string}		"bad json payload"
+// @Failure		409			{object}	apps.APIResponse{message=string}		"item already exists"
+// @Failure		422			{object}	apps.APIResponse{message=string}		"no item ID provided"
+// @Failure		503			{object}	apps.APIResponse{message=string}		"instance error during check"
+// @Failure		500			{object}	apps.APIResponse{message=string}		"instance error during add"
 // @Failure		404			{object}	string									"bad token or api key"
 // @Router			/sonarr/{instance}/add [post]
 // @Security		ApiKeyAuth
@@ -172,9 +172,9 @@ func sonarrData(series *sonarr.Series) map[string]any {
 // @Produce		json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			tvdbid		path		int64								true	"TVDB ID"
-// @Success		201			{object}	apps.ApiResponse{message=string}	"series does not exist"
-// @Failure		409			{object}	apps.ApiResponse{message=string}	"item already exists"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		201			{object}	apps.APIResponse{message=string}	"series does not exist"
+// @Failure		409			{object}	apps.APIResponse{message=string}	"item already exists"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/sonarr/{instance}/check/{tvdbid} [get]
 // @Security		ApiKeyAuth
@@ -197,8 +197,8 @@ func sonarrCheckSeries(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64									true	"instance ID"
 // @Param			seriesID	path		int64									true	"Series ID"
-// @Success		201			{object}	apps.ApiResponse{message=sonarr.Series}	"series content"
-// @Failure		503			{object}	apps.ApiResponse{message=string}		"instance error"
+// @Success		201			{object}	apps.APIResponse{message=sonarr.Series}	"series content"
+// @Failure		503			{object}	apps.APIResponse{message=string}		"instance error"
 // @Failure		404			{object}	string									"bad token or api key"
 // @Router			/sonarr/{instance}/get/{seriesID} [get]
 // @Security		ApiKeyAuth
@@ -219,8 +219,8 @@ func sonarrGetSeries(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64										true	"instance ID"
 // @Param			seriesID	path		int64										true	"Series ID"
-// @Success		201			{object}	apps.ApiResponse{message=[]sonarr.Episode}	"episodes content"
-// @Failure		503			{object}	apps.ApiResponse{message=string}			"instance error"
+// @Success		201			{object}	apps.APIResponse{message=[]sonarr.Episode}	"episodes content"
+// @Failure		503			{object}	apps.APIResponse{message=string}			"instance error"
 // @Failure		404			{object}	string										"bad token or api key"
 // @Router			/sonarr/{instance}/getEpisodes/{seriesID} [get]
 // @Security		ApiKeyAuth
@@ -241,8 +241,8 @@ func sonarrGetEpisodes(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64										true	"instance ID"
 // @Param			episodeID	path		int64										true	"Episode ID"
-// @Success		201			{object}	apps.ApiResponse{message=sonarr.Episode}	"episode content"
-// @Failure		503			{object}	apps.ApiResponse{message=string}			"instance error"
+// @Success		201			{object}	apps.APIResponse{message=sonarr.Episode}	"episode content"
+// @Failure		503			{object}	apps.APIResponse{message=string}			"instance error"
 // @Failure		404			{object}	string										"bad token or api key"
 // @Router			/sonarr/{instance}/unmonitor/{episodeID} [get]
 // @Security		ApiKeyAuth
@@ -265,8 +265,8 @@ func sonarrUnmonitorEpisode(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			seriesID	path		int64								true	"Series ID"
-// @Success		201			{object}	apps.ApiResponse{message=string}	"search status"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		201			{object}	apps.APIResponse{message=string}	"search status"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/sonarr/{instance}/command/search/{seriesID} [get]
 // @Security		ApiKeyAuth
@@ -291,9 +291,9 @@ func sonarrTriggerSearchSeries(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64												true	"instance ID"
 // @Param			POST		body		sonarr.CommandRequest								true	"command content, must include series ID"
-// @Success		201			{object}	apps.ApiResponse{message=sonarr.CommandResponse}	"command response"
-// @Failure		400			{object}	apps.ApiResponse{message=string}					"invalid json input"
-// @Failure		503			{object}	apps.ApiResponse{message=string}					"instance error"
+// @Success		201			{object}	apps.APIResponse{message=sonarr.CommandResponse}	"command response"
+// @Failure		400			{object}	apps.APIResponse{message=string}					"invalid json input"
+// @Failure		503			{object}	apps.APIResponse{message=string}					"instance error"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/sonarr/{instance}/command [post]
 // @Security		ApiKeyAuth
@@ -320,8 +320,8 @@ func sonarrTriggerCommand(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64												true	"instance ID"
 // @Param			commandID	path		int64												true	"Command ID returned by executing a command"
-// @Success		201			{object}	apps.ApiResponse{message=sonarr.CommandResponse}	"command status"
-// @Failure		503			{object}	apps.ApiResponse{message=string}					"instance error"
+// @Success		201			{object}	apps.APIResponse{message=sonarr.CommandResponse}	"command status"
+// @Failure		503			{object}	apps.APIResponse{message=string}					"instance error"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/sonarr/{instance}/command/{commandID} [get]
 // @Security		ApiKeyAuth
@@ -342,8 +342,8 @@ func sonarrStatusCommand(req *http.Request) (int, any) {
 // @Tags			Sonarr
 // @Produce		json
 // @Param			instance	path		int64										true	"instance ID"
-// @Success		201			{object}	apps.ApiResponse{message=map[int64]string}	"map of ID to name"
-// @Failure		500			{object}	apps.ApiResponse{message=string}			"instance error"
+// @Success		201			{object}	apps.APIResponse{message=map[int64]string}	"map of ID to name"
+// @Failure		500			{object}	apps.APIResponse{message=string}			"instance error"
 // @Failure		404			{object}	string										"bad token or api key"
 // @Router			/sonarr/{instance}/languageProfiles [get]
 // @Security		ApiKeyAuth
@@ -368,8 +368,8 @@ func sonarrLangProfiles(req *http.Request) (int, any) {
 // @Tags			Sonarr
 // @Produce		json
 // @Param			instance	path		int64												true	"instance ID"
-// @Success		201			{object}	apps.ApiResponse{message=[]sonarr.QualityProfile}	"all profiles"
-// @Failure		500			{object}	apps.ApiResponse{message=string}					"instance error"
+// @Success		201			{object}	apps.APIResponse{message=[]sonarr.QualityProfile}	"all profiles"
+// @Failure		500			{object}	apps.APIResponse{message=string}					"instance error"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/sonarr/{instance}/qualityProfile [get]
 // @Security		ApiKeyAuth
@@ -388,8 +388,8 @@ func sonarrGetQualityProfile(req *http.Request) (int, any) {
 // @Tags			Sonarr
 // @Produce		json
 // @Param			instance	path		int64										true	"instance ID"
-// @Success		201			{object}	apps.ApiResponse{message=map[int64]string}	"map of ID to name"
-// @Failure		500			{object}	apps.ApiResponse{message=string}			"instance error"
+// @Success		201			{object}	apps.APIResponse{message=map[int64]string}	"map of ID to name"
+// @Failure		500			{object}	apps.APIResponse{message=string}			"instance error"
 // @Failure		404			{object}	string										"bad token or api key"
 // @Router			/sonarr/{instance}/qualityProfiles [get]
 // @Security		ApiKeyAuth
@@ -416,9 +416,9 @@ func sonarrGetQualityProfiles(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			POST		body		sonarr.QualityProfile				true	"new item content"
-// @Success		200			{object}	apps.ApiResponse{message=int64}		"new profile ID"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"json input error"
-// @Failure		500			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=int64}		"new profile ID"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"json input error"
+// @Failure		500			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/sonarr/{instance}/qualityProfile [post]
 // @Security		ApiKeyAuth
@@ -448,10 +448,10 @@ func sonarrAddQualityProfile(req *http.Request) (int, any) {
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			profileID	path		int64								true	"profile ID to update"
 // @Param			PUT			body		sonarr.QualityProfile				true	"updated item content"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"json input error"
-// @Failure		422			{object}	apps.ApiResponse{message=string}	"no profile ID"
-// @Failure		500			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"json input error"
+// @Failure		422			{object}	apps.APIResponse{message=string}	"no profile ID"
+// @Failure		500			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/sonarr/{instance}/qualityProfile/{profileID} [put]
 // @Security		ApiKeyAuth
@@ -484,9 +484,9 @@ func sonarrUpdateQualityProfile(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			profileID	path		int64								true	"profile ID to update"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"no profile ID"
-// @Failure		500			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"no profile ID"
+// @Failure		500			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/sonarr/{instance}/qualityProfile/{profileID} [delete]
 // @Security		ApiKeyAuth
@@ -510,8 +510,8 @@ func sonarrDeleteQualityProfile(req *http.Request) (int, any) {
 // @Tags			Sonarr
 // @Produce		json
 // @Param			instance	path		int64											true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=apps.deleteResponse}	"delete status"
-// @Failure		500			{object}	apps.ApiResponse{message=string}				"instance error getting profiles"
+// @Success		200			{object}	apps.APIResponse{message=apps.deleteResponse}	"delete status"
+// @Failure		500			{object}	apps.APIResponse{message=string}				"instance error getting profiles"
 // @Failure		404			{object}	string											"bad token or api key"
 // @Router			/sonarr/{instance}/qualityProfiles/all [delete]
 // @Security		ApiKeyAuth
@@ -549,8 +549,8 @@ func sonarrDeleteAllQualityProfiles(req *http.Request) (int, any) {
 // @Tags			Sonarr
 // @Produce		json
 // @Param			instance	path		int64												true	"instance ID"
-// @Success		201			{object}	apps.ApiResponse{message=[]sonarr.ReleaseProfile}	"all profiles"
-// @Failure		500			{object}	apps.ApiResponse{message=string}					"instance error"
+// @Success		201			{object}	apps.APIResponse{message=[]sonarr.ReleaseProfile}	"all profiles"
+// @Failure		500			{object}	apps.APIResponse{message=string}					"instance error"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/sonarr/{instance}/releaseProfile [get]
 // @Security		ApiKeyAuth
@@ -571,9 +571,9 @@ func sonarrGetReleaseProfiles(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			POST		body		sonarr.ReleaseProfile				true	"new item content"
-// @Success		200			{object}	apps.ApiResponse{message=int64}		"new profile ID"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"json input error"
-// @Failure		500			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=int64}		"new profile ID"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"json input error"
+// @Failure		500			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/sonarr/{instance}/releaseProfile [post]
 // @Security		ApiKeyAuth
@@ -603,10 +603,10 @@ func sonarrAddReleaseProfile(req *http.Request) (int, any) {
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			profileID	path		int64								true	"profile ID to update"
 // @Param			PUT			body		sonarr.ReleaseProfile				true	"updated item content"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"json input error"
-// @Failure		422			{object}	apps.ApiResponse{message=string}	"no profile ID"
-// @Failure		500			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"json input error"
+// @Failure		422			{object}	apps.APIResponse{message=string}	"no profile ID"
+// @Failure		500			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/sonarr/{instance}/releaseProfile/{profileID} [put]
 // @Security		ApiKeyAuth
@@ -639,9 +639,9 @@ func sonarrUpdateReleaseProfile(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			profileID	path		int64								true	"profile ID to update"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"no profile ID"
-// @Failure		500			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"no profile ID"
+// @Failure		500			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/sonarr/{instance}/releaseProfile/{profileID} [delete]
 // @Security		ApiKeyAuth
@@ -665,8 +665,8 @@ func sonarrDeleteReleaseProfile(req *http.Request) (int, any) {
 // @Tags			Sonarr
 // @Produce		json
 // @Param			instance	path		int64											true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=apps.deleteResponse}	"delete status"
-// @Failure		500			{object}	apps.ApiResponse{message=string}				"instance error getting profiles"
+// @Success		200			{object}	apps.APIResponse{message=apps.deleteResponse}	"delete status"
+// @Failure		500			{object}	apps.APIResponse{message=string}				"instance error getting profiles"
 // @Failure		404			{object}	string											"bad token or api key"
 // @Router			/sonarr/{instance}/releaseProfile/all [delete]
 // @Security		ApiKeyAuth
@@ -704,8 +704,8 @@ func sonarrDeleteAllReleaseProfiles(req *http.Request) (int, any) {
 // @Tags			Sonarr
 // @Produce		json
 // @Param			instance	path		int64										true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=map[string]int64}	"map of path->space free"
-// @Failure		500			{object}	apps.ApiResponse{message=string}			"instance error"
+// @Success		200			{object}	apps.APIResponse{message=map[string]int64}	"map of path->space free"
+// @Failure		500			{object}	apps.APIResponse{message=string}			"instance error"
 // @Failure		404			{object}	string										"bad token or api key"
 // @Router			/sonarr/{instance}/rootFolder [get]
 // @Security		ApiKeyAuth
@@ -730,8 +730,8 @@ func sonarrRootFolders(req *http.Request) (int, any) {
 // @Tags			Sonarr
 // @Produce		json
 // @Param			instance	path		int64									true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=sonarr.Naming}	"naming conventions"
-// @Failure		500			{object}	apps.ApiResponse{message=string}		"instance error"
+// @Success		200			{object}	apps.APIResponse{message=sonarr.Naming}	"naming conventions"
+// @Failure		500			{object}	apps.APIResponse{message=string}		"instance error"
 // @Failure		404			{object}	string									"bad token or api key"
 // @Router			/sonarr/{instance}/naming [get]
 // @Security		ApiKeyAuth
@@ -750,9 +750,9 @@ func sonarrGetNaming(req *http.Request) (int, any) {
 // @Produce		json
 // @Accept			json
 // @Param			PUT	body		sonarr.Naming						true	"naming conventions"
-// @Success		200	{object}	apps.ApiResponse{message=int64}		"naming ID"
-// @Failure		400	{object}	apps.ApiResponse{message=string}	"bad json input"
-// @Failure		500	{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200	{object}	apps.APIResponse{message=int64}		"naming ID"
+// @Failure		400	{object}	apps.APIResponse{message=string}	"bad json input"
+// @Failure		500	{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404	{object}	string								"bad token or api key"
 // @Router			/sonarr/{instance}/naming [put]
 // @Security		ApiKeyAuth
@@ -820,8 +820,8 @@ func convertToSeriesSearchOutput(item *sonarr.Series, score int) SeriesSearchIte
 // @Produce		json
 // @Param			query		path		string												true	"title search string"
 // @Param			instance	path		int64												true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]apps.SeriesSearchItem}	"minimal series data"
-// @Failure		503			{object}	apps.ApiResponse{message=string}					"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]apps.SeriesSearchItem}	"minimal series data"
+// @Failure		503			{object}	apps.APIResponse{message=string}					"instance error"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/sonarr/{instance}/search/{query} [get]
 // @Security		ApiKeyAuth
@@ -944,8 +944,8 @@ func seriesMatches(wuzz *wuzzy.MatchPair, series []*sonarr.Series) []int {
 // @Tags			Sonarr
 // @Produce		json
 // @Param			instance	path		int64									true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]starr.Tag}	"tags"
-// @Failure		503			{object}	apps.ApiResponse{message=string}		"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]starr.Tag}	"tags"
+// @Failure		503			{object}	apps.APIResponse{message=string}		"instance error"
 // @Failure		404			{object}	string									"bad token or api key"
 // @Router			/sonarr/{instance}/tag [get]
 // @Security		ApiKeyAuth
@@ -965,8 +965,8 @@ func sonarrGetTags(req *http.Request) (int, any) {
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			tagID		path		int64								true	"tag ID to update"
 // @Param			label		path		string								true	"new label"
-// @Success		200			{object}	apps.ApiResponse{message=int64}		"tag ID"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=int64}		"tag ID"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/sonarr/{instance}/tag/{tagID}/{label} [put]
 // @Security		ApiKeyAuth
@@ -987,8 +987,8 @@ func sonarrUpdateTag(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			label		path		string								true	"tag label"
-// @Success		200			{object}	apps.ApiResponse{message=int64}		"tag ID"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=int64}		"tag ID"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/sonarr/{instance}/tag/{label} [put]
 // @Security		ApiKeyAuth
@@ -1008,8 +1008,8 @@ func sonarrSetTag(req *http.Request) (int, any) {
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			moveFiles	query		int64								true	"move files? true/false"
 // @Param			PUT			body		sonarr.Series						true	"series content"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"OK"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"OK"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/sonarr/{instance} [put]
 // @Security		ApiKeyAuth
@@ -1038,9 +1038,9 @@ func sonarrUpdateSeries(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			POST		body		sonarr.SeasonPass					true	"Season pass content"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"invalid json provided"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"invalid json provided"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/sonarr/{instance}/seasonPass [post]
 // @Security		ApiKeyAuth
@@ -1067,9 +1067,9 @@ func sonarrSeasonPass(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64												true	"instance ID"
 // @Param			POST		body		sonarr.CustomFormatInput							true	"New Custom Format content"
-// @Success		200			{object}	apps.ApiResponse{message=sonarr.CustomFormatOutput}	"custom format"
-// @Failure		400			{object}	apps.ApiResponse{message=string}					"invalid json provided"
-// @Failure		500			{object}	apps.ApiResponse{message=string}					"instance error"
+// @Success		200			{object}	apps.APIResponse{message=sonarr.CustomFormatOutput}	"custom format"
+// @Failure		400			{object}	apps.APIResponse{message=string}					"invalid json provided"
+// @Failure		500			{object}	apps.APIResponse{message=string}					"instance error"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/sonarr/{instance}/customformats [post]
 // @Security		ApiKeyAuth
@@ -1094,8 +1094,8 @@ func sonarrAddCustomFormat(req *http.Request) (int, any) {
 // @Tags			Sonarr
 // @Produce		json
 // @Param			instance	path		int64													true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]sonarr.CustomFormatOutput}	"custom formats"
-// @Failure		500			{object}	apps.ApiResponse{message=string}						"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]sonarr.CustomFormatOutput}	"custom formats"
+// @Failure		500			{object}	apps.APIResponse{message=string}						"instance error"
 // @Failure		404			{object}	string													"bad token or api key"
 // @Router			/sonarr/{instance}/customformats [get]
 // @Security		ApiKeyAuth
@@ -1116,9 +1116,9 @@ func sonarrGetCustomFormats(req *http.Request) (int, any) {
 // @Param			instance	path		int64												true	"instance ID"
 // @Param			formatID	path		int64												true	"Custom Format ID"
 // @Param			PUT			body		sonarr.CustomFormatInput							true	"Updated Custom Format content"
-// @Success		200			{object}	apps.ApiResponse{message=sonarr.CustomFormatOutput}	"custom format"
-// @Failure		400			{object}	apps.ApiResponse{message=string}					"invalid json provided"
-// @Failure		500			{object}	apps.ApiResponse{message=string}					"instance error"
+// @Success		200			{object}	apps.APIResponse{message=sonarr.CustomFormatOutput}	"custom format"
+// @Failure		400			{object}	apps.APIResponse{message=string}					"invalid json provided"
+// @Failure		500			{object}	apps.APIResponse{message=string}					"instance error"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/sonarr/{instance}/customformats/{formatID} [put]
 // @Security		ApiKeyAuth
@@ -1142,8 +1142,8 @@ func sonarrUpdateCustomFormat(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			formatID	path		int64								true	"Custom Format ID"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		500			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		500			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/sonarr/{instance}/customformats/{formatID} [delete]
 // @Security		ApiKeyAuth
@@ -1163,8 +1163,8 @@ func sonarrDeleteCustomFormat(req *http.Request) (int, any) {
 // @Tags			Sonarr
 // @Produce		json
 // @Param			instance	path		int64											true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=apps.deleteResponse}	"item delete counters"
-// @Failure		500			{object}	apps.ApiResponse{message=string}				"instance error"
+// @Success		200			{object}	apps.APIResponse{message=apps.deleteResponse}	"item delete counters"
+// @Failure		500			{object}	apps.APIResponse{message=string}				"instance error"
 // @Failure		404			{object}	string											"bad token or api key"
 // @Router			/sonarr/{instance}/customformats/all [delete]
 // @Security		ApiKeyAuth
@@ -1201,8 +1201,8 @@ func sonarrDeleteAllCustomFormats(req *http.Request) (int, any) {
 // @Tags			Sonarr
 // @Produce		json
 // @Param			instance	path		int64												true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]sonarr.ImportListOutput}	"list of import lists"
-// @Failure		500			{object}	apps.ApiResponse{message=string}					"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]sonarr.ImportListOutput}	"list of import lists"
+// @Failure		500			{object}	apps.APIResponse{message=string}					"instance error"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/sonarr/{instance}/importlist [get]
 // @Security		ApiKeyAuth
@@ -1223,9 +1223,9 @@ func sonarrGetImportLists(req *http.Request) (int, any) {
 // @Param			instance	path		int64												true	"instance ID"
 // @Param			listID		path		int64												true	"Import List ID"
 // @Param			PUT			body		sonarr.ImportListInput								true	"Updated Import List Content"
-// @Success		200			{object}	apps.ApiResponse{message=sonarr.ImportListOutput}	"import list returns"
-// @Failure		400			{object}	apps.ApiResponse{message=string}					"invalid json provided"
-// @Failure		500			{object}	apps.ApiResponse{message=string}					"instance error"
+// @Success		200			{object}	apps.APIResponse{message=sonarr.ImportListOutput}	"import list returns"
+// @Failure		400			{object}	apps.APIResponse{message=string}					"invalid json provided"
+// @Failure		500			{object}	apps.APIResponse{message=string}					"instance error"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/sonarr/{instance}/importlist/{listID} [put]
 // @Security		ApiKeyAuth
@@ -1252,9 +1252,9 @@ func sonarrUpdateImportList(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64												true	"instance ID"
 // @Param			POST		body		sonarr.ImportListInput								true	"New Import List"
-// @Success		200			{object}	apps.ApiResponse{message=sonarr.ImportListOutput}	"import list returns"
-// @Failure		400			{object}	apps.ApiResponse{message=string}					"invalid json provided"
-// @Failure		500			{object}	apps.ApiResponse{message=string}					"instance error"
+// @Success		200			{object}	apps.APIResponse{message=sonarr.ImportListOutput}	"import list returns"
+// @Failure		400			{object}	apps.APIResponse{message=string}					"invalid json provided"
+// @Failure		500			{object}	apps.APIResponse{message=string}					"instance error"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/sonarr/{instance}/importlist [post]
 // @Security		ApiKeyAuth
@@ -1277,8 +1277,8 @@ func sonarrAddImportList(req *http.Request) (int, any) {
 // @Tags			Sonarr
 // @Produce		json
 // @Param			instance	path		int64													true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]sonarr.QualityDefinition}	"quality definitions list"
-// @Failure		500			{object}	apps.ApiResponse{message=string}						"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]sonarr.QualityDefinition}	"quality definitions list"
+// @Failure		500			{object}	apps.APIResponse{message=string}						"instance error"
 // @Failure		404			{object}	string													"bad token or api key"
 // @Router			/sonarr/{instance}/qualitydefinition [get]
 // @Security		ApiKeyAuth
@@ -1298,9 +1298,9 @@ func sonarrGetQualityDefinitions(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64													true	"instance ID"
 // @Param			PUT			body		[]sonarr.QualityDefinition								true	"Updated Import Listcontent"
-// @Success		200			{object}	apps.ApiResponse{message=[]sonarr.QualityDefinition}	"quality definitions return"
-// @Failure		400			{object}	apps.ApiResponse{message=string}						"invalid json provided"
-// @Failure		500			{object}	apps.ApiResponse{message=string}						"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]sonarr.QualityDefinition}	"quality definitions return"
+// @Failure		400			{object}	apps.APIResponse{message=string}						"invalid json provided"
+// @Failure		500			{object}	apps.APIResponse{message=string}						"instance error"
 // @Failure		404			{object}	string													"bad token or api key"
 // @Router			/sonarr/{instance}/qualitydefinition [put]
 // @Security		ApiKeyAuth
@@ -1323,8 +1323,8 @@ func sonarrUpdateQualityDefinition(req *http.Request) (int, any) {
 // @Tags			Sonarr
 // @Produce		json
 // @Param			instance	path		int64													true	"instance ID"
-// @Success		200			{object}	apps.ApiResponse{message=[]sonarr.NotificationOutput}	"notifications"
-// @Failure		503			{object}	apps.ApiResponse{message=string}						"instance error"
+// @Success		200			{object}	apps.APIResponse{message=[]sonarr.NotificationOutput}	"notifications"
+// @Failure		503			{object}	apps.APIResponse{message=string}						"instance error"
 // @Failure		404			{object}	string													"bad token or api key"
 // @Router			/sonarr/{instance}/notifications [get]
 // @Security		ApiKeyAuth
@@ -1352,9 +1352,9 @@ func sonarrGetNotifications(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			PUT			body		sonarr.NotificationInput			true	"notification content"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"bad json input"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"bad json input"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/sonarr/{instance}/notification [put]
 // @Security		ApiKeyAuth
@@ -1381,9 +1381,9 @@ func sonarrUpdateNotification(req *http.Request) (int, any) {
 // @Accept			json
 // @Param			instance	path		int64								true	"instance ID"
 // @Param			POST		body		sonarr.NotificationInput			true	"new item content"
-// @Success		200			{object}	apps.ApiResponse{message=int64}		"new notification ID"
-// @Failure		400			{object}	apps.ApiResponse{message=string}	"json input error"
-// @Failure		503			{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200			{object}	apps.APIResponse{message=int64}		"new notification ID"
+// @Failure		400			{object}	apps.APIResponse{message=string}	"json input error"
+// @Failure		503			{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/sonarr/{instance}/notification [post]
 // @Security		ApiKeyAuth
@@ -1413,8 +1413,8 @@ func sonarrAddNotification(req *http.Request) (int, any) {
 // @Param			blocklist			query		bool								false	"add item to blocklist?"
 // @Param			skipRedownload		query		bool								false	"skip downloading this again?"
 // @Param			changeCategory		query		bool								false	"tell download client to change categories?"
-// @Success		200					{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		500					{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200					{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		500					{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404					{object}	string								"bad token or api key"
 // @Failure		423					{object}	string								"rate limit reached"
 // @Router			/sonarr/{instance}/queue/{queueID} [delete]
@@ -1444,8 +1444,8 @@ func sonarrDeleteQueue(req *http.Request) (int, any) {
 // @Produce		json
 // @Param			instance		path		int64								true	"instance ID"
 // @Param			episodeFileID	path		int64								true	"episode file ID to delete, not episode ID"
-// @Success		200				{object}	apps.ApiResponse{message=string}	"ok"
-// @Failure		500				{object}	apps.ApiResponse{message=string}	"instance error"
+// @Success		200				{object}	apps.APIResponse{message=string}	"ok"
+// @Failure		500				{object}	apps.APIResponse{message=string}	"instance error"
 // @Failure		404				{object}	string								"bad token or api key"
 // @Failure		423				{object}	string								"rate limit reached"
 // @Router			/sonarr/{instance}/delete/{episodeFileID} [post]

--- a/pkg/client/handlers.go
+++ b/pkg/client/handlers.go
@@ -267,7 +267,7 @@ func (c *Client) fixForwardedFor(next http.Handler) http.Handler {
 // @Produce		json
 // @Param			app			path		string												true	"Application"	Enums(lidarr, prowlarr, radarr, readarr, sonarr)
 // @Param			instance	path		int64												true	"Application instance (1-index)."
-// @Success		200			{object}	apps.ApiResponse{message=map[string]map[int]bool}	"map for app->instance->up"
+// @Success		200			{object}	apps.APIResponse{message=map[string]map[int]bool}	"map for app->instance->up"
 // @Failure		404			{object}	string												"bad token or api key"
 // @Router			/ping/{app}/{instance} [get]
 // @Security		ApiKeyAuth
@@ -279,7 +279,7 @@ func _() {}
 // @Tags			Client
 // @Produce		json
 // @Param			apps	path		string												true	"Application, comma separated"	Enums(lidarr, prowlarr, radarr, readarr, sonarr)
-// @Success		200		{object}	apps.ApiResponse{message=map[string]map[int]bool}	"map for app->instance->up"
+// @Success		200		{object}	apps.APIResponse{message=map[string]map[int]bool}	"map for app->instance->up"
 // @Failure		404		{object}	string												"bad token or api key"
 // @Router			/ping/{apps} [get]
 // @Security		ApiKeyAuth
@@ -291,7 +291,7 @@ func _() {}
 // @Summary		Ping all starr instances.
 // @Tags			Client
 // @Produce		json
-// @Success		200	{object}	apps.ApiResponse{message=map[string]map[int]bool}	"map for app->instance->up"
+// @Success		200	{object}	apps.APIResponse{message=map[string]map[int]bool}	"map for app->instance->up"
 // @Failure		404	{object}	string												"bad token or api key"
 // @Router			/ping [get]
 // @Security		ApiKeyAuth

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -435,7 +435,7 @@ func (s *Services) handleTrigger(req *http.Request, event website.EventType) (in
 // @Summary		Get service check results
 // @Tags			Triggers
 // @Produce		json
-// @Success		200	{object}	apps.ApiResponse{message=[]CheckResult}	"list check results"
+// @Success		200	{object}	apps.APIResponse{message=[]CheckResult}	"list check results"
 // @Failure		404	{object}	string									"bad token or api key"
 // @Router			/services/list [get]
 // @Security		ApiKeyAuth

--- a/pkg/triggers/cfsync/handler.go
+++ b/pkg/triggers/cfsync/handler.go
@@ -22,8 +22,8 @@ import (
 // @Produce		json
 // @Accept			json
 // @Param			request	body		TrashAggInput									true	"list of instances"
-// @Success		200		{object}	apps.ApiResponse{message=[]RadarrTrashPayload}	"contains app info included appStatus"
-// @Failure		400		{object}	apps.ApiResponse{message=string}				"bad input payload or missing app"
+// @Success		200		{object}	apps.APIResponse{message=[]RadarrTrashPayload}	"contains app info included appStatus"
+// @Failure		400		{object}	apps.APIResponse{message=string}				"bad input payload or missing app"
 // @Failure		404		{object}	string											"bad token or api key"
 // @Router			/trash/radarr [post]
 // @Security		ApiKeyAuth
@@ -35,8 +35,8 @@ func _() {}
 // @Produce		json
 // @Accept			json
 // @Param			request	body		TrashAggInput									true	"list of instances"
-// @Success		200		{object}	apps.ApiResponse{message=[]LidarrTrashPayload}	"contains app info included appStatus"
-// @Failure		400		{object}	apps.ApiResponse{message=string}				"bad input payload or missing app"
+// @Success		200		{object}	apps.APIResponse{message=[]LidarrTrashPayload}	"contains app info included appStatus"
+// @Failure		400		{object}	apps.APIResponse{message=string}				"bad input payload or missing app"
 // @Failure		404		{object}	string											"bad token or api key"
 // @Router			/trash/lidarr [post]
 // @Security		ApiKeyAuth
@@ -50,8 +50,8 @@ func _() {}
 //	@Produce		json
 //	@Accept			json
 //	@Param			request	body		TrashAggInput									true	"list of instances"
-//	@Success		200		{object}	apps.ApiResponse{message=[]SonarrTrashPayload}	"contains app info included appStatus"
-//	@Failure		400		{object}	apps.ApiResponse{message=string}				"bad input payload or missing app"
+//	@Success		200		{object}	apps.APIResponse{message=[]SonarrTrashPayload}	"contains app info included appStatus"
+//	@Failure		400		{object}	apps.APIResponse{message=string}				"bad input payload or missing app"
 //	@Failure		404		{object}	string											"bad token or api key"
 //	@Router			/trash/sonarr [post]
 //	@Security		ApiKeyAuth

--- a/pkg/triggers/handler.go
+++ b/pkg/triggers/handler.go
@@ -66,7 +66,7 @@ type triggerOutput struct {
 // @Summary		Get trigger list
 // @Tags			Triggers
 // @Produce		json
-// @Success		200	{object}	apps.ApiResponse{message=triggers.triggerOutput}	"lists of triggers and website timers"
+// @Success		200	{object}	apps.APIResponse{message=triggers.triggerOutput}	"lists of triggers and website timers"
 // @Failure		404	{object}	string												"bad token or api key"
 // @Router			/triggers [get]
 // @Security		ApiKeyAuth
@@ -186,7 +186,7 @@ func (a *Actions) runTrigger(req *http.Request, input *common.ActionInput, trigg
 // @Tags			Triggers
 // @Produce		json
 // @Param			idx	path		int									true	"ID of the custom website timer to trigger"
-// @Success		200	{object}	apps.ApiResponse{message=string}	"success: name of timer"
+// @Success		200	{object}	apps.APIResponse{message=string}	"success: name of timer"
 // @Failure		400	{object}	string								"invalid timer ID"
 // @Failure		404	{object}	string								"bad token or api key"
 // @Router			/trigger/custom/{idx} [get]
@@ -210,7 +210,7 @@ func (a *Actions) customTimer(input *common.ActionInput, content string) (int, s
 // @Tags			Triggers
 // @Produce		json
 // @Param			enabled	path		bool								true	"Enable or disable client error log sharing."
-// @Success		200		{object}	apps.ApiResponse{message=string}	"success"
+// @Success		200		{object}	apps.APIResponse{message=string}	"success"
 // @Failure		404		{object}	string								"bad token or api key"
 // @Router			/trigger/clientlogs/{enabled} [get]
 // @Security		ApiKeyAuth
@@ -232,8 +232,8 @@ func (a *Actions) clientLogs(content string) (int, string) {
 // @Param			hash	path		bool		true	"Unique hash for command being executed"
 // @Param			args	formData	[]string	true	"provide args as multiple 'args' parameters in POST body"	collectionFormat(multi)	example(args=/tmp&args=/var)
 // @Accept			application/x-www-form-urlencoded
-// @Success		200	{object}	apps.ApiResponse{message=string}	"success"
-// @Failure		400	{object}	apps.ApiResponse{message=string}	"bad or missing hash"
+// @Success		200	{object}	apps.APIResponse{message=string}	"success"
+// @Failure		400	{object}	apps.APIResponse{message=string}	"bad or missing hash"
 // @Failure		404	{object}	string								"bad token or api key"
 // @Router			/trigger/command/{hash} [post]
 // @Security		ApiKeyAuth
@@ -246,8 +246,8 @@ func _() {}
 // @Tags			Triggers
 // @Produce		json
 // @Param			hash	path		bool								true	"Unique hash for command being executed"
-// @Success		200		{object}	apps.ApiResponse{message=string}	"success"
-// @Failure		400		{object}	apps.ApiResponse{message=string}	"bad or missing hash"
+// @Success		200		{object}	apps.APIResponse{message=string}	"success"
+// @Failure		400		{object}	apps.APIResponse{message=string}	"bad or missing hash"
 // @Failure		404		{object}	string								"bad token or api key"
 // @Router			/trigger/command/{hash} [get]
 // @Security		ApiKeyAuth
@@ -267,8 +267,8 @@ func (a *Actions) command(input *common.ActionInput, content string) (int, strin
 // @Tags			Triggers
 // @Produce		json
 // @Param			name	path		bool								true	"Name or URL of endpoint being triggered"
-// @Success		200		{object}	apps.ApiResponse{message=string}	"success"
-// @Failure		400		{object}	apps.ApiResponse{message=string}	"bad or missing name"
+// @Success		200		{object}	apps.APIResponse{message=string}	"success"
+// @Failure		400		{object}	apps.APIResponse{message=string}	"bad or missing name"
 // @Failure		404		{object}	string								"bad token or api key"
 // @Router			/trigger/endpoint/{name} [get]
 // @Security		ApiKeyAuth
@@ -288,7 +288,7 @@ func (a *Actions) endpoint(input *common.ActionInput, content string) (int, stri
 // @Tags			Triggers,TRaSH
 // @Produce		json
 // @Param			instance	path		bool								false	"Triggers sync on this instance if provided, otherwise all instances"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"success"
+// @Success		200			{object}	apps.APIResponse{message=string}	"success"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/trigger/cfsync/{instance} [get]
 // @Security		ApiKeyAuth
@@ -311,7 +311,7 @@ func (a *Actions) cfsync(input *common.ActionInput, content string) (int, string
 // @Tags			Triggers,TRaSH
 // @Produce		json
 // @Param			instance	path		bool								false	"Triggers sync on this instance if provided, otherwise all instances"
-// @Success		200			{object}	apps.ApiResponse{message=string}	"success"
+// @Success		200			{object}	apps.APIResponse{message=string}	"success"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/trigger/rpsync/{instance} [get]
 // @Security		ApiKeyAuth
@@ -333,7 +333,7 @@ func (a *Actions) rpsync(input *common.ActionInput, content string) (int, string
 // @Summary		Run all service checks
 // @Tags			Triggers
 // @Produce		json
-// @Success		200	{object}	apps.ApiResponse{message=string}	"success"
+// @Success		200	{object}	apps.APIResponse{message=string}	"success"
 // @Failure		404	{object}	string								"bad token or api key"
 // @Router			/trigger/services [get]
 // @Security		ApiKeyAuth
@@ -346,8 +346,8 @@ func (a *Actions) services(input *common.ActionInput) (int, string) {
 // @Summary		Collect Plex Sessions
 // @Tags			Triggers
 // @Produce		json
-// @Success		200	{object}	apps.ApiResponse{message=string}	"success"
-// @Failure		501	{object}	apps.ApiResponse{message=string}	"plex is disabled"
+// @Success		200	{object}	apps.APIResponse{message=string}	"success"
+// @Failure		501	{object}	apps.APIResponse{message=string}	"plex is disabled"
 // @Failure		404	{object}	string								"bad token or api key"
 // @Router			/trigger/sessions [get]
 // @Security		ApiKeyAuth
@@ -365,7 +365,7 @@ func (a *Actions) sessions(input *common.ActionInput) (int, string) {
 // @Summary		Send a stuck items notification
 // @Tags			Triggers
 // @Produce		json
-// @Success		200	{object}	apps.ApiResponse{message=string}	"success"
+// @Success		200	{object}	apps.APIResponse{message=string}	"success"
 // @Failure		404	{object}	string								"bad token or api key"
 // @Router			/trigger/stuckitems [get]
 // @Security		ApiKeyAuth
@@ -378,7 +378,7 @@ func (a *Actions) stuckitems(input *common.ActionInput) (int, string) {
 // @Summary		Send a dashboard notification
 // @Tags			Triggers
 // @Produce		json
-// @Success		200	{object}	apps.ApiResponse{message=string}	"success"
+// @Success		200	{object}	apps.APIResponse{message=string}	"success"
 // @Failure		404	{object}	string								"bad token or api key"
 // @Router			/trigger/dashboard [get]
 // @Security		ApiKeyAuth
@@ -391,7 +391,7 @@ func (a *Actions) dashboard(input *common.ActionInput) (int, string) {
 // @Summary		Send a system snapshot notification
 // @Tags			Triggers
 // @Produce		json
-// @Success		200	{object}	apps.ApiResponse{message=string}	"success"
+// @Success		200	{object}	apps.APIResponse{message=string}	"success"
 // @Failure		404	{object}	string								"bad token or api key"
 // @Router			/trigger/snapshot [get]
 // @Security		ApiKeyAuth
@@ -404,7 +404,7 @@ func (a *Actions) snapshot(input *common.ActionInput) (int, string) {
 // @Summary		Send Collections Gaps Notification
 // @Tags			Triggers
 // @Produce		json
-// @Success		200	{object}	apps.ApiResponse{message=string}	"success"
+// @Success		200	{object}	apps.APIResponse{message=string}	"success"
 // @Failure		404	{object}	string								"bad token or api key"
 // @Router			/trigger/gaps [get]
 // @Security		ApiKeyAuth
@@ -418,8 +418,8 @@ func (a *Actions) gaps(input *common.ActionInput) (int, string) {
 // @Tags			Triggers
 // @Produce		json
 // @Param			app	path		string								true	"app type to check"	Enum(lidarr, prowlarr, radarr, readarr, sonarr)
-// @Success		200	{object}	apps.ApiResponse{message=string}	"success"
-// @Failure		400	{object}	apps.ApiResponse{message=string}	"missing app"
+// @Success		200	{object}	apps.APIResponse{message=string}	"success"
+// @Failure		400	{object}	apps.APIResponse{message=string}	"missing app"
 // @Failure		404	{object}	string								"bad token or api key"
 // @Router			/trigger/corrupt/{app} [get]
 // @Security		ApiKeyAuth
@@ -439,8 +439,8 @@ func (a *Actions) corrupt(input *common.ActionInput, content string) (int, strin
 // @Tags			Triggers
 // @Produce		json
 // @Param			app	path		string								true	"app type to check"	Enum(lidarr, prowlarr, radarr, readarr, sonarr)
-// @Success		200	{object}	apps.ApiResponse{message=string}	"success"
-// @Failure		400	{object}	apps.ApiResponse{message=string}	"missing app"
+// @Success		200	{object}	apps.APIResponse{message=string}	"success"
+// @Failure		400	{object}	apps.APIResponse{message=string}	"missing app"
 // @Failure		404	{object}	string								"bad token or api key"
 // @Router			/trigger/backup/{app} [get]
 // @Security		ApiKeyAuth
@@ -459,7 +459,7 @@ func (a *Actions) backup(input *common.ActionInput, content string) (int, string
 // @Summary		Reload Application
 // @Tags			Triggers
 // @Produce		json
-// @Success		200	{object}	apps.ApiResponse{message=string}	"success"
+// @Success		200	{object}	apps.APIResponse{message=string}	"success"
 // @Failure		404	{object}	string								"bad token or api key"
 // @Router			/trigger/reload [get]
 // @Security		ApiKeyAuth
@@ -480,8 +480,8 @@ func (a *Actions) handleConfigReload() (int, string) {
 // @Tags			Triggers
 // @Produce		json
 // @Param			content	path		string								true	"Data for the notification."
-// @Success		200		{object}	apps.ApiResponse{message=string}	"success"
-// @Failure		400		{object}	apps.ApiResponse{message=string}	"no content"
+// @Success		200		{object}	apps.APIResponse{message=string}	"success"
+// @Failure		400		{object}	apps.APIResponse{message=string}	"no content"
 // @Failure		404		{object}	string								"bad token or api key"
 // @Router			/trigger/notification/{content} [get]
 // @Security		ApiKeyAuth
@@ -501,8 +501,8 @@ func (a *Actions) notification(ctx context.Context, content string) (int, string
 // @Tags			Triggers,Plex
 // @Produce		json
 // @Param			libraryKeys	path		[]string							true	"List of library keys, comma separated."
-// @Success		200			{object}	apps.ApiResponse{message=string}	"started"
-// @Failure		501			{object}	apps.ApiResponse{message=string}	"plex not enabled"
+// @Success		200			{object}	apps.APIResponse{message=string}	"started"
+// @Failure		501			{object}	apps.APIResponse{message=string}	"plex not enabled"
 // @Failure		404			{object}	string								"bad token or api key"
 // @Router			/trigger/emptyplextrash/{libraryKeys} [get]
 // @Security		ApiKeyAuth
@@ -520,7 +520,7 @@ func (a *Actions) emptyplextrash(input *common.ActionInput, content string) (int
 // @Summary		Send Libraries for MDBList
 // @Tags			Triggers
 // @Produce		json
-// @Success		200	{object}	apps.ApiResponse{message=string}	"success"
+// @Success		200	{object}	apps.APIResponse{message=string}	"success"
 // @Failure		404	{object}	string								"bad token or api key"
 // @Router			/trigger/mdblist [get]
 // @Security		ApiKeyAuth
@@ -534,9 +534,9 @@ func (a *Actions) mdblist(input *common.ActionInput) (int, string) {
 // @Tags			Triggers
 // @Produce		json
 // @Param			file	path		string								true	"File to upload. Must be one of app, http, debug"
-// @Success		200		{object}	apps.ApiResponse{message=string}	"success"
-// @Failure		400		{object}	apps.ApiResponse{message=string}	"bad or missing file"
-// @Failure		424		{object}	apps.ApiResponse{message=string}	"log uploads disabled"
+// @Success		200		{object}	apps.APIResponse{message=string}	"success"
+// @Failure		400		{object}	apps.APIResponse{message=string}	"bad or missing file"
+// @Failure		424		{object}	apps.APIResponse{message=string}	"log uploads disabled"
 // @Failure		404		{object}	string								"bad token or api key"
 // @Router			/trigger/uploadlog/{file} [get]
 // @Security		ApiKeyAuth
@@ -557,7 +557,7 @@ func (a *Actions) uploadlog(input *common.ActionInput, file string) (int, string
 // @Summary		Reconfigure Actions
 // @Tags			Triggers
 // @Produce		json
-// @Success		200		{object}	apps.ApiResponse{message=string}	"success"
+// @Success		200		{object}	apps.APIResponse{message=string}	"success"
 // @Failure		404		{object}	string								"bad token or api key"
 // @Router			/trigger/reconfig [get]
 // @Security		ApiKeyAuth

--- a/pkg/website/clientinfo/handlers.go
+++ b/pkg/website/clientinfo/handlers.go
@@ -106,7 +106,7 @@ type AppStatuses struct {
 //	@Summary		Retrieve client info.
 //	@Tags			Client
 //	@Produce		json
-//	@Success		200	{object}	apps.ApiResponse{message=AppInfo}	"contains all info except appStatus"
+//	@Success		200	{object}	apps.APIResponse{message=AppInfo}	"contains all info except appStatus"
 //	@Failure		404	{object}	string								"bad token or api key"
 //	@Router			/info [get]
 //	@Security		ApiKeyAuth
@@ -122,7 +122,7 @@ func (c *Config) InfoHandler(r *http.Request) (int, any) {
 //	@Summary		Retrieve client info + starr/plex info.
 //	@Tags			Client
 //	@Produce		json
-//	@Success		200	{object}	apps.ApiResponse{message=AppInfo}	"contains app info included appStatus"
+//	@Success		200	{object}	apps.APIResponse{message=AppInfo}	"contains app info included appStatus"
 //	@Failure		404	{object}	string								"bad token or api key"
 //	@Router			/version [get]
 //	@Security		ApiKeyAuth
@@ -142,7 +142,7 @@ func (c *Config) VersionHandler(r *http.Request) (int, any) {
 //	@Produce		json
 //	@Param			app			path		string								true	"Application"	Enums(lidarr, prowlarr, radarr, readarr, sonarr, plex, tautulli)
 //	@Param			instance	path		int64								true	"Application instance (1-index)."
-//	@Success		200			{object}	apps.ApiResponse{message=AppInfo}	"contains app info included appStatus"
+//	@Success		200			{object}	apps.APIResponse{message=AppInfo}	"contains app info included appStatus"
 //	@Failure		404			{object}	string								"bad token or api key"
 //	@Router			/version/{app}/{instance} [get]
 //	@Security		ApiKeyAuth


### PR DESCRIPTION
## Summary
- Swagger comments still referenced `apps.ApiResponse` after modernize renamed the Go type to `APIResponse`, so `make generate` / swag failed with `cannot find type definition: apps.ApiResponse`.
- Update `@Success`/`@Failure` comments to `apps.APIResponse` and regenerate committed swagger JSON. `ApiKeyAuth` is left unchanged (security scheme name, not a Go type). No other swagger object types used leftover `Api`/`Url`/`Http`/`Id`/`Json` names.

Fixes CI: https://github.com/Notifiarr/notifiarr/actions/runs/32348475320/job/96362224348

## Test plan
- [ ] Confirm swagger generate succeeds (`go generate ./frontend` swag step / no `cannot find type definition: apps.ApiResponse`)
- [ ] Confirm Make Release Assets job gets past `make generate`


Made with [Cursor](https://cursor.com)