### PR TITLE
Fix Vite 8 production build

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,24 +6,25 @@ export default defineConfig({
   build: {
     chunkSizeWarningLimit: 2000,
     sourcemap: false,
-    rollupOptions: {
+    rolldownOptions: {
       output: {
-        manualChunks: {
-          bootstrap: ['@sveltestrap/sveltestrap', 'bootstrap/dist/css/bootstrap.min.css'],
-          fontawesome: [
-            '@fortawesome/sharp-duotone-light-svg-icons',
-            '@fortawesome/sharp-duotone-regular-svg-icons',
-            '@fortawesome/sharp-duotone-solid-svg-icons',
-            '@fortawesome/free-brands-svg-icons',
-            // 'svelte-fa',
+        // Vite 8 / Rolldown dropped object-form manualChunks.
+        codeSplitting: {
+          groups: [
+            {
+              name: 'bootstrap',
+              test: /[\\/]node_modules[\\/](?:@sveltestrap[\\/]sveltestrap|bootstrap)(?:[\\/]|$)/,
+            },
+            {
+              name: 'fontawesome',
+              test: /[\\/]node_modules[\\/]@fortawesome[\\/]/,
+            },
+            // If the app grows too big, this is a good place to split it:
+            // {
+            //   name: 'includes',
+            //   test: /[\\/]src[\\/]includes[\\/]/,
+            // },
           ],
-          // If the app grows too big, this is a good place to split it:
-          // includes: [
-          //   './src/includes/formsTracker.svelte.ts',
-          //   './src/includes/instanceValidator.ts',
-          //   './src/includes/util.ts',
-          //   './src/includes/theme.svelte.ts',
-          // ],
         },
       },
     },


### PR DESCRIPTION
## Summary
- Vite 8 (Rolldown) rejects the object form of `manualChunks`, which is what broke `make generate` / `vite build` after #1294 (`TypeError: manualChunks is not a function`).
- Replaced it with Rolldown's `output.codeSplitting.groups` under `build.rolldownOptions`, keeping the bootstrap and Font Awesome splits.

## Test plan
- [x] `npm run build` in `frontend/` succeeds and still emits `bootstrap-*.js/css` and `fontawesome-*.js`
- [ ] `make generate` / `make dev` succeeds locally
- [ ] CI release-asset job that runs the frontend generate step succeeds


Made with [Cursor](https://cursor.com)