### PR TITLE
Keep instance originals aligned after deleting a middle row

### DIFF
--- a/frontend/src/includes/formsTracker.svelte.ts
+++ b/frontend/src/includes/formsTracker.svelte.ts
@@ -64,9 +64,9 @@ export class FormListTracker<T> {
   private feedback: Record<number, Record<string, string | undefined>>
   /** The form-bound list of instances in our tabs. */
   public instances: T[]
-  /** List of removed instance indexes. Use .length to get the number of removed instances. */
+  /** Count of deleted saved instances. Use .length for the Deleted badge. Indexes are not stable. */
   public removed: number[]
-  /** The original list of instances in our tabs. */
+  /** Saved instances still in the form. Kept index-aligned with `instances` when deleting. */
   public readonly original: T[]
   /** Data about the app we're validating. */
   public readonly app: App<T>
@@ -105,12 +105,13 @@ export class FormListTracker<T> {
     this.active = undefined
     // Wait for it to slide shut.
     await delay(400)
+    // Drop the matching saved original so remaining rows keep the right Reset/Changed state.
+    if (index < this.original.length) {
+      this.original.splice(index, 1)
+      this.removed.push(index)
+    }
     // Remove the instance from the form (delete the accordion).
     this.instances.splice(index, 1)
-    // Record the removed index. Once. If it's not a new index.
-    // This is the 'Deleted' counter.
-    if (!this.removed.includes(index) && index < this.original.length)
-      this.removed.push(index)
     // Reset the feedback for the instance.
     this.feedback = {}
     // Re-open a remaining instance. Never select index 0 on an empty list:


### PR DESCRIPTION
## Summary
- Follow-up to Copilot’s review on #1298: deleting a non-last instance spliced `instances` but left `original` untouched, so the next row compared against the deleted config, showed Changed, and Reset swapped in the wrong instance.
- Splice the matching saved original when removing an existing row so Reset/Changed/headers stay on the surviving instance. The Deleted badge still uses `removed.length`; dropping the unique-index check also counts two deletes that both land on index 0.

## Test plan
- [ ] Two Starr or downloader instances A then B. Delete A. B should not show Changed, its header/name/url should still be B, and Reset should restore B (not A).
- [ ] Save after that delete; only B remains after reload.
- [ ] Delete B first then A; Deleted badge should show 2.
- [ ] Add a new instance, delete it without saving; Deleted badge should stay 0 and Save should disable if nothing else changed.


Made with [Cursor](https://cursor.com)