### PR TITLE
Keep Input validation classes when callers pass class.

### DIFF
--- a/frontend/src/includes/Input.svelte
+++ b/frontend/src/includes/Input.svelte
@@ -81,6 +81,7 @@
     inner = $bindable(),
     noDisable = false,
     envVar,
+    class: restClass,
     ...rest
   }: Props = $props()
 
@@ -195,7 +196,7 @@
       {@render pre?.()}
       <Input
         {id}
-        class="{inputClass} {changed ? 'changed' : ''}"
+        class={[inputClass, changed && 'changed', restClass]}
         type={currType as InputType}
         bind:inner
         bind:value


### PR DESCRIPTION
## Summary
- Pull `class` out of Input's rest props and merge it with `is-valid` / `is-invalid` / `changed`.
- Callers like `serviceChecks.disabled` can pass `class="mb-0"` without wiping dirty/validation highlighting.

## Test plan
- [ ] Open a form field that passes `class` (service checks disabled) and confirm Bootstrap/dirty classes still apply when the value changes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>