### PR TITLE
Stop File Watcher self-log errors from spamming Discord

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,9 @@ linters:
       - common-false-positives
       - legacy
     rules:
+      - path: 'pkg/.*/.*_test.go'
+        linters:
+          - err113
       # Exclude some linters from running on auto-generated files.
       - path: 'pkg/bindata/docs/*'
         linters:

--- a/frontend/src/includes/locale/en.json
+++ b/frontend/src/includes/locale/en.json
@@ -959,7 +959,8 @@
       "label": "File Path",
       "description": "Path to the file to watch. Recommend absolute path names.",
       "placeholder": "/var/log/nginx/access.log",
-      "required": "Path is required"
+      "required": "Path is required",
+      "clientLog": "Cannot watch the client's own log file; that would loop. Client errors are already sent as client_error_log."
     },
     "disabled": { "label": "Active", "description": "Disable this watcher." },
     "regex": {

--- a/frontend/src/pages/fileWatcher/page.svelte.ts
+++ b/frontend/src/pages/fileWatcher/page.svelte.ts
@@ -38,9 +38,25 @@ const merge = (index: number, form: WatchFile): Config => {
 }
 
 const normalizePath = (path: string, windows: boolean): string => {
-  let n = path.trim().replaceAll('\\', '/').replace(/\/+$/, '')
+  let n = path.trim().replaceAll('\\', '/')
   if (windows) n = n.toLowerCase()
-  return n
+
+  const unc = n.startsWith('//')
+  const stack: string[] = []
+  for (const part of n.split('/')) {
+    if (part === '' || part === '.') continue
+    if (part === '..') {
+      const head = stack.at(-1)
+      if (head && head !== '..' && !(windows && /^[a-z]:$/.test(head))) stack.pop()
+      continue
+    }
+    stack.push(part)
+  }
+
+  let out = stack.join('/')
+  if (unc) out = '//' + out
+  else if (n.startsWith('/')) out = '/' + out
+  return out.replace(/\/+$/, '')
 }
 
 const isClientLogPath = (path: string): boolean => {

--- a/frontend/src/pages/fileWatcher/page.svelte.ts
+++ b/frontend/src/pages/fileWatcher/page.svelte.ts
@@ -42,12 +42,14 @@ const normalizePath = (path: string, windows: boolean): string => {
   if (windows) n = n.toLowerCase()
 
   const unc = n.startsWith('//')
+  const rooted = unc || n.startsWith('/') || (windows && /^[a-z]:\//.test(n))
   const stack: string[] = []
   for (const part of n.split('/')) {
     if (part === '' || part === '.') continue
     if (part === '..') {
       const head = stack.at(-1)
       if (head && head !== '..' && !(windows && /^[a-z]:$/.test(head))) stack.pop()
+      else if (!rooted) stack.push('..')
       continue
     }
     stack.push(part)

--- a/frontend/src/pages/fileWatcher/page.svelte.ts
+++ b/frontend/src/pages/fileWatcher/page.svelte.ts
@@ -37,10 +37,36 @@ const merge = (index: number, form: WatchFile): Config => {
   return c
 }
 
+const normalizePath = (path: string, windows: boolean): string => {
+  let n = path.trim().replaceAll('\\', '/').replace(/\/+$/, '')
+  if (windows) n = n.toLowerCase()
+  return n
+}
+
+const isClientLogPath = (path: string): boolean => {
+  const p = get(profile)
+  const windows = !!p.isWindows
+  const want = normalizePath(path, windows)
+  if (!want) return false
+
+  const candidates = [
+    p.config?.logFile,
+    p.config?.httpLog,
+    p.config?.debugLog,
+    p.config?.services?.logFile,
+    ...(p.logFileInfo?.list ?? []).filter(f => f.used).map(f => f.path),
+  ]
+
+  return candidates.some(
+    c => typeof c === 'string' && c !== '' && normalizePath(c, windows) === want,
+  )
+}
+
 const validator = (id: string, value: any): string => {
   id = id.split('.').pop() ?? id
   if (id === 'path') {
     if (!value) return get(_)('FileWatcher.path.required')
+    if (isClientLogPath(value)) return get(_)('FileWatcher.path.clientLog')
   } else if (id === 'regex') {
     if (!value) return get(_)('FileWatcher.regex.required')
   }

--- a/pkg/logs/share/share.go
+++ b/pkg/logs/share/share.go
@@ -3,6 +3,7 @@ package share
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,7 +15,13 @@ type Website interface {
 	SendData(req *website.Request)
 }
 
-const shareCooldown = time.Hour
+const (
+	shareCooldown = time.Hour
+	// Keep skip counts this many cooldowns so the next send can annotate, then drop them.
+	skipRetain = 2
+	traceOpen  = "{trace:"
+	traceClose = "} "
+)
 
 var (
 	// Config is setup by the configfile package.
@@ -85,6 +92,28 @@ func newDeduper(cool time.Duration) *deduper {
 	}
 }
 
+// shareKey strips a {trace:reqID} prefix so the same error dedupes across requests.
+func shareKey(msg string) string {
+	if !strings.HasPrefix(msg, traceOpen) {
+		return msg
+	}
+
+	idx := strings.Index(msg, traceClose)
+	if idx < 0 {
+		return msg
+	}
+
+	return msg[idx+len(traceClose):]
+}
+
+func repeatedSuffix(n int) string {
+	if n == 1 {
+		return fmt.Sprintf(" (repeated %d time)", n)
+	}
+
+	return fmt.Sprintf(" (repeated %d times)", n)
+}
+
 // take returns the (possibly annotated) message to send.
 // The second return is false when this message is still on cooldown.
 func (d *deduper) take(msg string) (string, bool) {
@@ -94,17 +123,19 @@ func (d *deduper) take(msg string) (string, bool) {
 	now := d.now()
 	d.prune(now)
 
-	if last, ok := d.last[msg]; ok && now.Sub(last) < d.cool {
-		d.skipped[msg]++
+	key := shareKey(msg)
+
+	if last, ok := d.last[key]; ok && now.Sub(last) < d.cool {
+		d.skipped[key]++
 		return "", false
 	}
 
-	n := d.skipped[msg]
-	d.skipped[msg] = 0
-	d.last[msg] = now
+	n := d.skipped[key]
+	d.skipped[key] = 0
+	d.last[key] = now
 
 	if n > 0 {
-		return fmt.Sprintf("%s (repeated %d times)", msg, n), true
+		return msg + repeatedSuffix(n), true
 	}
 
 	return msg, true
@@ -112,7 +143,12 @@ func (d *deduper) take(msg string) (string, bool) {
 
 func (d *deduper) prune(now time.Time) {
 	for key, last := range d.last {
-		if now.Sub(last) < d.cool || d.skipped[key] > 0 {
+		limit := d.cool
+		if d.skipped[key] > 0 {
+			limit *= skipRetain
+		}
+
+		if now.Sub(last) < limit {
 			continue
 		}
 

--- a/pkg/logs/share/share.go
+++ b/pkg/logs/share/share.go
@@ -83,7 +83,7 @@ type deduper struct {
 	skipped map[string]int
 }
 
-func newDeduper(cool time.Duration) *deduper {
+func newDeduper(cool time.Duration) *deduper { //nolint:unparam
 	return &deduper{
 		cool:    cool,
 		now:     time.Now,
@@ -98,12 +98,12 @@ func shareKey(msg string) string {
 		return msg
 	}
 
-	idx := strings.Index(msg, traceClose)
-	if idx < 0 {
+	_, after, ok := strings.Cut(msg, traceClose)
+	if !ok {
 		return msg
 	}
 
-	return msg[idx+len(traceClose):]
+	return after
 }
 
 func repeatedSuffix(n int) string {

--- a/pkg/logs/share/share.go
+++ b/pkg/logs/share/share.go
@@ -2,7 +2,9 @@
 package share
 
 import (
+	"fmt"
 	"sync"
+	"time"
 
 	"github.com/Notifiarr/notifiarr/pkg/triggers/data"
 	"github.com/Notifiarr/notifiarr/pkg/website"
@@ -12,10 +14,13 @@ type Website interface {
 	SendData(req *website.Request)
 }
 
+const shareCooldown = time.Hour
+
 var (
 	// Config is setup by the configfile package.
 	enabled bool
 	locker  sync.RWMutex
+	dedupe  = newDeduper(shareCooldown)
 )
 
 func Enable() {
@@ -40,6 +45,7 @@ type Match struct {
 }
 
 // Log sends an error message to the website.
+// Identical messages are suppressed for shareCooldown; the next send notes how many were skipped.
 func Log(reqID string, msg string) {
 	locker.RLock()
 	defer locker.RUnlock()
@@ -48,11 +54,69 @@ func Log(reqID string, msg string) {
 		return
 	}
 
+	line, ok := dedupe.take(msg)
+	if !ok {
+		return
+	}
+
 	website.SendData(&website.Request{
 		ReqID:      reqID,
-		Payload:    &Match{File: "client_error_log", Line: msg, Matches: []string{"[ERROR]"}},
+		Payload:    &Match{File: "client_error_log", Line: line, Matches: []string{"[ERROR]"}},
 		Route:      website.LogLineRoute,
 		Event:      website.EventFile,
 		LogPayload: true,
 	})
+}
+
+type deduper struct {
+	mu      sync.Mutex
+	cool    time.Duration
+	now     func() time.Time
+	last    map[string]time.Time
+	skipped map[string]int
+}
+
+func newDeduper(cool time.Duration) *deduper {
+	return &deduper{
+		cool:    cool,
+		now:     time.Now,
+		last:    make(map[string]time.Time),
+		skipped: make(map[string]int),
+	}
+}
+
+// take returns the (possibly annotated) message to send.
+// The second return is false when this message is still on cooldown.
+func (d *deduper) take(msg string) (string, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	now := d.now()
+	d.prune(now)
+
+	if last, ok := d.last[msg]; ok && now.Sub(last) < d.cool {
+		d.skipped[msg]++
+		return "", false
+	}
+
+	n := d.skipped[msg]
+	d.skipped[msg] = 0
+	d.last[msg] = now
+
+	if n > 0 {
+		return fmt.Sprintf("%s (repeated %d times)", msg, n), true
+	}
+
+	return msg, true
+}
+
+func (d *deduper) prune(now time.Time) {
+	for key, last := range d.last {
+		if now.Sub(last) < d.cool || d.skipped[key] > 0 {
+			continue
+		}
+
+		delete(d.last, key)
+		delete(d.skipped, key)
+	}
 }

--- a/pkg/logs/share/share_test.go
+++ b/pkg/logs/share/share_test.go
@@ -1,0 +1,59 @@
+package share //nolint:testpackage
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDeduperTake(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	duper := newDeduper(time.Hour)
+	duper.now = func() time.Time { return now }
+
+	line, ok := duper.take("boom")
+	if !ok || line != "boom" {
+		t.Fatalf("first take: got %q ok=%v, want boom true", line, ok)
+	}
+
+	line, ok = duper.take("boom")
+	if ok || line != "" {
+		t.Fatalf("second take during cooldown: got %q ok=%v, want empty false", line, ok)
+	}
+
+	_, _ = duper.take("boom")
+	_, _ = duper.take("other")
+
+	now = now.Add(time.Hour)
+
+	line, ok = duper.take("boom")
+	if !ok || line != "boom (repeated 2 times)" {
+		t.Fatalf("after cooldown: got %q ok=%v, want annotated true", line, ok)
+	}
+
+	line, ok = duper.take("other")
+	if !ok || line != "other" {
+		t.Fatalf("other after cooldown with no extras: got %q ok=%v", line, ok)
+	}
+}
+
+func TestDeduperPrune(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	duper := newDeduper(time.Hour)
+	duper.now = func() time.Time { return now }
+
+	_, _ = duper.take("old")
+	now = now.Add(2 * time.Hour)
+	_, _ = duper.take("new")
+
+	if _, ok := duper.last["old"]; ok {
+		t.Fatal("expected expired unused message to be pruned")
+	}
+
+	if _, ok := duper.last["new"]; !ok {
+		t.Fatal("expected new message to remain")
+	}
+}

--- a/pkg/logs/share/share_test.go
+++ b/pkg/logs/share/share_test.go
@@ -12,14 +12,14 @@ func TestDeduperTake(t *testing.T) {
 	duper := newDeduper(time.Hour)
 	duper.now = func() time.Time { return now }
 
-	line, ok := duper.take("boom")
-	if !ok || line != "boom" {
-		t.Fatalf("first take: got %q ok=%v, want boom true", line, ok)
+	line, exists := duper.take("boom")
+	if !exists || line != "boom" {
+		t.Fatalf("first take: got %q ok=%v, want boom true", line, exists)
 	}
 
-	line, ok = duper.take("boom")
-	if ok || line != "" {
-		t.Fatalf("second take during cooldown: got %q ok=%v, want empty false", line, ok)
+	line, exists = duper.take("boom")
+	if exists || line != "" {
+		t.Fatalf("second take during cooldown: got %q ok=%v, want empty false", line, exists)
 	}
 
 	_, _ = duper.take("boom")
@@ -27,14 +27,14 @@ func TestDeduperTake(t *testing.T) {
 
 	now = now.Add(time.Hour)
 
-	line, ok = duper.take("boom")
-	if !ok || line != "boom (repeated 2 times)" {
-		t.Fatalf("after cooldown: got %q ok=%v, want annotated true", line, ok)
+	line, exists = duper.take("boom")
+	if !exists || line != "boom (repeated 2 times)" {
+		t.Fatalf("after cooldown: got %q ok=%v, want annotated true", line, exists)
 	}
 
-	line, ok = duper.take("other")
-	if !ok || line != "other" {
-		t.Fatalf("other after cooldown with no extras: got %q ok=%v", line, ok)
+	line, exists = duper.take("other")
+	if !exists || line != "other" {
+		t.Fatalf("other after cooldown with no extras: got %q ok=%v", line, exists)
 	}
 }
 

--- a/pkg/logs/share/share_test.go
+++ b/pkg/logs/share/share_test.go
@@ -5,6 +5,25 @@ import (
 	"time"
 )
 
+func TestShareKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in, want string
+	}{
+		{in: "boom", want: "boom"},
+		{in: "{trace:abc-123} boom", want: "boom"},
+		{in: "{trace:abc-123} Unable to watch file: x", want: "Unable to watch file: x"},
+		{in: "{trace:no-close boom", want: "{trace:no-close boom"},
+	}
+
+	for _, test := range tests {
+		if got := shareKey(test.in); got != test.want {
+			t.Fatalf("shareKey(%q) = %q, want %q", test.in, got, test.want)
+		}
+	}
+}
+
 func TestDeduperTake(t *testing.T) {
 	t.Parallel()
 
@@ -38,6 +57,48 @@ func TestDeduperTake(t *testing.T) {
 	}
 }
 
+func TestDeduperRepeatedOnce(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	duper := newDeduper(time.Hour)
+	duper.now = func() time.Time { return now }
+
+	_, _ = duper.take("boom")
+	_, _ = duper.take("boom")
+	now = now.Add(time.Hour)
+
+	line, exists := duper.take("boom")
+	if !exists || line != "boom (repeated 1 time)" {
+		t.Fatalf("got %q ok=%v, want singular repeated 1 time", line, exists)
+	}
+}
+
+func TestDeduperTraceKey(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	duper := newDeduper(time.Hour)
+	duper.now = func() time.Time { return now }
+
+	line, exists := duper.take("{trace:req-1} boom")
+	if !exists || line != "{trace:req-1} boom" {
+		t.Fatalf("first traced take: got %q ok=%v", line, exists)
+	}
+
+	line, exists = duper.take("{trace:req-2} boom")
+	if exists || line != "" {
+		t.Fatalf("second traced take should dedupe on untraced key, got %q ok=%v", line, exists)
+	}
+
+	now = now.Add(time.Hour)
+
+	line, exists = duper.take("{trace:req-3} boom")
+	if !exists || line != "{trace:req-3} boom (repeated 1 time)" {
+		t.Fatalf("after cooldown: got %q ok=%v", line, exists)
+	}
+}
+
 func TestDeduperPrune(t *testing.T) {
 	t.Parallel()
 
@@ -55,5 +116,34 @@ func TestDeduperPrune(t *testing.T) {
 
 	if _, ok := duper.last["new"]; !ok {
 		t.Fatal("expected new message to remain")
+	}
+}
+
+func TestDeduperPruneSkipped(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	duper := newDeduper(time.Hour)
+	duper.now = func() time.Time { return now }
+
+	_, _ = duper.take("once")
+	_, _ = duper.take("once") // skipped=1, would previously never prune
+
+	now = now.Add(time.Hour)
+	_, _ = duper.take("other")
+
+	if _, ok := duper.last["once"]; !ok {
+		t.Fatal("skip count should be retained for one extra cooldown")
+	}
+
+	now = now.Add(time.Hour)
+	_, _ = duper.take("other")
+
+	if _, ok := duper.last["once"]; ok {
+		t.Fatal("expected skipped-only message to be pruned after 2 cooldowns")
+	}
+
+	if duper.skipped["once"] != 0 {
+		t.Fatal("expected skipped count to be dropped with the key")
 	}
 }

--- a/pkg/triggers/filewatch/filewatch.go
+++ b/pkg/triggers/filewatch/filewatch.go
@@ -141,7 +141,7 @@ func (c *cmd) run(ctx context.Context) {
 
 	for _, item := range c.files {
 		if err := item.setup(c.ignored); err != nil {
-			mnd.Log.Errorf(mnd.GetID(ctx), "Unable to watch file: %v", err)
+			logWatchSetupError(mnd.GetID(ctx), err)
 			continue
 		}
 
@@ -191,6 +191,19 @@ func (w *WatchFile) setup(ignored ignored) error {
 	w.retries = 0
 
 	return nil
+}
+
+// logWatchSetupError logs a file-watcher setup failure.
+// Watching the client's own log, or a disabled watcher, is expected and is never shared.
+func logWatchSetupError(reqID string, err error) {
+	switch {
+	case errors.Is(err, ErrIgnoredLog):
+		mnd.Log.Printf(reqID, "Skipping File Watcher for client's own log (would loop): %v", err)
+	case errors.Is(err, ErrDisabled):
+		mnd.Log.Debugf(reqID, "Skipping disabled File Watcher: %v", err)
+	default:
+		mnd.Log.Errorf(reqID, "Unable to watch file: %v", err)
+	}
 }
 
 // collectFileTails uses reflection to watch a dynamic list of files in one go routine.

--- a/pkg/triggers/filewatch/filewatch.go
+++ b/pkg/triggers/filewatch/filewatch.go
@@ -193,6 +193,11 @@ func (w *WatchFile) setup(ignored ignored) error {
 	return nil
 }
 
+// isQuietSetupErr is true for expected setup outcomes that must not be shared to Discord.
+func isQuietSetupErr(err error) bool {
+	return errors.Is(err, ErrIgnoredLog) || errors.Is(err, ErrDisabled)
+}
+
 // logWatchSetupError logs a file-watcher setup failure.
 // Watching the client's own log, or a disabled watcher, is expected and is never shared.
 func logWatchSetupError(reqID string, err error) {
@@ -321,11 +326,21 @@ func (c *cmd) fileWatcherTicker(ctx context.Context, died bool) bool {
 			item.retries, maxRetries, item.Path)
 
 		if err := c.addFileWatcher(item); err != nil {
-			mnd.Log.Errorf(mnd.GetID(ctx), "Restarting File Watcher (retries: %d/%d): %s: %v",
-				item.retries, maxRetries, item.Path, err)
 			mnd.FileWatcher.Add(item.Path+Errors, 1)
-
 			stilldead = true
+
+			reqID := mnd.GetID(ctx)
+			switch {
+			case isQuietSetupErr(err):
+				logWatchSetupError(reqID, err)
+				retries = maxRetries // do not keep retrying expected failures.
+			case retries >= maxRetries:
+				mnd.Log.Errorf(reqID, "Giving up restarting File Watcher after %d retries: %s: %v",
+					maxRetries, item.Path, err)
+			default:
+				mnd.Log.ErrorfNoShare(reqID, "Restarting File Watcher (retries: %d/%d): %s: %v",
+					retries, maxRetries, item.Path, err)
+			}
 		} else {
 			mnd.FileWatcher.Add(item.Path+" Restarts", 1)
 		}

--- a/pkg/triggers/filewatch/filewatch.go
+++ b/pkg/triggers/filewatch/filewatch.go
@@ -293,7 +293,7 @@ func (c *cmd) tailFiles(ctx context.Context, cases []reflect.SelectCase, tails [
 // If that does not return an error, it means Stop was already called.
 func (c *cmd) killWatcher(ctx context.Context, item *WatchFile) bool {
 	if err := item.deactivate(); err != nil {
-		mnd.Log.Errorf(mnd.GetID(ctx), "No longer watching file (channel closed): %s: %v", item.Path, err)
+		mnd.Log.ErrorfNoShare(mnd.GetID(ctx), "No longer watching file (channel closed): %s: %v", item.Path, err)
 		mnd.FileWatcher.Add(item.Path+Errors, 1)
 
 		return true

--- a/pkg/triggers/filewatch/filewatch_test.go
+++ b/pkg/triggers/filewatch/filewatch_test.go
@@ -1,0 +1,36 @@
+package filewatch //nolint:testpackage
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsQuietSetupErr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "ignored log", err: fmt.Errorf("%w: %s", ErrIgnoredLog, "Notifiarr.log"), want: true},
+		{name: "disabled", err: fmt.Errorf("%w: %s", ErrDisabled, "foo.log"), want: true},
+		{
+			name: "invalid regexp",
+			err:  fmt.Errorf("%w: no regexp match provided, ignored: %s", ErrInvalidRegexp, "foo"),
+			want: false,
+		},
+		{name: "other", err: fmt.Errorf("watching file %s: no such file", "foo.log"), want: false},
+		{name: "nil", err: nil, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isQuietSetupErr(test.err); got != test.want {
+				t.Fatalf("isQuietSetupErr(%v) = %v, want %v", test.err, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Do not share expected File Watcher setup outcomes (`ErrIgnoredLog`, disabled watchers) as `client_error_log`; those were the Discord loop in #1269.
- Dedupe identical shared client errors for an hour and note the skip count on the next send.
- Reject File Watcher paths that point at the client's own logs in the UI.
- Keep File Watcher restart attempts local (`ErrorfNoShare`) and share once when retries are exhausted.

Fixes #1269

## Test plan
- [ ] Enable Log Watcher / client errors, point a File Watcher at the client's log file, save: UI should reject the path.
- [ ] With an existing config that watches the client log, reload/reconfigure: local log should show the skip message, Discord should not get `internally ignored`.
- [ ] Invalid File Watcher regexp still shares once as a real config error (and is deduped on reload).
- [ ] A watched file that disappears retries locally; Discord gets one give-up error after 12 retries.


Made with [Cursor](https://cursor.com)