### PR TITLE
Stop Input addon buttons from submitting forms.

### DIFF
--- a/frontend/src/includes/Input.svelte
+++ b/frontend/src/includes/Input.svelte
@@ -179,6 +179,7 @@
     <InputGroup>
       {#if tooltip != id + '.tooltip' || (envVar && !rest.disabled)}
         <Button
+          type="button"
           color="secondary"
           onclick={toggleTooltip}
           outline

--- a/frontend/src/includes/fileBrowser/BButton.svelte
+++ b/frontend/src/includes/fileBrowser/BButton.svelte
@@ -7,6 +7,6 @@
   const click = () => (onclick?.(), (isOpen = true))
 </script>
 
-<Button outline onclick={click} style="width:44px;">
+<Button type="button" outline onclick={click} style="width:44px;">
   <Fa i={FolderOpen} btn c1="Gold" d1="Moccasin" />
 </Button>

--- a/frontend/src/pages/endpoints/Endpoint.svelte
+++ b/frontend/src/pages/endpoints/Endpoint.svelte
@@ -95,6 +95,7 @@
           {validate}>
           {#snippet post()}
             <Button
+              type="button"
               color="secondary"
               outline
               style="width:44px;"


### PR DESCRIPTION
## Summary
- Set `type="button"` on Input tooltip, file-browser, and endpoint follow-redirect addon buttons.
- sveltestrap Button defaults to submit, so those addons were submitting the surrounding form.

## Test plan
- [ ] Click the tooltip / file-browser / follow-redirect addon on a settings form and confirm the form does not submit.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>