### PR TITLE
Mobile nav follow-ups: backdrop, Back guard, toast width

### DIFF
--- a/frontend/src/assets/app.css
+++ b/frontend/src/assets/app.css
@@ -13,15 +13,14 @@
   --toastContainerTop: 5rem;
   --toastContainerRight: auto;
   --toastContainerBottom: auto;
-  --toastContainerLeft: calc(50vw - 15rem);
-  --toastWidth: 30rem;
+  --toastWidth: min(30rem, calc(100vw - 2rem));
+  --toastContainerLeft: max(1rem, calc((100vw - min(30rem, 100vw - 2rem)) / 2));
 }
 
 html,
 body {
   margin: 0;
-  min-height: 100%;
-  height: 100vh;
+  min-height: 100dvh;
 }
 
 /* https://github.com/react-bootstrap/react-bootstrap/issues/6796 */

--- a/frontend/src/navigation/Index.svelte
+++ b/frontend/src/navigation/Index.svelte
@@ -43,9 +43,18 @@
 
 <svelte:window
   bind:innerWidth={() => windowWidth, setWindowWidth}
-  on:popstate={e => nav.popstate(e)} />
+  onpopstate={e => nav.popstate(e)} />
 
 <Modals />
+
+{#if isMobile && sidebarOpen}
+  <button
+    type="button"
+    class="sidebar-backdrop"
+    aria-label={$_('buttons.HideMenu')}
+    onclick={closeSidebar}>
+  </button>
+{/if}
 
 {#if isMobile}
   <div class="menu-toggle-wrapper">
@@ -131,6 +140,17 @@
     gap: 8px;
     width: 100%;
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  }
+
+  .sidebar-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 1015;
+    margin: 0;
+    border: 0;
+    padding: 0;
+    background: rgba(0, 0, 0, 0.4);
+    cursor: pointer;
   }
 
   /* Mobile drawer: fill the visual viewport and let Sidebar scroll internally. */

--- a/frontend/src/navigation/nav.svelte.ts
+++ b/frontend/src/navigation/nav.svelte.ts
@@ -27,6 +27,8 @@ class Navigator {
   public showUnsavedAlert = $state('')
   /** This is used to force a navigation event even if there are unsaved changes. */
   public forceEvent = { type: 'force', preventDefault: () => { } } as Event
+  // Ignore the synthetic popstate from history.go(1) after blocking Back.
+  private ignorePop = false
 
   /** Call this in the onMount function of the parent component to set the initial page. */
   public onMount = () => {
@@ -62,7 +64,7 @@ class Navigator {
     }
 
     if (this.formChanged && event?.type !== 'force' && pid !== this.activePage) {
-      this.showUnsavedAlert = pid
+      this.showUnsavedAlert = pid || 'Landing'
       return
     }
 
@@ -92,15 +94,33 @@ class Navigator {
 
   // popstate is split from goto(), so we can call it from popstate.
   /**  Call this only when the back button is clicked. */
-  public popstate = (e: PopStateEvent) => (
-    e.preventDefault(),
-    this.setActivePage(e.state?.uri ?? '')
-  )
+  public popstate = (e: PopStateEvent) => {
+    e.preventDefault()
+
+    if (this.ignorePop) {
+      this.ignorePop = false
+      return
+    }
+
+    closeSidebar()
+
+    const pid = e.state?.uri ?? ''
+    if (this.formChanged && pid !== this.activePage) {
+      this.ignorePop = true
+      window.history.go(1)
+      this.showUnsavedAlert = pid || 'Landing'
+      return
+    }
+
+    this.setActivePage(pid)
+  }
 
   /** active returns true if the provided page id is currently selected. */
   public active = (page: string): boolean => iequals(this.activePage, page)
 
   private setActivePage = (newPage: string): string => {
+    if (iequals(newPage, 'Landing')) newPage = ''
+
     const page = allPages.find(p => iequals(p.path ?? p.id, newPage))
     this.ActivePage = page?.component || Landing
     return (this.activePage = page ? (page.path ?? page.id) : '')


### PR DESCRIPTION
## Summary
- Close the mobile drawer by tapping the dimmed backdrop (the Hide Menu control sat under the overlay).
- Browser Back now restores the current page and shows the unsaved-changes modal instead of discarding edits; it also closes the drawer.
- Clamp toast width/position so 30rem toasts do not overflow phones; use `100dvh` for the document min-height.

Stacked on #1307. Merge that first, then this.

## Test plan
- [ ] Phone: Show Menu, tap the dimmed area beside the drawer → menu closes
- [ ] Edit Config, hit Back → unsaved modal appears; Stay keeps Config; Leave goes to the previous page
- [ ] Edit Config, click the logo → unsaved modal appears (Landing target)
- [ ] Trigger a toast on a ~375px-wide viewport; it stays on screen


Made with [Cursor](https://cursor.com)