### PR TITLE
Stop binding Input to derived lists and restore Nvidia validation.

### DIFF
--- a/frontend/src/includes/Instance.svelte
+++ b/frontend/src/includes/Instance.svelte
@@ -42,14 +42,18 @@
 
   /** Array converted to newline-separated string for textarea. */
   let busIds: string = $state(form?.busIDs?.join('\n') ?? '')
-  /** Rows for textarea based on count of newlines. */
-  const rows = $derived(busIds.split('\n').length < 10 ? busIds.split('\n').length : 1)
-  // Update form variables if they existed prior to this effect.
-  $effect(() => {
-    // form.smiPath and form.busIDs only exist on Nvidia. form can be undefined while an
-    // instance accordion is closing after delete (this component is shared by Starr apps).
-    if (form && typeof form.smiPath !== 'undefined') form.busIDs = busIds.split(/\s+/)
-  })
+  const rows = $derived(Math.min(Math.max(busIds.split('\n').length, 1), 10))
+
+  function applyBusIds() {
+    if (!form || typeof form.smiPath === 'undefined') return
+    const ids = busIds.split(/\s+/).filter((id: string) => id.length)
+    form.busIDs = ids.length ? ids : ['']
+  }
+
+  function resetInstance() {
+    reset?.()
+    busIds = original?.busIDs?.join('\n') ?? ''
+  }
 
   /** Shorthand variable to set Col sizes for username and password inputs. */
   const hasToken = $derived(
@@ -253,6 +257,7 @@
             original={original?.busIDs?.join('\n') ?? ''}
             envVar={envPrefix + '_BUS_IDS'}
             disabled={app.disabled?.includes('busIds')}
+            oninput={applyBusIds}
             {validate} />
         </Col>
       {/if}
@@ -261,7 +266,7 @@
     <!-- Show an optional reset button if the form has changes. -->
     {#if reset && !deepEqual(form, original)}
       <div class="mb-2" transition:slide>
-        <Button color="primary" outline onclick={reset} class="float-end">
+        <Button color="primary" outline onclick={resetInstance} class="float-end">
           {$_('buttons.ResetForm')}
         </Button>
         &nbsp;

--- a/frontend/src/includes/InstancesTab.svelte
+++ b/frontend/src/includes/InstancesTab.svelte
@@ -52,7 +52,8 @@
         indexed={false}
         bind:form={flt.instances[0]}
         original={flt.original[0]}
-        app={flt.app} />
+        app={flt.app}
+        validate={(id, value) => flt.validate(id, value, 0)} />
     {:else if !one}
       <Instances bind:flt Child={Instance}>
         {#snippet headerActive(index)}

--- a/frontend/src/pages/configuration/Index.svelte
+++ b/frontend/src/pages/configuration/Index.svelte
@@ -21,7 +21,7 @@
   // Local state that syncs with profile store.
   let config = $state($profile.config)
   // Convert array to newline-separated string for textarea
-  let extraKeys = $derived($profile.config.extraKeys?.join('\n') ?? '')
+  let extraKeys = $state(config.extraKeys?.join('\n') ?? '')
   const rows = $derived(
     extraKeys.split('\n').length > 10 ? 10 : extraKeys.split('\n').length,
   )
@@ -33,7 +33,10 @@
   }
 
   const reset = (ok: boolean) => {
-    if (ok) config = $profile.config
+    if (ok) {
+      config = $profile.config
+      extraKeys = config.extraKeys?.join('\n') ?? ''
+    }
   }
 
   // Reset config when profile is updated (when reload button is clicked).


### PR DESCRIPTION
## Summary
- Stop binding Input to derived lists for extra keys and GPU bus IDs.
- Bus ID rows cap between 1 and 10; the single-instance Nvidia tab gets the same validator as other apps.

## Test plan
- [ ] Extra config keys and Nvidia bus IDs edit, reset, and save without fighting derived state.
- [ ] Nvidia `one` instance mode still validates like the list view.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>