### PR TITLE
Stop binding checked on every Input.

### DIFF
--- a/frontend/src/includes/Input.svelte
+++ b/frontend/src/includes/Input.svelte
@@ -201,7 +201,6 @@
         type={currType as InputType}
         bind:inner
         bind:value
-        bind:checked={value}
         autocomplete="off"
         {placeholder}
         {...rest}>


### PR DESCRIPTION
## Summary
- Drop `bind:checked={value}` from Input.
- sveltestrap only uses `checked` for checkbox/radio/switch; pairing it with `value` on text and select fields is incorrect.

## Test plan
- [ ] Text, select, interval, and timeout fields still bind and save.
- [ ] Boolean Enabled/Disabled selects still toggle.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>