### PR TITLE
Make Input dirty highlighting beat Bootstrap is-valid.

### DIFF
--- a/frontend/src/includes/CheckedInput.svelte
+++ b/frontend/src/includes/CheckedInput.svelte
@@ -158,9 +158,3 @@
     </Input>
   </div>
 {/if}
-
-<style>
-  .checked-input :global(.changed) {
-    background-color: rgba(205, 92, 92, 0.322);
-  }
-</style>

--- a/frontend/src/includes/Input.svelte
+++ b/frontend/src/includes/Input.svelte
@@ -294,8 +294,11 @@
     font-family: Verdana, Geneva, Tahoma, sans-serif;
   }
 
-  .input :global(.changed) {
-    background-color: rgba(205, 92, 92, 0.322);
+  /* Beat Bootstrap .form-control.is-valid / .form-select.is-valid. */
+  .input :global(.form-control.changed),
+  .input :global(.form-select.changed),
+  .input :global(.btn.changed) {
+    background-color: rgba(205, 92, 92, 0.322) !important;
   }
 
   .input :global(.input-group > .btn) {

--- a/frontend/src/pages/endpoints/Endpoint.svelte
+++ b/frontend/src/pages/endpoints/Endpoint.svelte
@@ -186,9 +186,3 @@
     </Row>
   </div>
 {/if}
-
-<style>
-  .endpoint :global(.changed) {
-    background-color: rgba(205, 92, 92, 0.322) !important;
-  }
-</style>

--- a/frontend/src/pages/serviceChecks/Check.svelte
+++ b/frontend/src/pages/serviceChecks/Check.svelte
@@ -113,9 +113,3 @@
     </Row>
   </div>
 {/if}
-
-<style>
-  .serviceCheck :global(.changed) {
-    background-color: rgba(205, 92, 92, 0.322) !important;
-  }
-</style>

--- a/frontend/src/pages/serviceChecks/HTTP.svelte
+++ b/frontend/src/pages/serviceChecks/HTTP.svelte
@@ -138,4 +138,8 @@
     font-family: Verdana, Geneva, Tahoma, sans-serif;
     font-weight: 550;
   }
+
+  .http-group :global(.changed) {
+    background-color: rgba(205, 92, 92, 0.322) !important;
+  }
 </style>


### PR DESCRIPTION
## Summary
- Give `.changed` higher specificity than Bootstrap `is-valid` on Input controls.
- Remove duplicate `.changed` CSS from CheckedInput, Endpoint, and service Checks now that the parent Input wrapper owns it.

## Test plan
- [ ] Dirty fields show the salmon highlight even when Bootstrap marks them valid.
- [ ] Check instance / follow-redirect addons still highlight when changed.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>