### PR TITLE
Keep Docker NFS bind mounts in snapshots

### DIFF
--- a/pkg/snapshot/diskusage.go
+++ b/pkg/snapshot/diskusage.go
@@ -25,37 +25,35 @@ func (s *Snapshot) getDisksUsage(ctx context.Context, run bool, allDrives bool) 
 	return errs
 }
 
-func GetDisksUsage(ctx context.Context, allDrives bool) (map[string]*Partition, []error) { //nolint:cyclop
-	var (
-		errs        []error
-		output      = make(map[string]*Partition)
-		getAllDisks = allDrives || mnd.IsDocker
-	)
+func GetDisksUsage(ctx context.Context, allDrives bool) (map[string]*Partition, []error) {
+	var errs []error
 
-	partitions, err := disk.PartitionsWithContext(ctx, getAllDisks)
+	// Docker and "all drives" must pass all=true: gopsutil otherwise omits nodev
+	// filesystems, which includes nfs/nfs4/cifs/fuse used by bind mounts and automounts.
+	partitions, err := disk.PartitionsWithContext(ctx, allDrives || mnd.IsDocker)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("unable to get partitions: %w", err))
 	}
 
+	return collectDiskUsage(partitions, func(mount string) (*disk.UsageStat, error) {
+		return disk.UsageWithContext(ctx, mount)
+	}), errs
+}
+
+func collectDiskUsage( //nolint:cyclop
+	partitions []disk.PartitionStat,
+	usageFor func(string) (*disk.UsageStat, error),
+) map[string]*Partition {
+	output := make(map[string]*Partition)
+
 	for idx := range partitions {
-		usage, err := disk.UsageWithContext(ctx, partitions[idx].Mountpoint)
-		if err != nil {
-			// errs = append(errs, fmt.Errorf("unable to get partition usage: %s: %w", partitions[idx].Mountpoint, err))
+		part := &partitions[idx]
+		if skipPartition(part) {
 			continue
 		}
 
-		// skip tmpfs volumes
-		if usage.Fstype == "tmpfs" ||
-			// skip read only volumes with no device.
-			(slices.Contains(partitions[idx].Opts, "ro") && slices.Contains(partitions[idx].Opts, "nodev")) ||
-			// skip hidden volumes on macos.
-			(mnd.IsDarwin && slices.Contains(partitions[idx].Opts, "nobrowse")) {
-			continue
-		}
-
-		if usage.Total == 0 ||
-			((mnd.IsDarwin || strings.HasSuffix(runtime.GOOS, "bsd")) &&
-				!strings.HasPrefix(partitions[idx].Device, "/dev/")) {
+		usage, err := usageFor(part.Mountpoint)
+		if err != nil || skipUsage(part, usage) {
 			continue
 		}
 
@@ -63,19 +61,120 @@ func GetDisksUsage(ctx context.Context, allDrives bool) (map[string]*Partition, 
 			usage.Used = usage.Total - usage.Free
 		}
 
-		output[partitions[idx].Device] = &Partition{
-			Device:     partitions[idx].Mountpoint,
-			DevicePath: partitions[idx].Device,
+		fstype := usage.Fstype
+		if fstype == "" {
+			fstype = part.Fstype
+		}
+
+		next := &Partition{
+			Device:     part.Mountpoint,
+			DevicePath: part.Device,
 			Total:      usage.Total,
 			Free:       usage.Free,
 			Used:       usage.Used,
-			FSType:     usage.Fstype,
-			ReadOnly:   slices.Contains(partitions[idx].Opts, "ro"),
-			Opts:       partitions[idx].Opts,
+			FSType:     fstype,
+			ReadOnly:   slices.Contains(part.Opts, "ro"),
+			Opts:       part.Opts,
 		}
+
+		key := diskUsageKey(part)
+		if existing, ok := output[key]; ok && mountScore(existing.Device) >= mountScore(next.Device) {
+			continue
+		}
+
+		output[key] = next
 	}
 
-	return output, errs
+	return output
+}
+
+// virtualFSTypes are kernel/synthetic filesystems, not user storage.
+// Match partition fstype from mountinfo; usage.Fstype comes from statfs and
+// can follow a triggered automount (autofs → nfs) or the backing overlay.
+var virtualFSTypes = map[string]struct{}{
+	"autofs": {}, "binfmt_misc": {}, "bpf": {}, "cgroup": {}, "cgroup2": {},
+	"configfs": {}, "debugfs": {}, "devpts": {}, "devtmpfs": {}, "efivarfs": {},
+	"fusectl": {}, "hugetlbfs": {}, "mqueue": {}, "nsfs": {}, "proc": {},
+	"pstore": {}, "ramfs": {}, "rpc_pipefs": {}, "securityfs": {}, "shm": {},
+	"squashfs": {}, "sysfs": {}, "tmpfs": {}, "tracefs": {},
+}
+
+func skipPartition(part *disk.PartitionStat) bool {
+	if isVirtualFS(part.Fstype) || isVirtualFS(part.Device) ||
+		strings.HasPrefix(part.Device, "systemd-") || isJunkMount(part.Mountpoint) {
+		return true
+	}
+
+	if mnd.IsDarwin && slices.Contains(part.Opts, "nobrowse") {
+		return true
+	}
+
+	return false
+}
+
+func skipUsage(part *disk.PartitionStat, usage *disk.UsageStat) bool {
+	if usage == nil || usage.Total == 0 {
+		return true
+	}
+
+	if part.Fstype == "" && isVirtualFS(usage.Fstype) {
+		return true
+	}
+
+	// Keep NFS/CIFS/etc. Darwin/BSD still hide other non-device mounts.
+	if (mnd.IsDarwin || strings.HasSuffix(runtime.GOOS, "bsd")) &&
+		!strings.HasPrefix(part.Device, "/dev/") && !isNetworkDevice(part.Device) {
+		return true
+	}
+
+	return false
+}
+
+func isVirtualFS(fstype string) bool {
+	_, ok := virtualFSTypes[strings.ToLower(fstype)]
+	return ok
+}
+
+func isNetworkDevice(device string) bool {
+	return strings.Contains(device, ":/") || strings.HasPrefix(device, "//")
+}
+
+func isJunkMount(mount string) bool {
+	switch mount {
+	case "/etc/resolv.conf", "/etc/hostname", "/etc/hosts", "/etc/mtab":
+		return true
+	}
+
+	return strings.HasPrefix(mount, "/proc") ||
+		strings.HasPrefix(mount, "/sys") ||
+		strings.HasPrefix(mount, "/dev/") ||
+		strings.HasPrefix(mount, "/run/")
+}
+
+func diskUsageKey(part *disk.PartitionStat) string {
+	if isNetworkDevice(part.Device) {
+		return part.Mountpoint
+	}
+
+	return part.Device
+}
+
+const (
+	mountScoreRoot     = 100
+	mountScoreBoot     = 20
+	mountScoreDefault  = 80
+	maxMountLenPenalty = 40
+)
+
+func mountScore(mount string) int {
+	switch {
+	case mount == "/" || (len(mount) == 2 && mount[1] == ':'):
+		return mountScoreRoot
+	case strings.HasPrefix(mount, "/boot"):
+		return mountScoreBoot
+	default:
+		return mountScoreDefault - min(len(mount), maxMountLenPenalty)
+	}
 }
 
 func (s *Snapshot) getQuota(ctx context.Context, run bool) error {

--- a/pkg/snapshot/diskusage.go
+++ b/pkg/snapshot/diskusage.go
@@ -145,6 +145,10 @@ func isJunkMount(mount string) bool {
 		return true
 	}
 
+	if strings.HasPrefix(mount, "/run/media/") || mount == "/run/media" {
+		return false
+	}
+
 	return strings.HasPrefix(mount, "/proc") ||
 		strings.HasPrefix(mount, "/sys") ||
 		strings.HasPrefix(mount, "/dev/") ||

--- a/pkg/snapshot/diskusage_test.go
+++ b/pkg/snapshot/diskusage_test.go
@@ -139,6 +139,14 @@ func TestIsNetworkDevice(t *testing.T) {
 	assert.False(t, isNetworkDevice("systemd-1"))
 }
 
+func TestIsJunkMountKeepsRemovableMedia(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, isJunkMount("/run/media/user/USB"))
+	assert.True(t, isJunkMount("/run/docker.sock"))
+	assert.True(t, isJunkMount("/etc/hosts"))
+}
+
 func TestSkipPartitionDoesNotTreatNodevAsNoDevice(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/snapshot/diskusage_test.go
+++ b/pkg/snapshot/diskusage_test.go
@@ -1,0 +1,163 @@
+package snapshot //nolint:testpackage
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/shirou/gopsutil/v4/disk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errUsageMissing = errors.New("usage missing")
+
+func TestCollectDiskUsageKeepsReadOnlyNFSBinds(t *testing.T) {
+	t.Parallel()
+
+	// Docker `:ro` bind mounts of NFS (and systemd automounts) commonly have
+	// both `ro` and `nodev`. `nodev` is a security flag, not "no device".
+	got := collectDiskUsage([]disk.PartitionStat{
+		{
+			Device: "/dev/mapper/ubuntu--vg-ubuntu--lv", Mountpoint: "/", Fstype: "ext4",
+			Opts: []string{"rw", "relatime"},
+		},
+		{
+			Device: "192.168.50.206:/mnt/array1/Movies", Mountpoint: "/buffalo01", Fstype: "nfs4",
+			Opts: []string{"ro", "relatime", "nosuid", "nodev"},
+		},
+		{
+			Device: "192.168.50.205:/nfs/server_mnt", Mountpoint: "/lenovo01", Fstype: "nfs4",
+			Opts: []string{"ro", "relatime", "nosuid", "nodev"},
+		},
+	}, usageMap{
+		"/":          {Fstype: "ext4", Total: 913_000_000_000, Free: 841_000_000_000, Used: 34_000_000_000},
+		"/buffalo01": {Fstype: "nfs4", Total: 8_100_000_000_000, Free: 2_600_000_000_000, Used: 5_500_000_000_000},
+		"/lenovo01":  {Fstype: "nfs4", Total: 8_000_000_000_000, Free: 8_000_000_000_000, Used: 4_900_000_000},
+	}.get)
+
+	require.Len(t, got, 3)
+	assert.Equal(t, "/", got["/dev/mapper/ubuntu--vg-ubuntu--lv"].Device)
+	assert.Equal(t, "/buffalo01", got["/buffalo01"].Device)
+	assert.Equal(t, "192.168.50.206:/mnt/array1/Movies", got["/buffalo01"].DevicePath)
+	assert.Equal(t, "/lenovo01", got["/lenovo01"].Device)
+	assert.True(t, got["/buffalo01"].ReadOnly)
+	assert.True(t, got["/lenovo01"].ReadOnly)
+}
+
+func TestCollectDiskUsageDropsSystemdAutofsDuplicates(t *testing.T) {
+	t.Parallel()
+
+	got := collectDiskUsage([]disk.PartitionStat{
+		{
+			Device: "systemd-1", Mountpoint: "/mnt/buffalo01", Fstype: "autofs",
+			Opts: []string{"rw", "relatime"},
+		},
+		{
+			Device: "192.168.50.206:/mnt/array1/Movies", Mountpoint: "/mnt/buffalo01", Fstype: "nfs4",
+			Opts: []string{"rw", "relatime"},
+		},
+		{
+			Device: "systemd-1", Mountpoint: "/mnt/lenovo01", Fstype: "autofs",
+			Opts: []string{"rw", "relatime"},
+		},
+		{
+			Device: "192.168.50.205:/nfs/server_mnt", Mountpoint: "/mnt/lenovo01", Fstype: "nfs4",
+			Opts: []string{"rw", "relatime"},
+		},
+	}, usageMap{
+		"/mnt/buffalo01": {Fstype: "nfs4", Total: 8_100_000_000_000, Free: 2_600_000_000_000, Used: 5_500_000_000_000},
+		"/mnt/lenovo01":  {Fstype: "nfs4", Total: 8_000_000_000_000, Free: 8_000_000_000_000, Used: 4_900_000_000},
+	}.get)
+
+	require.Len(t, got, 2)
+	assert.Equal(t, "192.168.50.206:/mnt/array1/Movies", got["/mnt/buffalo01"].DevicePath)
+	assert.Equal(t, "192.168.50.205:/nfs/server_mnt", got["/mnt/lenovo01"].DevicePath)
+
+	for _, part := range got {
+		assert.NotEqual(t, "autofs", part.FSType)
+		assert.False(t, strings.HasPrefix(part.DevicePath, "systemd-"))
+	}
+}
+
+func TestCollectDiskUsageSkipsTmpfsEvenWhenUsageLooksLikeOverlay(t *testing.T) {
+	t.Parallel()
+
+	got := collectDiskUsage([]disk.PartitionStat{
+		{
+			Device: "/dev/mapper/ubuntu--vg-ubuntu--lv", Mountpoint: "/", Fstype: "ext4",
+			Opts: []string{"rw", "relatime"},
+		},
+		{
+			Device: "tmpfs", Mountpoint: "/tmp", Fstype: "tmpfs",
+			Opts: []string{"rw", "nosuid", "nodev"},
+		},
+	}, usageMap{
+		"/":    {Fstype: "ext4", Total: 913_000_000_000, Free: 841_000_000_000, Used: 34_000_000_000},
+		"/tmp": {Fstype: "overlay", Total: 913_000_000_000, Free: 841_000_000_000, Used: 34_000_000_000},
+	}.get)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "/", got["/dev/mapper/ubuntu--vg-ubuntu--lv"].Device)
+}
+
+func TestCollectDiskUsagePrefersVolumeMountOverDockerMetadata(t *testing.T) {
+	t.Parallel()
+
+	mapper := "/dev/mapper/ubuntu--vg-ubuntu--lv"
+	got := collectDiskUsage([]disk.PartitionStat{
+		{
+			Device: mapper, Mountpoint: "/etc/hosts", Fstype: "ext4",
+			Opts: []string{"rw", "relatime", "bind"},
+		},
+		{
+			Device: mapper, Mountpoint: "/config", Fstype: "ext4",
+			Opts: []string{"rw", "relatime", "bind"},
+		},
+		{
+			Device: mapper, Mountpoint: "/logs", Fstype: "ext4",
+			Opts: []string{"rw", "relatime", "bind"},
+		},
+	}, usageMap{
+		"/etc/hosts": {Fstype: "ext4", Total: 913_000_000_000, Free: 841_000_000_000, Used: 34_000_000_000},
+		"/config":    {Fstype: "ext4", Total: 913_000_000_000, Free: 841_000_000_000, Used: 34_000_000_000},
+		"/logs":      {Fstype: "ext4", Total: 913_000_000_000, Free: 841_000_000_000, Used: 34_000_000_000},
+	}.get)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "/logs", got[mapper].Device)
+	assert.Equal(t, mapper, got[mapper].DevicePath)
+}
+
+func TestIsNetworkDevice(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isNetworkDevice("192.168.50.205:/nfs/server_mnt"))
+	assert.True(t, isNetworkDevice("//nas.lan/share"))
+	assert.False(t, isNetworkDevice("/dev/sda1"))
+	assert.False(t, isNetworkDevice("overlay"))
+	assert.False(t, isNetworkDevice("systemd-1"))
+}
+
+func TestSkipPartitionDoesNotTreatNodevAsNoDevice(t *testing.T) {
+	t.Parallel()
+
+	part := disk.PartitionStat{
+		Device:     "192.168.50.205:/nfs/server_mnt",
+		Mountpoint: "/lenovo01",
+		Fstype:     "nfs4",
+		Opts:       []string{"ro", "nodev", "nosuid"},
+	}
+	assert.False(t, skipPartition(&part))
+}
+
+type usageMap map[string]*disk.UsageStat
+
+func (u usageMap) get(mount string) (*disk.UsageStat, error) {
+	stat, ok := u[mount]
+	if !ok {
+		return nil, errUsageMissing
+	}
+
+	return stat, nil
+}


### PR DESCRIPTION
## Summary
- Fixes Docker NFS (and other `:ro` bind) mounts missing from snapshots and the Storage UI. Fixes #1260.
- Stops treating the `nodev` mount option as "no device" — that flag is a security option, and Docker adds it to read-only binds, which dropped every NFS share.
- Skips systemd `autofs` (`systemd-1`) before calling `statfs`, keys network filesystems by mountpoint so two shares no longer collapse, and ignores Docker metadata binds like `/etc/hosts`.
- After Copilot review: keep udisks removable drives at `/run/media` instead of treating all of `/run/` as junk.

## Test plan
- [ ] `go test ./pkg/snapshot/`
- [ ] In a Docker client with `:ro` NFS (or systemd automount) binds, confirm both shares appear on System → Storage and in a snapshot
- [ ] Confirm `systemd-1` / autofs duplicates are gone
- [ ] Confirm `/tmp` tmpfs does not inherit the overlay/root size
- [ ] Confirm `/etc/hosts` (and similar Docker file binds) are not listed as disks
- [ ] Confirm a USB/removable disk mounted at `/run/media/...` still appears