### PR TITLE
Fix nil logger panic when adding a service after Start

### DIFF
--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -52,6 +52,7 @@ func (s *Services) add(svc *ServiceConfig) {
 		ServiceConfig: svc,
 		State:         StateUnknown,
 		Since:         time.Now(),
+		log:           s.log,
 	}
 }
 

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -324,6 +324,24 @@ func TestAddAfterEmptyStartCanRunCheck(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("check queued after empty Start never ran; worker pool was empty")
 	}
+
+	// Wait for update() to finish, not just the HTTP hit. A nil Service.log panics there.
+	deadline := time.After(2 * time.Second)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		got := resultsByName(svc.GetResults())
+		if late := got["late"]; late != nil && late.State == services.StateOK {
+			return
+		}
+
+		select {
+		case <-deadline:
+			t.Fatal("late check started but never recorded a result")
+		case <-ticker.C:
+		}
+	}
 }
 
 func TestConcurrentStartAndStop(t *testing.T) {


### PR DESCRIPTION
## Summary
- Copy `Services.log` onto checks created by `add()`, so a service added after `Start()` does not panic in `update()`.
- Make `TestAddAfterEmptyStartCanRunCheck` wait for the recorded result, not only the HTTP hit, so this cannot slip past as a flake.

This showed up as a Ubuntu `gotest` panic on unrelated PRs (including codesign): `Service.update` nil pointer at `s.log.Printf`.

## Test plan
- [ ] `go test ./pkg/services/ -count=20` stays green
- [ ] CI `gotest (ubuntu)` on this PR passes


Made with [Cursor](https://cursor.com)