### PR TITLE
Fail unstable.golift.io uploads on HTTP errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,9 +165,13 @@ jobs:
           for file in *.{zip,dmg,gz}; do
             [ -f "$file" ] || continue;
             echo "Uploading: ${file}";
-            curl -sSH "X-API-KEY: ${{ secrets.UNSTABLE_UPLOAD_KEY }}" "https://unstable.golift.io/upload.php?folder=notifiarr" -F "file=@${file}";
+            curl -sS --fail-with-body --retry 5 --retry-all-errors --retry-delay 2
+            -H "X-API-KEY: ${{ secrets.UNSTABLE_UPLOAD_KEY }}"
+            "https://unstable.golift.io/upload.php?folder=notifiarr" -F "file=@${file}";
             echo '{"version":"${{needs.release.outputs.version}}","revision":${{needs.release.outputs.revision}},"size":'$(stat --printf="%s" ${file})'}' >> ${file}.txt
-            curl -sSH "X-API-KEY: ${{ secrets.UNSTABLE_UPLOAD_KEY }}" "https://unstable.golift.io/upload.php?folder=notifiarr" -F "file=@${file}.txt";
+            curl -sS --fail-with-body --retry 5 --retry-all-errors --retry-delay 2
+            -H "X-API-KEY: ${{ secrets.UNSTABLE_UPLOAD_KEY }}"
+            "https://unstable.golift.io/upload.php?folder=notifiarr" -F "file=@${file}.txt";
           done
 
   deploy-unstable-packagecloud:


### PR DESCRIPTION
## Summary
- `curl -sS` returns 0 on Cloudflare 521, so a missing binary or sidecar does not fail the deploy job.
- Use `--fail-with-body` and retry transient HTTP errors so origin blips are retried and a real failure fails the workflow.

## Test plan
- [ ] Confirm the workflow YAML still parses (`run` folded scalar with the extra curl flags).
- [ ] After merge to `unstable`, a deploy that hits 521 retries and either succeeds or fails the job.


Made with [Cursor](https://cursor.com)