### PR TITLE
Make boolean Enabled/Disabled inversion an explicit prop.

### DIFF
--- a/frontend/src/includes/Input.svelte
+++ b/frontend/src/includes/Input.svelte
@@ -56,6 +56,8 @@
     inner?: any
     /** When type is "timeout" this controls if -1 / disabled is an option. */
     noDisable?: boolean
+    /** Invert Enabled/Disabled select values (true = Disabled). Defaults to id ending in "disabled". */
+    invert?: boolean
     /** If this env var is set a notice is provided to the user as such. */
     envVar?: string
     /** Optional other attributes to apply to the input. */
@@ -80,6 +82,7 @@
     msg,
     inner = $bindable(),
     noDisable = false,
+    invert,
     envVar,
     class: restClass,
     ...rest
@@ -113,6 +116,7 @@
   const inputClass = $derived(!!feedback ? 'is-invalid' : changed ? 'is-valid' : '')
   const env = $derived('DN_' + envVar?.toUpperCase())
   const hasEnv = $derived(!rest.disabled && !!envVar && !!$profile.environment?.[env])
+  const inverted = $derived(invert ?? id.endsWith('disabled'))
   const selectOptions = $derived.by((): Option[] | undefined => {
     if (type === 'interval') {
       return [
@@ -230,13 +234,10 @@
             </option>
           {/each}
         {:else if typeof value === 'boolean' && type === 'select'}
-          <!-- Create a boolean select-option list: Enabled/Disabled
-           If the name of the input ends with 'disabled', then the values are inverted.
-           -->
-          <option value={id.endsWith('disabled') ? true : false}>
+          <option value={inverted}>
             {$_('words.select-option.Disabled')}
           </option>
-          <option value={id.endsWith('disabled') ? false : true}>
+          <option value={!inverted}>
             {$_('words.select-option.Enabled')}
           </option>
         {/if}


### PR DESCRIPTION
## Summary
- Add an explicit `invert` prop for boolean Enabled/Disabled selects.
- Default remains `id.endsWith('disabled')` so existing Starr/Plex fields keep working.

## Test plan
- [ ] A `*.disabled` field still treats true as Disabled.
- [ ] Passing `invert={false}` treats true as Enabled.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>