### PR TITLE
Stop checkbox addons from toggling twice and translate their titles.

### DIFF
--- a/frontend/src/includes/CheckedInput.svelte
+++ b/frontend/src/includes/CheckedInput.svelte
@@ -6,7 +6,6 @@
   import Checks from 'phosphor-svelte/lib/Checks'
   import CheckCircle from 'phosphor-svelte/lib/CheckCircle'
   import XCircle from 'phosphor-svelte/lib/XCircle'
-  import { get } from 'svelte/store'
   import type { App } from './formsTracker.svelte'
   import Input from './Input.svelte'
   import { delay, maxLength } from './util'
@@ -42,28 +41,27 @@
   let ok = $state(undefined as boolean | undefined)
   let body = $state('')
   let testing = $state(false)
+  const https = $derived(id === 'url' && form?.[id]?.toString()?.startsWith('https://'))
 
   const checkInstance = async (e: Event) => {
     e.preventDefault()
     if (!form) return
     body = ''
     testing = true
-
-    let p = ''
     try {
+      let p = ''
       if (params) p = `?${(await params()).toString()}`
       else await delay(300) // satisfying spinner.
+      const uri = 'checkInstance/' + app.name.toLowerCase() + '/' + index + p
+      const data = app.merge(index, form)
+      const res = await postUi(uri, JSON.stringify(data), false)
+      ok = res.ok
+      body = res.body
     } catch {
+      // params() can throw when extra query data is not ready.
+    } finally {
       testing = false
-      return
     }
-
-    const uri = 'checkInstance/' + app.name.toLowerCase() + '/' + index + p
-    const data = app.merge(index, form)
-    const res = await postUi(uri, JSON.stringify(data), false)
-    ok = res.ok
-    body = res.body
-    testing = false
   }
 </script>
 
@@ -72,11 +70,16 @@
     style="width:44px;"
     type="button"
     outline
-    title="Validate SSL certificate"
+    title={$_('phrases.ValidateSSL')}
+    aria-pressed={!!form?.['validSsl']}
     color="notifiarr"
     class={form?.['validSsl'] !== original?.['validSsl'] ? 'changed' : ''}
     onclick={() => form && (form['validSsl'] = !form['validSsl'])}>
-    <Box type="checkbox" bind:checked={form['validSsl']} />
+    <Box
+      type="checkbox"
+      checked={!!form['validSsl']}
+      tabindex={-1}
+      style="pointer-events:none" />
   </Button>
 {/snippet}
 
@@ -85,11 +88,16 @@
     style="width:44px;"
     type="button"
     outline
-    title="Run as shell command"
+    title={$_('phrases.RunAsShell')}
+    aria-pressed={!!form?.['shell']}
     color="notifiarr"
     class={form?.['shell'] !== original?.['shell'] ? 'changed' : ''}
     onclick={() => form && (form['shell'] = !form['shell'])}>
-    <Box type="checkbox" bind:checked={form['shell']} />
+    <Box
+      type="checkbox"
+      checked={!!form['shell']}
+      tabindex={-1}
+      style="pointer-events:none" />
   </Button>
 {/snippet}
 
@@ -100,8 +108,8 @@
       bind:value={form[id]}
       original={original?.[id] ?? undefined}
       disabled={app.disabled?.includes(id.toString())}
-      description={id === 'url' && form[id]?.toString()?.startsWith('https://')
-        ? get(_)('words.instance-options.validSsl.description')
+      description={https
+        ? $_('words.instance-options.validSsl.description')
         : rest.description}
       {envVar}
       {...rest}>
@@ -111,7 +119,7 @@
           style="width:44px;"
           type="button"
           outline
-          title="Check instance"
+          title={$_('phrases.CheckInstance')}
           color="notifiarr"
           disabled={testing || disabled}
           onclick={checkInstance}>
@@ -129,7 +137,7 @@
 
       <!-- If they type in an https:// url, add a checkbox to validate the SSL certificate. -->
       {#snippet post()}
-        {#if id === 'url' && form[id]?.startsWith('https://')}
+        {#if https}
           {@render validSsl()}
         {:else if id === 'command'}
           {@render shell()}

--- a/frontend/src/includes/fileBrowser/BButton.svelte
+++ b/frontend/src/includes/fileBrowser/BButton.svelte
@@ -2,11 +2,18 @@
   import { Button } from '@sveltestrap/sveltestrap'
   import Fa from '../Fa.svelte'
   import FolderOpen from 'phosphor-svelte/lib/FolderOpen'
+  import { _ } from '../Translate.svelte'
   type Props = { onclick?: () => void; isOpen?: boolean }
   let { onclick, isOpen = $bindable(false) }: Props = $props()
   const click = () => (onclick?.(), (isOpen = true))
 </script>
 
-<Button type="button" outline onclick={click} style="width:44px;">
+<Button
+  type="button"
+  outline
+  onclick={click}
+  style="width:44px;"
+  title={$_('phrases.BrowseFiles')}
+  aria-label={$_('phrases.BrowseFiles')}>
   <Fa i={FolderOpen} btn c1="Gold" d1="Moccasin" />
 </Button>

--- a/frontend/src/includes/locale/en.json
+++ b/frontend/src/includes/locale/en.json
@@ -167,6 +167,11 @@
     "ShowMore": "Show more information",
     "ShowPassword": "Show password",
     "HidePassword": "Hide password",
+    "CheckInstance": "Check instance",
+    "ValidateSSL": "Validate SSL certificate",
+    "RunAsShell": "Run as shell command",
+    "FollowRedirects": "Follow redirects",
+    "BrowseFiles": "Browse files",
     "APIKey": {
       "title": "Provide API Key",
       "placeholder": "Global API key from notifiarr.com",

--- a/frontend/src/pages/endpoints/Endpoint.svelte
+++ b/frontend/src/pages/endpoints/Endpoint.svelte
@@ -99,9 +99,16 @@
               color="secondary"
               outline
               style="width:44px;"
-              title="Follow redirects"
-              class={form.follow === original?.follow ? '' : 'changed'}>
-              <Box type="checkbox" id={app.id + '.follow'} bind:checked={form.follow} />
+              title={$_('phrases.FollowRedirects')}
+              aria-pressed={!!form.follow}
+              class={form.follow === original?.follow ? '' : 'changed'}
+              onclick={() => (form.follow = !form.follow)}>
+              <Box
+                type="checkbox"
+                id={app.id + '.follow'}
+                checked={!!form.follow}
+                tabindex={-1}
+                style="pointer-events:none" />
             </Button>
           {/snippet}
         </Input>


### PR DESCRIPTION
## Summary
- Checkbox-in-button addons no longer bind `checked` on a nested control that also handles the click (double toggle).
- Translate addon titles and always clear the instance-check spinner if the request throws.

## Test plan
- [ ] Check instance, follow redirects, run-as-shell, and file-browser addons toggle once per click.
- [ ] A failed instance check still clears the spinner.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>