### PR TITLE
Hide environment-variable copy unless envVar is set.

### DIFF
--- a/frontend/src/includes/Input.svelte
+++ b/frontend/src/includes/Input.svelte
@@ -256,7 +256,7 @@
     {#if showTooltip}
       <div transition:slide>
         <Card body class="mt-1" color="warning" outline>
-          {#if !rest.disabled}
+          {#if envVar && !rest.disabled}
             <ul class="mb-0">
               <li><T id="phrases.EnvironmentVariable" variableName={env} /></li>
             </ul>


### PR DESCRIPTION
## Summary
- Render environment-variable copy only when `envVar` is set and the field is not disabled.
- Fields with only a tooltip no longer show `DN_undefined`.
<img width="721" height="300" alt="Screenshot 2026-09-01 at 12 33 44 AM" src="https://github.com/user-attachments/assets/d0308429-badb-43bf-840d-aee2669b12c3" />

## Test plan
- [ ] Tooltip-only fields do not mention an environment variable.
- [ ] A field with `envVar` still shows `DN_*` in the tooltip card.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>