### PR TITLE
Fix unstable.golift.io upload curl YAML

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,18 +160,18 @@ jobs:
         with:
           name: ${{ matrix.files }}
       - name: Upload files to unstable.golift.io
-        run: >-
-          set -euo pipefail;
+        run: |
+          set -euo pipefail
           for file in *.{zip,dmg,gz}; do
-            [ -f "$file" ] || continue;
-            echo "Uploading: ${file}";
-            curl -sS --fail-with-body --retry 5 --retry-all-errors --retry-delay 2
-            -H "X-API-KEY: ${{ secrets.UNSTABLE_UPLOAD_KEY }}"
-            "https://unstable.golift.io/upload.php?folder=notifiarr" -F "file=@${file}";
-            echo '{"version":"${{needs.release.outputs.version}}","revision":${{needs.release.outputs.revision}},"size":'$(stat --printf="%s" ${file})'}' >> ${file}.txt
-            curl -sS --fail-with-body --retry 5 --retry-all-errors --retry-delay 2
-            -H "X-API-KEY: ${{ secrets.UNSTABLE_UPLOAD_KEY }}"
-            "https://unstable.golift.io/upload.php?folder=notifiarr" -F "file=@${file}.txt";
+            [ -f "$file" ] || continue
+            echo "Uploading: ${file}"
+            curl -sS --fail-with-body --retry 5 --retry-all-errors --retry-delay 2 \
+              -H "X-API-KEY: ${{ secrets.UNSTABLE_UPLOAD_KEY }}" \
+              "https://unstable.golift.io/upload.php?folder=notifiarr" -F "file=@${file}"
+            echo '{"version":"${{needs.release.outputs.version}}","revision":${{needs.release.outputs.revision}},"size":'$(stat --printf="%s" "${file}")'}' >> "${file}.txt"
+            curl -sS --fail-with-body --retry 5 --retry-all-errors --retry-delay 2 \
+              -H "X-API-KEY: ${{ secrets.UNSTABLE_UPLOAD_KEY }}" \
+              "https://unstable.golift.io/upload.php?folder=notifiarr" -F "file=@${file}.txt"
           done
 
   deploy-unstable-packagecloud:


### PR DESCRIPTION
## Summary
- Folded `run: >-` only joins same-indent lines, so the more-indented `curl` flags stayed as real newlines. Bash then ran `curl` with no URL (`curl: (2) no URL specified`) and the dmg-release deploy died.
- The metadata `echo … >> file.txt` was also missing a terminator before the next `curl`, so a real fold would have glued those two commands together.
- Switch that step to a literal block with `\` continuations so each `curl` is one command.

## Test plan
- [ ] Merge to `unstable` and confirm both `GoLift Unstable Deploy (release)` and `(dmg-release)` upload zip/dmg/gz plus sidecar `.txt`
- [ ] Confirm the step no longer logs `curl: (2) no URL specified`


Made with [Cursor](https://cursor.com)