### PR TITLE
Fix mobile sidebar scroll so Trust Profile is reachable on Home

### DIFF
--- a/frontend/src/navigation/Index.svelte
+++ b/frontend/src/navigation/Index.svelte
@@ -25,7 +25,7 @@
   // windowWidth is used for sidebar collapse state.
   let windowWidth = $state(magicNumber - 1)
   const isMobile = $derived(windowWidth <= magicNumber)
-  // Use this to limit the sidebar height to the content height.
+  // Desktop: stretch the sticky sidebar to the content height.
   let contentHeight = $state(0)
 
   onMount(async () => {
@@ -33,12 +33,17 @@
     await nav.onMount()
   })
 
-  $effect(() => {
-    if (windowWidth < magicNumber) sidebarOpen = false
-  })
+  // Close the overlay only when crossing desktop → mobile, not on every
+  // innerWidth tick (rotation would otherwise dismiss an open menu).
+  const setWindowWidth = (width: number) => {
+    if (width <= magicNumber && windowWidth > magicNumber) sidebarOpen = false
+    windowWidth = width
+  }
 </script>
 
-<svelte:window bind:innerWidth={windowWidth} on:popstate={e => nav.popstate(e)} />
+<svelte:window
+  bind:innerWidth={() => windowWidth, setWindowWidth}
+  on:popstate={e => nav.popstate(e)} />
 
 <Modals />
 
@@ -64,7 +69,7 @@
   {@const transition = { duration: 600, axis: 'x' as const }}
   <!-- Navigation Sidebar. -->
   <div class="sidebar-col col mb-2 {flex}" transition:slide={transition}>
-    <Sidebar slide={transition} height={contentHeight} />
+    <Sidebar slide={transition} height={contentHeight} {isMobile} />
   </div>
 {/if}
 
@@ -128,17 +133,27 @@
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
   }
 
-  /* Mobile styles for sidebar. Turns it into a fixed sidebar w/ toggler. */
+  /* Mobile drawer: fill the visual viewport and let Sidebar scroll internally. */
   .flex-col {
     position: fixed;
     z-index: 1020;
-    max-height: 100vh;
-    overflow-y: auto;
     top: 0;
     left: 0;
+    bottom: 0;
+    height: 100dvh;
+    max-height: 100dvh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
     padding: 1px;
     border-radius: 12px;
     box-shadow: 2px 0 10px rgba(0, 0, 0, 0.1);
     background: rgba(118, 122, 126, 0.9);
+  }
+
+  .flex-col :global(.sidebar-card-wrapper) {
+    flex: 1 1 auto;
+    min-height: 0;
+    height: 100%;
   }
 </style>

--- a/frontend/src/navigation/Sidebar.svelte
+++ b/frontend/src/navigation/Sidebar.svelte
@@ -6,24 +6,24 @@
   import ProfileMenu from './ProfileMenu.svelte'
   import { slide as slyde } from 'svelte/transition'
 
-  // This is how many pixels we need to display the entire sidebar.
-  // If you add elements to pages.ts, you may need to increase this.
+  // Desktop only: stretch the sidebar card up to the content height so a
+  // tall Config page does not leave a short sticky nav. Mobile ignores this
+  // and fills the viewport drawer instead.
   const h: number = 900
-  // The slide parameters have to match the parent element, so it's passed in.
-  let { slide = { duration: 600, axis: 'x' }, height = h } = $props()
-  // This is a hack to get the sidebar to expand up to the height of the content.
-  const style = $derived(`max-height: ${height > h ? height + 1 : h}px !important;`)
+  let { slide = { duration: 600, axis: 'x' }, height = h, isMobile = false } = $props()
+  const style = $derived(
+    isMobile ? '' : `max-height: ${height > h ? height + 1 : h}px !important;`,
+  )
 </script>
 
-<div class="sidebar-card-wrapper" transition:slyde={slide} {style}>
+<div class="sidebar-card-wrapper" class:mobile={isMobile} transition:slyde={slide} {style}>
   <Card body class="sidebar-card pb-2" theme={$theme}>
-    <!-- Settings -->
-    <Section title="Settings" pages={settings} />
-    <div class="section-divider"></div>
-    <!-- Insights -->
-    <Section title="Insights" pages={insights} />
-    <!-- Profile Dropdown -->
-    <div class="mt-auto pt-2">
+    <div class="sidebar-scroll">
+      <Section title="Settings" pages={settings} />
+      <div class="section-divider"></div>
+      <Section title="Insights" pages={insights} />
+    </div>
+    <div class="sidebar-profile mt-auto pt-2">
       <div class="section-divider"></div>
       <ProfileMenu />
     </div>
@@ -41,6 +41,14 @@
     min-height: calc(100vh - 150px);
   }
 
+  .sidebar-card-wrapper.mobile {
+    position: static;
+    top: auto;
+    min-height: 0;
+    height: 100%;
+    overflow: hidden;
+  }
+
   .section-divider {
     height: 2px;
     background-color: var(--bs-secondary-bg-subtle);
@@ -52,6 +60,26 @@
     border-radius: 12px;
     padding: 10px 5px 10px 5px;
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+  }
+
+  .sidebar-card-wrapper.mobile :global(.sidebar-card) {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .sidebar-card-wrapper.mobile .sidebar-scroll {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .sidebar-profile {
+    flex-shrink: 0;
   }
 
   /* These styles are used by ProfileMenu.svelte and Section.svelte */


### PR DESCRIPTION
## Summary
- Pin the profile dropdown at the bottom of the mobile drawer and let Settings/Insights scroll on their own, so Trust Profile stays reachable on short pages such as Home ([#1303](https://github.com/Notifiarr/notifiarr/issues/1303)).
- Size the drawer with `100dvh` instead of a 900px cap tied to page height, and only close the overlay when shrinking from desktop to mobile (not on rotation).

## Test plan
- [ ] Phone or narrow desktop: Home → Show Menu → Trust Profile is visible without scrolling the page
- [ ] Home: scroll the middle of the menu independently of the profile block
- [ ] Config (tall page): menu still works; profile stays at the bottom of the drawer
- [ ] Rotate the phone with the menu open; it should stay open
- [ ] Desktop (>1005px): sticky sidebar still stretches with tall content


Made with [Cursor](https://cursor.com)