### PR TITLE
Sign Windows exe with golift/codesign@v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,9 @@ jobs:
       - name: Make Release v${{steps.vars.outputs.version}}-${{steps.vars.outputs.revision}}
         env:
           FONTAWESOME_PACKAGE_TOKEN: ${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}
+          # Job-level CODESIGN_URL is only for the codesign step's if.
+          # Make must not see it: signexe.sh would fail before the Action installs the CLI.
+          CODESIGN_URL: ""
         id: release
         run: |
           sudo apt install -y rpm fakeroot zip debsigs gnupg jq libarchive-tools

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,8 @@ jobs:
     env:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
       SLIPPERS: ${{ secrets.SLIPPERS }}
+      # Map first: secrets cannot be referenced in steps.if.
+      CODESIGN_URL: ${{ secrets.CODESIGN_URL }}
     steps:
       - name: Configure Fast APT Mirror
         uses: vegardit/fast-apt-mirror.sh@v1
@@ -105,7 +107,7 @@ jobs:
           [ -z SLIPPERS ] || eval "${SLIPPERS}"
           make release WINDOWS_ZIP=0
       - uses: golift/codesign@v1
-        if: ${{ secrets.CODESIGN_URL != '' }}
+        if: env.CODESIGN_URL != ''
         with:
           files: notifiarr.amd64.exe
           url: ${{ secrets.CODESIGN_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,7 @@ jobs:
       - name: Zip Windows exe
         run: |
           make windows_zip
+          rm -f release/sha512sums.txt
           openssl dgst -r -sha512 release/* | sed 's#release/##' | tee release/sha512sums.txt
       - name: Upload Release Artifacts v${{steps.vars.outputs.version}}-${{steps.vars.outputs.revision}}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,11 +64,12 @@ jobs:
       revision: ${{ steps.vars.outputs.revision }}
     name: Make Release Assets
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     env:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
       SLIPPERS: ${{ secrets.SLIPPERS }}
-      EXE_SIGNING_KEY: ${{ secrets.EXE_SIGNING_KEY }}
-      EXE_SIGNING_KEY_PASSWORD: ${{ secrets.EXE_SIGNING_KEY_PASSWORD }}
     steps:
       - name: Configure Fast APT Mirror
         uses: vegardit/fast-apt-mirror.sh@v1
@@ -98,11 +99,24 @@ jobs:
           FONTAWESOME_PACKAGE_TOKEN: ${{ secrets.FONTAWESOME_PACKAGE_TOKEN }}
         id: release
         run: |
-          sudo apt install -y rpm fakeroot zip debsigs gnupg jq libarchive-tools osslsigncode
+          sudo apt install -y rpm fakeroot zip debsigs gnupg jq libarchive-tools
           sudo gem install --no-document fpm
           echo "${GPG_SIGNING_KEY}" | gpg --import -
           [ -z SLIPPERS ] || eval "${SLIPPERS}"
-          make release
+          make release WINDOWS_ZIP=0
+      - uses: golift/codesign@v1
+        if: ${{ secrets.CODESIGN_URL != '' }}
+        with:
+          files: notifiarr.amd64.exe
+          url: ${{ secrets.CODESIGN_URL }}
+          client-cert: ${{ secrets.CODESIGN_CLIENT_CERT }}
+          client-key: ${{ secrets.CODESIGN_CLIENT_KEY }}
+          name: Notifiarr
+          website: https://notifiarr.com
+      - name: Zip Windows exe
+        run: |
+          make windows_zip
+          openssl dgst -r -sha512 release/* | sed 's#release/##' | tee release/sha512sums.txt
       - name: Upload Release Artifacts v${{steps.vars.outputs.version}}-${{steps.vars.outputs.revision}}
         uses: actions/upload-artifact@v7
         with:

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ ifeq ($(OUTPUTDIR),)
      OUTPUTDIR=.
 endif
 
+# CI sets WINDOWS_ZIP=0 so golift/codesign@v1 can Authenticode-sign the exe
+# before this zip loop deletes it. Local `make release` still zips.
+WINDOWS_ZIP ?= 1
+
 # Preserve the passed-in version & iteration (local development testing).
 _VERSION:=$(VERSION)
 _ITERATION:=$(ITERATION)
@@ -78,7 +82,9 @@ release: clean generate linux_packages freebsd_packages windows
 	mkdir -p $@
 	mv notifiarr.*.linux notifiarr.*.freebsd $@/
 	gzip -9r $@/
+ifneq ($(WINDOWS_ZIP),0)
 	for i in notifiarr*.exe ; do zip -9qj $@/$$i.zip $$i examples/*.example *.html; rm -f $$i;done
+endif
 	mv *.rpm *.deb *.txz *.zst $@/
 	mv *.sig $@/ || echo "...ignoring previous error"
 	# Generating File Hashes
@@ -188,6 +194,15 @@ notifiarr.amd64.exe: generate rsrc.syso main.go
 	# Building windows 64-bit x86 binary.
 	GOOS=windows GOARCH=amd64 go build $(WINDOWS_BUILD_FLAGS) -o $(OUTPUTDIR)/$@ -ldflags "-w -s $(VERSION_LDFLAGS) $(EXTRA_LDFLAGS) $(WINDOWS_LDFLAGS)"
 	bash init/windows/signexe.sh $(OUTPUTDIR)/$@
+
+# Zip Windows exe after Authenticode (used by CI when WINDOWS_ZIP=0).
+windows_zip:
+	mkdir -p release
+	for i in notifiarr*.exe ; do \
+		[ -f $$i ] || continue; \
+		zip -9qj release/$$i.zip $$i examples/*.example *.html; \
+		rm -f $$i; \
+	done
 
 ####################
 ##### Packages #####

--- a/init/windows/signexe.sh
+++ b/init/windows/signexe.sh
@@ -7,8 +7,8 @@ set -e -o pipefail
 # This script is for local `make windows` when CODESIGN_URL is set (SSH tunnel
 # or a configured CLI). PKCS#12 secrets are retired.
 #
-# On macOS, never call /usr/bin/codesign (Apple's tool). Prefer CODESIGN_BIN
-# or "$(go env GOPATH)/bin/codesign".
+# On macOS, never call /usr/bin/codesign (Apple's tool). Prefer CODESIGN_BIN,
+# "$(go env GOPATH)/bin/codesign", then any other `codesign` on PATH.
 
 function pick_codesign() {
   if [ -n "${CODESIGN_BIN:-}" ]; then
@@ -20,14 +20,15 @@ function pick_codesign() {
     echo "${gopath}/bin/codesign"
     return
   fi
-  case "$(uname -s)" in
-    Darwin)
-      return 1
-      ;;
-    *)
-      command -v codesign
-      ;;
-  esac
+  # Apple ships /usr/bin/codesign. Skip it; any other PATH hit is the CLI.
+  while IFS= read -r p; do
+    case "$p" in
+      /usr/bin/codesign|/bin/codesign) continue ;;
+    esac
+    echo "$p"
+    return
+  done < <(type -a -p codesign 2>/dev/null || true)
+  return 1
 }
 
 function sign() {

--- a/init/windows/signexe.sh
+++ b/init/windows/signexe.sh
@@ -38,6 +38,10 @@ function sign() {
   fi
 
   bin="$(pick_codesign)" || {
+    if [ -n "${GITHUB_ACTIONS:-}" ]; then
+      echo "Skipped signing ${FILE} (codesign CLI not on PATH; Action signs later) .." >&2
+      exit 0
+    fi
     echo "CODESIGN_URL is set but golift codesign CLI not found (set CODESIGN_BIN)" >&2
     exit 1
   }

--- a/init/windows/signexe.sh
+++ b/init/windows/signexe.sh
@@ -2,24 +2,49 @@
 
 set -e -o pipefail
 
-# https://blog.synapp.nz/2017/06/16/code-signing-a-windows-application-on-linux-on-windows/
-# https://stackoverflow.com/a/29073957/1142
+# Authenticode-sign a Windows PE via golift/codesign (YubiKey-backed signerd).
+# GitHub Actions uses golift/codesign@v1 after `make release WINDOWS_ZIP=0`.
+# This script is for local `make windows` when CODESIGN_URL is set (SSH tunnel
+# or a configured CLI). PKCS#12 secrets are retired.
+#
+# On macOS, never call /usr/bin/codesign (Apple's tool). Prefer CODESIGN_BIN
+# or "$(go env GOPATH)/bin/codesign".
+
+function pick_codesign() {
+  if [ -n "${CODESIGN_BIN:-}" ]; then
+    echo "${CODESIGN_BIN}"
+    return
+  fi
+  gopath="$(go env GOPATH 2>/dev/null || true)"
+  if [ -n "${gopath}" ] && [ -x "${gopath}/bin/codesign" ]; then
+    echo "${gopath}/bin/codesign"
+    return
+  fi
+  case "$(uname -s)" in
+    Darwin)
+      return 1
+      ;;
+    *)
+      command -v codesign
+      ;;
+  esac
+}
+
 function sign() {
-  if [ -z "${EXE_SIGNING_KEY}" ] || [ -z "${EXE_SIGNING_KEY_PASSWORD}" ]; then
-    echo "Skipped signing ${FILE} .." >&2
+  if [ -z "${CODESIGN_URL:-}" ]; then
+    echo "Skipped signing ${FILE} (CODESIGN_URL unset) .." >&2
     exit 0
   fi
 
-  rm -f "${FILE}.signed"
-  echo "${EXE_SIGNING_KEY}" | base64 -d | \
-  osslsigncode sign -pkcs12 /dev/stdin \
-    -pass "${EXE_SIGNING_KEY_PASSWORD}" \
-    -n "Notifiarr" \
-    -i "https://notifiarr.com" \
-    -t "http://timestamp.comodoca.com/authenticode" \
-    -in "${FILE}" -out "${FILE}.signed" \
-    && cp "${FILE}.signed" "${FILE}" >> /tmp/pwd >&2 \
-    && echo "Signed ${FILE} .." >&2
+  bin="$(pick_codesign)" || {
+    echo "CODESIGN_URL is set but golift codesign CLI not found (set CODESIGN_BIN)" >&2
+    exit 1
+  }
+
+  CODESIGN_NAME="${CODESIGN_NAME:-Notifiarr}" \
+  CODESIGN_WEBSITE="${CODESIGN_WEBSITE:-https://notifiarr.com}" \
+  "${bin}" -- "${FILE}"
+  echo "Signed ${FILE} .." >&2
 }
 
 [ -z "$1" ] || FILE="$1" sign


### PR DESCRIPTION
## Summary
- Replace the expired PKCS12 `osslsigncode` path with `uses: golift/codesign@v1`.
- `make release WINDOWS_ZIP=0` leaves the exe for the Action; `make windows_zip` packages afterward and refreshes `sha512sums.txt`.
- Skip signing when `CODESIGN_URL` is unset so this can merge before the signing endpoint and GitHub secrets exist.

Do not delete `EXE_SIGNING_KEY` / `EXE_SIGNING_KEY_PASSWORD` until a signed unstable build is verified. Job needs `id-token: write`.

Operator follow-up (not in this PR): org/repo secrets `CODESIGN_URL`, `CODESIGN_CLIENT_CERT`, `CODESIGN_CLIENT_KEY`, and allowlist `Notifiarr/notifiarr` on signerd.

## Test plan
- [ ] CI on this PR: Windows zip is unsigned, job still green (secrets unset)
- [ ] After secrets + live signerd: unstable Windows zip is Authenticode-signed
- [ ] Then delete the old PKCS12 secrets


Made with [Cursor](https://cursor.com)