### PR TITLE
Fix UI freeze when deleting the last app instance

### DIFF
--- a/frontend/src/includes/CheckedInput.svelte
+++ b/frontend/src/includes/CheckedInput.svelte
@@ -47,6 +47,7 @@
 
   const checkInstance = async (e: Event) => {
     e.preventDefault()
+    if (!form) return
     body = ''
     testing = true
 
@@ -75,8 +76,8 @@
     outline
     title="Validate SSL certificate"
     color="notifiarr"
-    class={form['validSsl'] !== original['validSsl'] ? 'changed' : ''}
-    onclick={() => (form['validSsl'] = !form['validSsl'])}>
+    class={form?.['validSsl'] !== original?.['validSsl'] ? 'changed' : ''}
+    onclick={() => form && (form['validSsl'] = !form['validSsl'])}>
     <Box type="checkbox" bind:checked={form['validSsl']} />
   </Button>
 {/snippet}
@@ -88,77 +89,79 @@
     outline
     title="Run as shell command"
     color="notifiarr"
-    class={form['shell'] !== original['shell'] ? 'changed' : ''}
-    onclick={() => (form['shell'] = !form['shell'])}>
+    class={form?.['shell'] !== original?.['shell'] ? 'changed' : ''}
+    onclick={() => form && (form['shell'] = !form['shell'])}>
     <Box type="checkbox" bind:checked={form['shell']} />
   </Button>
 {/snippet}
 
-<div class="checked-input">
-  <Input
-    id={app.id + '.' + id.toString()}
-    bind:value={form[id]}
-    original={original?.[id] ?? undefined}
-    disabled={app.disabled?.includes(id.toString())}
-    description={id === 'url' && form[id]?.toString()?.startsWith('https://')
-      ? get(_)('words.instance-options.validSsl.description')
-      : rest.description}
-    {envVar}
-    {...rest}>
-    <!-- This is a "checked" input, so add a check button for the instance. -->
-    {#snippet pre()}
-      <Button
-        style="width:44px;"
-        type="button"
-        outline
-        title="Check instance"
-        color="notifiarr"
-        disabled={testing || disabled}
-        onclick={checkInstance}>
-        {#if testing}
-          <Fa i={faSpinner} c1="orange" spin scale={1.5} />
-        {:else}
-          <Fa
-            i={faCheckDouble}
-            c1={disabled ? 'lightgrey' : 'green'}
-            c2={disabled ? 'darkgrey' : 'darkcyan'}
-            d1={disabled ? 'darkgrey' : 'limegreen'}
-            d2={disabled ? 'lightgrey' : 'cyan'}
-            scale={1.5} />
-        {/if}
-      </Button>
-    {/snippet}
-
-    <!-- If they type in an https:// url, add a checkbox to validate the SSL certificate. -->
-    {#snippet post()}
-      {#if id === 'url' && form[id]?.startsWith('https://')}
-        {@render validSsl()}
-      {:else if id === 'command'}
-        {@render shell()}
-      {/if}
-    {/snippet}
-
-    <!-- Feedback message is only used when the test/check button is clicked. -->
-    {#snippet msg()}
-      {#if body}
-        <div transition:slide>
-          <Alert
-            fade={false}
-            isOpen
-            toggle={() => (body = '')}
-            color={ok ? 'success' : 'danger'}>
+{#if form}
+  <div class="checked-input">
+    <Input
+      id={app.id + '.' + id.toString()}
+      bind:value={form[id]}
+      original={original?.[id] ?? undefined}
+      disabled={app.disabled?.includes(id.toString())}
+      description={id === 'url' && form[id]?.toString()?.startsWith('https://')
+        ? get(_)('words.instance-options.validSsl.description')
+        : rest.description}
+      {envVar}
+      {...rest}>
+      <!-- This is a "checked" input, so add a check button for the instance. -->
+      {#snippet pre()}
+        <Button
+          style="width:44px;"
+          type="button"
+          outline
+          title="Check instance"
+          color="notifiarr"
+          disabled={testing || disabled}
+          onclick={checkInstance}>
+          {#if testing}
+            <Fa i={faSpinner} c1="orange" spin scale={1.5} />
+          {:else}
             <Fa
-              scale={1.5}
-              i={ok ? faCircleCheck : faCircleXmark}
-              c1={ok ? 'green' : 'firebrick'}
-              c2="white"
-              d2="black" /> &nbsp; {@html maxLength(body, 200)}
-          </Alert>
-        </div>
-      {/if}
-    {/snippet}
-  </Input>
-</div>
+              i={faCheckDouble}
+              c1={disabled ? 'lightgrey' : 'green'}
+              c2={disabled ? 'darkgrey' : 'darkcyan'}
+              d1={disabled ? 'darkgrey' : 'limegreen'}
+              d2={disabled ? 'lightgrey' : 'cyan'}
+              scale={1.5} />
+          {/if}
+        </Button>
+      {/snippet}
+
+      <!-- If they type in an https:// url, add a checkbox to validate the SSL certificate. -->
+      {#snippet post()}
+        {#if id === 'url' && form[id]?.startsWith('https://')}
+          {@render validSsl()}
+        {:else if id === 'command'}
+          {@render shell()}
+        {/if}
+      {/snippet}
+
+      <!-- Feedback message is only used when the test/check button is clicked. -->
+      {#snippet msg()}
+        {#if body}
+          <div transition:slide>
+            <Alert
+              fade={false}
+              isOpen
+              toggle={() => (body = '')}
+              color={ok ? 'success' : 'danger'}>
+              <Fa
+                scale={1.5}
+                i={ok ? faCircleCheck : faCircleXmark}
+                c1={ok ? 'green' : 'firebrick'}
+                c2="white"
+                d2="black" /> &nbsp; {@html maxLength(body, 200)}
+            </Alert>
+          </div>
+        {/if}
+      {/snippet}
+    </Input>
+  </div>
+{/if}
 
 <style>
   .checked-input :global(.changed) {

--- a/frontend/src/includes/Instances.svelte
+++ b/frontend/src/includes/Instances.svelte
@@ -53,7 +53,7 @@
 {#if flt.instances.length > 0}
   <div class="instances" transition:slide>
     <Accordion class="mb-2">
-      {#each flt.instances as instance, index}
+      {#each flt.instances as instance, index (instance)}
         {@const changed = !deepEqual(instance, flt.original?.[index] ?? flt.app.empty)}
         <div class="accordion-item">
           <AccordionHeader
@@ -82,30 +82,35 @@
             <Card
               class="accordion-collapse {flt.active === index ? 'd-block' : 'd-none'}">
               <div class="accordion-body" transition:slide={{ duration: 350, axis: 'y' }}>
-                <Child
-                  bind:this={children[index]}
-                  bind:form={flt.instances[index]}
-                  original={flt.original?.[index] ?? flt.app.empty}
-                  app={flt.app}
-                  validate={(id, value) => flt.validate(id, value, index)}
-                  {index}
-                  active={flt.active === index} />
-                <Button
-                  color="danger"
-                  class="float-end"
-                  outline
-                  onclick={() => flt.delInstance(index)}>
-                  {$_(deleteButton)}
-                </Button>
-                <Button
-                  color="primary"
-                  class="float-end me-2"
-                  outline
-                  disabled={!changed}
-                  onclick={() => (flt.resetForm(index), children[index]?.reset?.())}>
-                  {$_('buttons.ResetForm')}
-                </Button>
-                <div style="clear: both;"></div>
+                <!-- Bind the live slot only while it is still this each item. After splice the
+                     outro keeps this block mounted, but flt.instances[index] is a different
+                     instance or undefined — which used to freeze the UI. -->
+                {#if flt.instances[index] === instance}
+                  <Child
+                    bind:this={children[index]}
+                    bind:form={flt.instances[index]}
+                    original={flt.original?.[index] ?? flt.app.empty}
+                    app={flt.app}
+                    validate={(id, value) => flt.validate(id, value, index)}
+                    {index}
+                    active={flt.active === index} />
+                  <Button
+                    color="danger"
+                    class="float-end"
+                    outline
+                    onclick={() => flt.delInstance(index)}>
+                    {$_(deleteButton)}
+                  </Button>
+                  <Button
+                    color="primary"
+                    class="float-end me-2"
+                    outline
+                    disabled={!changed}
+                    onclick={() => (flt.resetForm(index), children[index]?.reset?.())}>
+                    {$_('buttons.ResetForm')}
+                  </Button>
+                  <div style="clear: both;"></div>
+                {/if}
               </div>
             </Card>
           {/key}

--- a/frontend/src/includes/InstancesTab.svelte
+++ b/frontend/src/includes/InstancesTab.svelte
@@ -45,7 +45,7 @@
       </h5>
     </div>
 
-    {#if one}
+    {#if one && flt.instances[0]}
       <InstanceHeader {flt} />
       <Instance
         index={0}
@@ -53,7 +53,7 @@
         bind:form={flt.instances[0]}
         original={flt.original[0]}
         app={flt.app} />
-    {:else}
+    {:else if !one}
       <Instances bind:flt Child={Instance}>
         {#snippet headerActive(index)}
           {index + 1}. {flt.original[index]?.name}

--- a/frontend/src/includes/formsTracker.svelte.ts
+++ b/frontend/src/includes/formsTracker.svelte.ts
@@ -81,10 +81,12 @@ export class FormListTracker<T> {
     this.instances = $state(deepCopy(instances ?? []))
     this.original = $state(deepCopy(instances ?? []))
     this.app = app
-    this.formChanged = $derived(!deepEqual(this.instances, this.original))
     this.feedback = $state({})
     this.removed = $state([])
     this.active = $state(0)
+    this.formChanged = $derived(
+      this.removed.length > 0 || !deepEqual(this.instances, this.original),
+    )
     this.invalid = $derived(
       Object.values(this.feedback).some(v => Object.values(v).some(v => !!v)),
     )
@@ -92,7 +94,8 @@ export class FormListTracker<T> {
 
   /** Add a new instance to the list. */
   public addInstance = () => {
-    this.instances.push(this.app.empty!)
+    // Copy the empty template so each new instance is its own object.
+    this.instances.push(deepCopy(this.app.empty!))
     this.active = this.instances.length - 1
   }
 
@@ -110,7 +113,11 @@ export class FormListTracker<T> {
       this.removed.push(index)
     // Reset the feedback for the instance.
     this.feedback = {}
-    this.active = 0
+    // Re-open a remaining instance. Never select index 0 on an empty list:
+    // {#key flt.active} would remount children bound to undefined form and freeze the UI.
+    this.active = this.instances.length
+      ? Math.min(index, this.instances.length - 1)
+      : undefined
   }
 
   /** Reset the form to the original values. Call this after a form has been submitted. */

--- a/frontend/src/includes/instanceValidator.ts
+++ b/frontend/src/includes/instanceValidator.ts
@@ -27,14 +27,16 @@ export const validate = (
     })
     return value ? found : get(_)('phrases.NameMustNotBeEmpty')
   } else if (key == 'url') {
-    return value.startsWith('http://') || value.startsWith('https://')
+    // value is undefined while a deleted instance accordion is still outroing.
+    return typeof value === 'string' &&
+      (value.startsWith('http://') || value.startsWith('https://'))
       ? ''
       : get(_)('phrases.URLMustBeginWithHttp')
   } else if (key == 'host' && value === '') {
     return get(_)('phrases.HostMustNotBeEmpty')
-  } else if (key == 'apiKey' && value.length < 32) {
+  } else if (key == 'apiKey' && (value?.length ?? 0) < 32) {
     return get(_)('phrases.APIKeyMustBeCountCharactersOrLonger', { values: { count: 32 } })
-  } else if (key == 'token' && value.length < 8) {
+  } else if (key == 'token' && (value?.length ?? 0) < 8) {
     return get(_)('phrases.TokenMustBeCountCharacters', { values: { count: 8 } })
   }
 

--- a/frontend/src/pages/commands/Command.svelte
+++ b/frontend/src/pages/commands/Command.svelte
@@ -30,12 +30,12 @@
   /** If a command finishes quickly this updates its output after execution. */
   const refreshStats = async () => (await delay(1000), output?.getStats())
   // These are used to pass custom arguments into a command through a modal form.
-  let runArgs = $state(form.argValues?.map(arg => '') ?? [])
+  let runArgs = $state(form?.argValues?.map(arg => '') ?? [])
   let formResolve: (() => void) | null = $state(null)
   let formReject: (() => void) | null = $state(null)
   /** Passed into Instances as a callback to get command arguments. */
   const getCommandArgs = async (): Promise<URLSearchParams> => {
-    if (form.args === 0) {
+    if (!form || form.args === 0) {
       refreshStats() // do not await this.
       return new URLSearchParams()
     }
@@ -46,12 +46,13 @@
 
   $effect(() => {
     // Reset the args when the form values change.
-    if (active) runArgs = form.argValues?.map(a => '') ?? []
+    // form can be undefined while a deleted instance accordion is outroing.
+    if (active && form) runArgs = form.argValues?.map(a => '') ?? []
   })
 
   /** Checks the argValues (regex) against the given argument. */
   const checkRegex = (arg: string, i: number) => {
-    let re = form.argValues?.[i] ?? ''
+    let re = form?.argValues?.[i] ?? ''
     if (!re.startsWith('^')) re = '^(' + re + ')$'
     return !!arg.match(new RegExp(re))
   }
@@ -64,106 +65,108 @@
   }
 </script>
 
-<div class="command">
-  <Row>
-    <Col sm={7}>
-      <Input
-        id={app.id + '.name'}
-        envVar={`${app.envPrefix}_${index}_NAME`}
-        bind:value={form.name}
-        original={original?.name}
-        {validate} />
-    </Col>
-    <Col sm={5}>
-      <Input
-        type="select"
-        id={app.id + '.notify'}
-        envVar={`${app.envPrefix}_${index}_NOTIFY`}
-        bind:value={form.notify}
-        original={original?.notify}
-        {validate} />
-    </Col>
-    <Col md={12}>
-      <CheckedInput
-        id="command"
-        envVar={`${app.envPrefix}_${index}_COMMAND`}
-        params={getCommandArgs}
-        {app}
-        {index}
-        bind:form
-        bind:original
-        {validate}
-        disabled={form.command !== original?.command ||
-          form.command == '' ||
-          form.shell != original?.shell} />
-    </Col>
-    <Col sm={6}>
-      <Input
-        type="select"
-        id={app.id + '.log'}
-        envVar={`${app.envPrefix}_${index}_LOG`}
-        bind:value={form.log}
-        original={original?.log}
-        {validate} />
-    </Col>
-    <Col sm={6}>
-      <Input
-        type="timeout"
-        id={app.id + '.timeout'}
-        envVar={`${app.envPrefix}_${index}_TIMEOUT`}
-        bind:value={form.timeout}
-        original={original?.timeout}
-        noDisable
-        {validate} />
-    </Col>
-  </Row>
+{#if form}
+  <div class="command">
+    <Row>
+      <Col sm={7}>
+        <Input
+          id={app.id + '.name'}
+          envVar={`${app.envPrefix}_${index}_NAME`}
+          bind:value={form.name}
+          original={original?.name}
+          {validate} />
+      </Col>
+      <Col sm={5}>
+        <Input
+          type="select"
+          id={app.id + '.notify'}
+          envVar={`${app.envPrefix}_${index}_NOTIFY`}
+          bind:value={form.notify}
+          original={original?.notify}
+          {validate} />
+      </Col>
+      <Col md={12}>
+        <CheckedInput
+          id="command"
+          envVar={`${app.envPrefix}_${index}_COMMAND`}
+          params={getCommandArgs}
+          {app}
+          {index}
+          bind:form
+          bind:original
+          {validate}
+          disabled={form.command !== original?.command ||
+            form.command == '' ||
+            form.shell != original?.shell} />
+      </Col>
+      <Col sm={6}>
+        <Input
+          type="select"
+          id={app.id + '.log'}
+          envVar={`${app.envPrefix}_${index}_LOG`}
+          bind:value={form.log}
+          original={original?.log}
+          {validate} />
+      </Col>
+      <Col sm={6}>
+        <Input
+          type="timeout"
+          id={app.id + '.timeout'}
+          envVar={`${app.envPrefix}_${index}_TIMEOUT`}
+          bind:value={form.timeout}
+          original={original?.timeout}
+          noDisable
+          {validate} />
+      </Col>
+    </Row>
 
-  <!-- Show output component here. -->
-  <Output {form} {index} {active} bind:this={output} />
-</div>
+    <!-- Show output component here. -->
+    <Output {form} {index} {active} bind:this={output} />
+  </div>
 
-<!-- Modal is used to run commands that have custom arguments (regexes). -->
-<Nodal
-  follow={cancel}
-  isOpen={formResolve != null}
-  size="lg"
-  centered
-  title="Commands.enterCommandArguments"
-  esc>
-  <p class="text-muted">
-    <T id="Commands.commandRequiresArguments" count={form.args} />
-  </p>
-  <p><b class="text-primary font-monospace">{form.command}</b></p>
-  {#each form.argValues ?? [] as arg, i}
-    <FormGroup floating>
-      <div slot="label">
-        <Badge>{i + 1}</Badge> &nbsp; <b class="text-primary font-monospace">{arg}</b>
-      </div>
-      <Box
-        tabindex={i + 1}
-        bind:value={runArgs[i]}
-        invalid={!checkRegex(runArgs[i], i)}
-        feedback={$_('Commands.regexMismatch')} />
-    </FormGroup>
-  {/each}
-  {#snippet footer()}
-    <Button
-      outline
-      type="button"
-      color="warning"
-      onclick={cancel}
-      tabindex={form.args + 3}>
-      <T id="buttons.Cancel" /></Button>
-    <Button
-      type="submit"
-      color="notifiarr"
-      disabled={!runArgs.every(checkRegex)}
-      tabindex={form.args + 2}
-      onclick={e => {
-        e.preventDefault()
-        formResolve?.()
-        formResolve = null
-      }}>
-      <T id="buttons.Execute" /></Button>
-  {/snippet}
-</Nodal>
+  <!-- Modal is used to run commands that have custom arguments (regexes). -->
+  <Nodal
+    follow={cancel}
+    isOpen={formResolve != null}
+    size="lg"
+    centered
+    title="Commands.enterCommandArguments"
+    esc>
+    <p class="text-muted">
+      <T id="Commands.commandRequiresArguments" count={form.args} />
+    </p>
+    <p><b class="text-primary font-monospace">{form.command}</b></p>
+    {#each form.argValues ?? [] as arg, i}
+      <FormGroup floating>
+        <div slot="label">
+          <Badge>{i + 1}</Badge> &nbsp; <b class="text-primary font-monospace">{arg}</b>
+        </div>
+        <Box
+          tabindex={i + 1}
+          bind:value={runArgs[i]}
+          invalid={!checkRegex(runArgs[i], i)}
+          feedback={$_('Commands.regexMismatch')} />
+      </FormGroup>
+    {/each}
+    {#snippet footer()}
+      <Button
+        outline
+        type="button"
+        color="warning"
+        onclick={cancel}
+        tabindex={form.args + 3}>
+        <T id="buttons.Cancel" /></Button>
+      <Button
+        type="submit"
+        color="notifiarr"
+        disabled={!runArgs.every(checkRegex)}
+        tabindex={form.args + 2}
+        onclick={e => {
+          e.preventDefault()
+          formResolve?.()
+          formResolve = null
+        }}>
+        <T id="buttons.Execute" /></Button>
+    {/snippet}
+  </Nodal>
+{/if}

--- a/frontend/src/pages/commands/Output.svelte
+++ b/frontend/src/pages/commands/Output.svelte
@@ -37,7 +37,7 @@
   /** Retrieve the command output and update the last refreshed time. */
   export const getStats = async (e?: Event) => {
     e?.preventDefault()
-    if (!form.hash) return
+    if (!form?.hash) return
     const res = await getUi('ajax/cmdstats/' + form.hash)
     if (!res.ok) failure('Failure getting command output. ' + res.body)
     else output = res.body as Stats
@@ -46,7 +46,7 @@
 
   $effect(() => {
     // The delay prevents an error when saving the page.
-    if (active) delay(50).then(() => getStats())
+    if (active && form) delay(50).then(() => getStats())
   })
 
   $effect(() => {

--- a/frontend/src/pages/endpoints/Endpoint.svelte
+++ b/frontend/src/pages/endpoints/Endpoint.svelte
@@ -17,14 +17,14 @@
   }: ChildProps<Endpoint> = $props()
 
   let originalQuery = $derived.by(() =>
-    Object.entries(original.query ?? {})
+    Object.entries(original?.query ?? {})
       .filter(([_, value]) => value !== null)
       .map(([key, value]) => value?.map(v => `${key}=${v}`).join('\n') ?? '')
       .join('\n'),
   )
 
   let originalHeader = $derived.by(() =>
-    Object.entries(original.header ?? {})
+    Object.entries(original?.header ?? {})
       .filter(([_, value]) => value !== null)
       .map(([key, value]) => value?.map(v => `${key}: ${v}`).join('\n') ?? '')
       .join('\n'),
@@ -32,14 +32,14 @@
 
   // These are the form-binded values
   let query = $state<string>(
-    Object.entries(form.query ?? {})
+    Object.entries(form?.query ?? {})
       .filter(([_, value]) => value !== null)
       .map(([key, value]) => value?.map(v => `${key}=${v}`).join('\n') ?? '')
       .join('\n'),
   )
 
   let header = $state<string>(
-    Object.entries(form.header ?? {})
+    Object.entries(form?.header ?? {})
       .filter(([_, value]) => value !== null)
       .map(([key, value]) => value?.map(v => `${key}: ${v}`).join('\n') ?? '')
       .join('\n'),
@@ -50,12 +50,12 @@
   // This is called by Instances.svelte when the reset button is clicked.
   export const reset = () => {
     cronScheduler?.reset()
-    header = Object.entries(form.header ?? {})
+    header = Object.entries(form?.header ?? {})
       .filter(([_, value]) => value !== null)
       .map(([key, value]) => value?.map(v => `${key}: ${v}`).join('\n') ?? '')
       .join('\n')
 
-    query = Object.entries(form.query ?? {})
+    query = Object.entries(form?.query ?? {})
       .filter(([_, value]) => value !== null)
       .map(([key, value]) => value?.map(v => `${key}=${v}`).join('\n') ?? '')
       .join('\n')
@@ -75,113 +75,116 @@
   }
 </script>
 
-<div class="endpoint">
-  <Row>
-    <Col md={12}>
-      <Input
-        id={app.id + '.name'}
-        envVar={`${app.envPrefix}_${index}_NAME`}
-        bind:value={form.name}
-        original={original?.name}
-        {validate} />
-    </Col>
-    <Col md={6}>
-      <Input
-        id={app.id + '.template'}
-        envVar={`${app.envPrefix}_${index}_TEMPLATE`}
-        bind:value={form.template}
-        original={original?.template}
-        {validate}>
-        {#snippet post()}
-          <Button
-            color="secondary"
-            outline
-            style="width:44px;"
-            title="Follow redirects"
-            class={form.follow === original.follow ? '' : 'changed'}>
-            <Box type="checkbox" id={app.id + '.follow'} bind:checked={form.follow} />
-          </Button>
-        {/snippet}
-      </Input>
-    </Col>
-    <Col md={6}>
-      <Input
-        type="timeout"
-        id={app.id + '.timeout'}
-        envVar={`${app.envPrefix}_${index}_TIMEOUT`}
-        bind:value={form.timeout}
-        original={original?.timeout}
-        noDisable
-        {validate} />
-    </Col>
-    <Col md={2}>
-      <Input
-        type="select"
-        id={app.id + '.method'}
-        envVar={`${app.envPrefix}_${index}_METHOD`}
-        bind:value={form.method}
-        original={original?.method}
-        {validate}
-        options={['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'].map(m => ({
-          name: m,
-          value: m,
-        }))} />
-    </Col>
-    <Col md={10}>
-      <CheckedInput
-        id="url"
-        {app}
-        {index}
-        envVar={`${app.envPrefix}_${index}_URL`}
-        bind:form
-        bind:original
-        {validate} />
-    </Col>
-    <Col lg={12}>
-      <Input
-        rows={Math.min(form.body?.split('\n').length ?? 1, 15)}
-        type="textarea"
-        id={app.id + '.body'}
-        envVar={`${app.envPrefix}_${index}_BODY`}
-        bind:value={form.body}
-        original={original?.body}
-        badge={$_(app.id + '.badge.body', { values: { count: form.body?.length ?? 0 } })}
-        {validate} />
-    </Col>
-    <Col lg={12}>
-      <Input
-        rows={Math.min(query.split('\n').length, 15)}
-        type="textarea"
-        id={app.id + '.query'}
-        envVar={`${app.envPrefix}_${index}_QUERY`}
-        bind:value={query}
-        original={originalQuery}
-        badge={$_(app.id + '.badge.query', {
-          values: { count: mapLength(form.query ?? {}) },
-        })}
-        oninput={() => (form.query = updateMap(query, '='))}
-        {validate} />
-    </Col>
-    <Col lg={12}>
-      <Input
-        rows={Math.min(header.split('\n').length, 15)}
-        type="textarea"
-        id={app.id + '.header'}
-        envVar={`${app.envPrefix}_${index}_HEADER`}
-        bind:value={header}
-        original={originalHeader}
-        badge={$_(app.id + '.badge.header', {
-          values: { count: mapLength(form.header ?? {}) },
-        })}
-        oninput={() => (form.header = updateMap(header, ': '))}
-        {validate} />
-    </Col>
+{#if form}
+  <div class="endpoint">
+    <Row>
+      <Col md={12}>
+        <Input
+          id={app.id + '.name'}
+          envVar={`${app.envPrefix}_${index}_NAME`}
+          bind:value={form.name}
+          original={original?.name}
+          {validate} />
+      </Col>
+      <Col md={6}>
+        <Input
+          id={app.id + '.template'}
+          envVar={`${app.envPrefix}_${index}_TEMPLATE`}
+          bind:value={form.template}
+          original={original?.template}
+          {validate}>
+          {#snippet post()}
+            <Button
+              color="secondary"
+              outline
+              style="width:44px;"
+              title="Follow redirects"
+              class={form.follow === original?.follow ? '' : 'changed'}>
+              <Box type="checkbox" id={app.id + '.follow'} bind:checked={form.follow} />
+            </Button>
+          {/snippet}
+        </Input>
+      </Col>
+      <Col md={6}>
+        <Input
+          type="timeout"
+          id={app.id + '.timeout'}
+          envVar={`${app.envPrefix}_${index}_TIMEOUT`}
+          bind:value={form.timeout}
+          original={original?.timeout}
+          noDisable
+          {validate} />
+      </Col>
+      <Col md={2}>
+        <Input
+          type="select"
+          id={app.id + '.method'}
+          envVar={`${app.envPrefix}_${index}_METHOD`}
+          bind:value={form.method}
+          original={original?.method}
+          {validate}
+          options={['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'].map(
+            m => ({ name: m, value: m }),
+          )} />
+      </Col>
+      <Col md={10}>
+        <CheckedInput
+          id="url"
+          {app}
+          {index}
+          envVar={`${app.envPrefix}_${index}_URL`}
+          bind:form
+          bind:original
+          {validate} />
+      </Col>
+      <Col lg={12}>
+        <Input
+          rows={Math.min(form.body?.split('\n').length ?? 1, 15)}
+          type="textarea"
+          id={app.id + '.body'}
+          envVar={`${app.envPrefix}_${index}_BODY`}
+          bind:value={form.body}
+          original={original?.body}
+          badge={$_(app.id + '.badge.body', {
+            values: { count: form.body?.length ?? 0 },
+          })}
+          {validate} />
+      </Col>
+      <Col lg={12}>
+        <Input
+          rows={Math.min(query.split('\n').length, 15)}
+          type="textarea"
+          id={app.id + '.query'}
+          envVar={`${app.envPrefix}_${index}_QUERY`}
+          bind:value={query}
+          original={originalQuery}
+          badge={$_(app.id + '.badge.query', {
+            values: { count: mapLength(form.query ?? {}) },
+          })}
+          oninput={() => (form.query = updateMap(query, '='))}
+          {validate} />
+      </Col>
+      <Col lg={12}>
+        <Input
+          rows={Math.min(header.split('\n').length, 15)}
+          type="textarea"
+          id={app.id + '.header'}
+          envVar={`${app.envPrefix}_${index}_HEADER`}
+          bind:value={header}
+          original={originalHeader}
+          badge={$_(app.id + '.badge.header', {
+            values: { count: mapLength(form.header ?? {}) },
+          })}
+          oninput={() => (form.header = updateMap(header, ': '))}
+          {validate} />
+      </Col>
 
-    <Col md={12}>
-      <CronScheduler bind:cron={form} {original} {validate} bind:this={cronScheduler} />
-    </Col>
-  </Row>
-</div>
+      <Col md={12}>
+        <CronScheduler bind:cron={form} {original} {validate} bind:this={cronScheduler} />
+      </Col>
+    </Row>
+  </div>
+{/if}
 
 <style>
   .endpoint :global(.changed) {

--- a/frontend/src/pages/fileWatcher/Watcher.svelte
+++ b/frontend/src/pages/fileWatcher/Watcher.svelte
@@ -18,87 +18,89 @@
   let pathModal = $state(false)
 </script>
 
-<div class="watcher">
-  <Row>
-    <Col md={9}>
-      <Input
-        id={app.id + '.path'}
-        envVar={`${app.envPrefix}_${index}_PATH`}
-        bind:value={form.path}
-        original={original?.path}
-        {validate}>
-        {#snippet post()}<BButton bind:isOpen={pathModal} />{/snippet}
-      </Input>
-    </Col>
-    <Col md={3}>
-      <Input
-        type="select"
-        id={app.id + '.disabled'}
-        envVar={`${app.envPrefix}_${index}_DISABLED`}
-        bind:value={form.disabled}
-        original={original?.disabled}
-        {validate} />
-    </Col>
-    <Col lg={12}>
-      <Input
-        type="textarea"
-        id={app.id + '.regex'}
-        envVar={`${app.envPrefix}_${index}_REGEX`}
-        bind:value={form.regex}
-        original={original?.regex}
-        {validate} />
-    </Col>
-    <Col lg={12}>
-      <Input
-        type="textarea"
-        id={app.id + '.skip'}
-        envVar={`${app.envPrefix}_${index}_SKIP`}
-        bind:value={form.skip}
-        original={original?.skip}
-        {validate} />
-    </Col>
-    <Col sm={6}>
-      <Input
-        type="select"
-        id={app.id + '.poll'}
-        envVar={`${app.envPrefix}_${index}_POLL`}
-        bind:value={form.poll}
-        original={original?.poll}
-        {validate} />
-    </Col>
-    <Col sm={6}>
-      <Input
-        type="select"
-        id={app.id + '.pipe'}
-        envVar={`${app.envPrefix}_${index}_PIPE`}
-        bind:value={form.pipe}
-        original={original?.pipe}
-        {validate} />
-    </Col>
-    <Col sm={6}>
-      <Input
-        type="select"
-        id={app.id + '.mustExist'}
-        envVar={`${app.envPrefix}_${index}_MUST_EXIST`}
-        bind:value={form.mustExist}
-        original={original?.mustExist}
-        {validate} />
-    </Col>
-    <Col sm={6}>
-      <Input
-        type="select"
-        id={app.id + '.logMatch'}
-        envVar={`${app.envPrefix}_${index}_LOG_MATCH`}
-        bind:value={form.logMatch}
-        original={original?.logMatch}
-        {validate} />
-    </Col>
-  </Row>
-</div>
+{#if form}
+  <div class="watcher">
+    <Row>
+      <Col md={9}>
+        <Input
+          id={app.id + '.path'}
+          envVar={`${app.envPrefix}_${index}_PATH`}
+          bind:value={form.path}
+          original={original?.path}
+          {validate}>
+          {#snippet post()}<BButton bind:isOpen={pathModal} />{/snippet}
+        </Input>
+      </Col>
+      <Col md={3}>
+        <Input
+          type="select"
+          id={app.id + '.disabled'}
+          envVar={`${app.envPrefix}_${index}_DISABLED`}
+          bind:value={form.disabled}
+          original={original?.disabled}
+          {validate} />
+      </Col>
+      <Col lg={12}>
+        <Input
+          type="textarea"
+          id={app.id + '.regex'}
+          envVar={`${app.envPrefix}_${index}_REGEX`}
+          bind:value={form.regex}
+          original={original?.regex}
+          {validate} />
+      </Col>
+      <Col lg={12}>
+        <Input
+          type="textarea"
+          id={app.id + '.skip'}
+          envVar={`${app.envPrefix}_${index}_SKIP`}
+          bind:value={form.skip}
+          original={original?.skip}
+          {validate} />
+      </Col>
+      <Col sm={6}>
+        <Input
+          type="select"
+          id={app.id + '.poll'}
+          envVar={`${app.envPrefix}_${index}_POLL`}
+          bind:value={form.poll}
+          original={original?.poll}
+          {validate} />
+      </Col>
+      <Col sm={6}>
+        <Input
+          type="select"
+          id={app.id + '.pipe'}
+          envVar={`${app.envPrefix}_${index}_PIPE`}
+          bind:value={form.pipe}
+          original={original?.pipe}
+          {validate} />
+      </Col>
+      <Col sm={6}>
+        <Input
+          type="select"
+          id={app.id + '.mustExist'}
+          envVar={`${app.envPrefix}_${index}_MUST_EXIST`}
+          bind:value={form.mustExist}
+          original={original?.mustExist}
+          {validate} />
+      </Col>
+      <Col sm={6}>
+        <Input
+          type="select"
+          id={app.id + '.logMatch'}
+          envVar={`${app.envPrefix}_${index}_LOG_MATCH`}
+          bind:value={form.logMatch}
+          original={original?.logMatch}
+          {validate} />
+      </Col>
+    </Row>
+  </div>
 
-<BrowserModal
-  file
-  bind:isOpen={pathModal}
-  bind:value={form.path}
-  title="FileWatcher.path.label"
-  description="FileWatcher.path.description" />
+  <BrowserModal
+    file
+    bind:isOpen={pathModal}
+    bind:value={form.path}
+    title="FileWatcher.path.label"
+    description="FileWatcher.path.description" />
+{/if}

--- a/frontend/src/pages/serviceChecks/Check.svelte
+++ b/frontend/src/pages/serviceChecks/Check.svelte
@@ -22,7 +22,8 @@
 
   // When the check type changes, reset the form.
   const onchange = () => {
-    if (form.type === original.type) form = { ...original }
+    if (!form) return
+    if (original && form.type === original.type) Object.assign(form, original)
     else form.expect = form.value = ''
     reset()
   }
@@ -37,79 +38,81 @@
 
   // This is called by Instances.svelte when the reset button is clicked.
   // Calls the exported reset method of the current page component.
-  export const reset = () => pages[form.type]?.reset?.()
+  export const reset = () => pages[form?.type]?.reset?.()
 </script>
 
-<div class="serviceCheck">
-  <Row>
-    <Col md={6}>
-      <Input
-        id={app.id + '.name'}
-        envVar={`${app.envPrefix}_${index}_NAME`}
-        bind:value={form.name}
-        original={original.name}
-        {validate} />
-    </Col>
-    <Col md={6}>
-      <Input
-        type="select"
-        id={app.id + '.type'}
-        envVar={`${app.envPrefix}_${index}_TYPE`}
-        bind:value={form.type}
-        original={original?.type}
-        {onchange}
-        {validate}
-        options={['process', 'http', 'tcp', 'ping', 'icmp'].map(type => ({
-          name: $_(`ServiceChecks.type.options.${type}`),
-          value: type,
-          disabled: type === 'ping' && $profile.isWindows,
-        }))} />
-    </Col>
-  </Row>
+{#if form}
+  <div class="serviceCheck">
+    <Row>
+      <Col md={6}>
+        <Input
+          id={app.id + '.name'}
+          envVar={`${app.envPrefix}_${index}_NAME`}
+          bind:value={form.name}
+          original={original?.name}
+          {validate} />
+      </Col>
+      <Col md={6}>
+        <Input
+          type="select"
+          id={app.id + '.type'}
+          envVar={`${app.envPrefix}_${index}_TYPE`}
+          bind:value={form.type}
+          original={original?.type}
+          {onchange}
+          {validate}
+          options={['process', 'http', 'tcp', 'ping', 'icmp'].map(type => ({
+            name: $_(`ServiceChecks.type.options.${type}`),
+            value: type,
+            disabled: type === 'ping' && $profile.isWindows,
+          }))} />
+      </Col>
+    </Row>
 
-  {#if form.type === 'http'}
-    <div class="row" transition:slide>
-      <Http {form} {original} {app} {index} {validate} bind:this={pages.http} />
-    </div>
-  {:else if form.type === 'process'}
-    <div class="row" transition:slide>
-      <Proc {form} {original} {app} {index} {validate} bind:this={pages.process} />
-    </div>
-  {:else if form.type === 'icmp'}
-    <div class="row" transition:slide>
-      <Ping {form} {original} {app} {index} {validate} bind:this={pages.icmp} />
-    </div>
-  {:else if form.type === 'ping'}
-    <div class="row" transition:slide>
-      <Ping {form} {original} {app} {index} {validate} bind:this={pages.ping} />
-    </div>
-  {:else if form.type === 'tcp'}
-    <div class="row" transition:slide>
-      <Tcp {form} {original} {app} {index} {validate} bind:this={pages.tcp} />
-    </div>
-  {/if}
+    {#if form.type === 'http'}
+      <div class="row" transition:slide>
+        <Http {form} {original} {app} {index} {validate} bind:this={pages.http} />
+      </div>
+    {:else if form.type === 'process'}
+      <div class="row" transition:slide>
+        <Proc {form} {original} {app} {index} {validate} bind:this={pages.process} />
+      </div>
+    {:else if form.type === 'icmp'}
+      <div class="row" transition:slide>
+        <Ping {form} {original} {app} {index} {validate} bind:this={pages.icmp} />
+      </div>
+    {:else if form.type === 'ping'}
+      <div class="row" transition:slide>
+        <Ping {form} {original} {app} {index} {validate} bind:this={pages.ping} />
+      </div>
+    {:else if form.type === 'tcp'}
+      <div class="row" transition:slide>
+        <Tcp {form} {original} {app} {index} {validate} bind:this={pages.tcp} />
+      </div>
+    {/if}
 
-  <Row>
-    <Col md={6}>
-      <Input
-        id={app.id + '.timeout'}
-        type="timeout"
-        envVar={`${app.envPrefix}_${index}_TIMEOUT`}
-        bind:value={form.timeout}
-        original={original?.timeout}
-        {validate} />
-    </Col>
-    <Col md={6}>
-      <Input
-        id={app.id + '.interval'}
-        type="interval"
-        envVar={`${app.envPrefix}_${index}_INTERVAL`}
-        bind:value={form.interval}
-        original={original?.interval}
-        {validate} />
-    </Col>
-  </Row>
-</div>
+    <Row>
+      <Col md={6}>
+        <Input
+          id={app.id + '.timeout'}
+          type="timeout"
+          envVar={`${app.envPrefix}_${index}_TIMEOUT`}
+          bind:value={form.timeout}
+          original={original?.timeout}
+          {validate} />
+      </Col>
+      <Col md={6}>
+        <Input
+          id={app.id + '.interval'}
+          type="interval"
+          envVar={`${app.envPrefix}_${index}_INTERVAL`}
+          bind:value={form.interval}
+          original={original?.interval}
+          {validate} />
+      </Col>
+    </Row>
+  </div>
+{/if}
 
 <style>
   .serviceCheck :global(.changed) {

--- a/frontend/src/pages/serviceChecks/HTTP.svelte
+++ b/frontend/src/pages/serviceChecks/HTTP.svelte
@@ -4,7 +4,10 @@
 
   export const validator = (id: string, value: any): string => {
     /* HTTP */
-    if (id == 'url' && !value.match(/^http:\/\/../) && !value.match(/^https:\/\/../))
+    if (
+      id == 'url' &&
+      (!value || (!value.match(/^http:\/\/../) && !value.match(/^https:\/\/../)))
+    )
       return get(_)('phrases.URLMustBeginWithHttp')
     if (id === 'codes' && (!value || value.length === 0))
       return get(_)('ServiceChecks.http.codes.required')
@@ -44,9 +47,9 @@
     }
   }
 
-  const originalHttp = $derived(setData(original.value, original.expect))
-  let httpCheck = $state(setData(form.value, form.expect))
-  export const reset = () => (httpCheck = setData(form.value, form.expect))
+  const originalHttp = $derived(setData(original?.value ?? '', original?.expect ?? ''))
+  let httpCheck = $state(setData(form?.value ?? '', form?.expect ?? ''))
+  export const reset = () => (httpCheck = setData(form?.value ?? '', form?.expect ?? ''))
 
   let codeFeedback = $state<string | undefined>(undefined)
 

--- a/frontend/src/pages/serviceChecks/Ping.svelte
+++ b/frontend/src/pages/serviceChecks/Ping.svelte
@@ -37,9 +37,9 @@
     }
   }
 
-  const originalPing = $derived(setData(original.expect))
-  let pingCheck = $state(setData(form.expect))
-  export const reset = () => (pingCheck = setData(form.expect))
+  const originalPing = $derived(setData(original?.expect ?? ''))
+  let pingCheck = $state(setData(form?.expect ?? ''))
+  export const reset = () => (pingCheck = setData(form?.expect ?? ''))
 
   const updateExpect = (id: string, value: any) => {
     validate?.(app.id + '.ping.count', pingCheck.count)

--- a/frontend/src/pages/serviceChecks/Process.svelte
+++ b/frontend/src/pages/serviceChecks/Process.svelte
@@ -36,9 +36,9 @@
     }
   }
 
-  const originalProc = $derived(setData(original.expect))
-  let procCheck = $state(setData(form.expect))
-  export const reset = () => (procCheck = setData(form.expect))
+  const originalProc = $derived(setData(original?.expect ?? ''))
+  let procCheck = $state(setData(form?.expect ?? ''))
+  export const reset = () => (procCheck = setData(form?.expect ?? ''))
 
   const updateExpect = (id: string, value: any) => {
     if (procCheck.running) {
@@ -48,7 +48,7 @@
       procCheck.maximum = 0
       resetValidators()
     } else {
-      const os = original.expect.split(':').length
+      const os = original?.expect?.split(':').length ?? 0
       form.expect =
         `count:${procCheck.minimum}` +
         (procCheck.maximum > 0 || os > 2 ? `:${procCheck.maximum}` : '') +

--- a/frontend/src/pages/serviceChecks/TCP.svelte
+++ b/frontend/src/pages/serviceChecks/TCP.svelte
@@ -26,7 +26,7 @@
   }: ChildProps<ServiceConfig> = $props()
 
   onMount(() => {
-    validate?.(app.id + '.value', form.value)
+    validate?.(app.id + '.value', form?.value)
     return () => validate?.(app.id + '.value', 'this.is.valid')
   })
 </script>


### PR DESCRIPTION
## Summary
- Deleting the last instance (often the only Transmission row) closed the accordion, spliced the list, then remounted children bound to `undefined` form during the slide outro. That uncaught exception froze the UI while the yellow Deleted badge still appeared ([#1263](https://github.com/Notifiarr/notifiarr/issues/1263)).
- Stop selecting index 0 on an empty list, only bind a live slot while it is still that each item, and guard the other instance forms (commands, endpoints, watchers, service checks) plus validators the same way the busIDs/`Instance.svelte` missing-form fix did.
- Copy the empty template when adding an instance so new rows are not the same object.
- Closes #1263

## Test plan
- [ ] On Downloaders → Transmission, delete the only instance. Accordion should close, Deleted badge should show, UI should stay usable, Save should enable. Save and reload; the instance should be gone.
- [ ] Delete one of two Starr/downloader instances (not the last). Remaining instance should stay intact and Save should persist the shorter list.
- [ ] Repeat last-instance delete on Commands, Endpoints, File Watcher, and Service Checks.
- [ ] Add two new instances of the same app, edit them independently, then delete one.

Made with [Cursor](https://cursor.com)