### PR TITLE
Give Input an explicit showChanged flag and wire profile originals.

### DIFF
--- a/frontend/src/includes/Input.svelte
+++ b/frontend/src/includes/Input.svelte
@@ -38,6 +38,8 @@
     value?: any
     /** Optional original value. Used to check for changes.*/
     original?: any
+    /** When false, skip dirty highlighting. Defaults to true. */
+    showChanged?: boolean
     /** Optional badge to display on the input header. */
     badge?: string
     /** Optional options for select input. */
@@ -71,6 +73,7 @@
     tooltip,
     value = $bindable(undefined),
     original = value,
+    showChanged = true,
     options = undefined,
     validate,
     pre,
@@ -96,7 +99,7 @@
 
   let showTooltip = $state(false)
   let revealed = $state(false)
-  let changed = $derived(original !== null && !deepEqual(value, original))
+  let changed = $derived(showChanged && original !== null && !deepEqual(value, original))
   const currType = $derived(
     type === 'interval' || type === 'timeout'
       ? 'select'

--- a/frontend/src/includes/TestRegex.svelte
+++ b/frontend/src/includes/TestRegex.svelte
@@ -34,13 +34,13 @@
   type="textarea"
   bind:value={test}
   rows={1}
-  original={null} />
+  showChanged={false} />
 <Input
   id={'RegexTester.testPattern'}
   type="textarea"
   bind:value={pattern}
   rows={1}
-  original={null} />
+  showChanged={false} />
 
 {#if pattern && test}
   <div transition:slide>

--- a/frontend/src/pages/profile/Index.svelte
+++ b/frontend/src/pages/profile/Index.svelte
@@ -90,6 +90,7 @@
           id="profile.authType"
           type="select"
           bind:value={form.authType}
+          original={$profile?.upstreamType}
           options={[
             { value: Auth.password, name: $_('profile.authType.options.password') },
             { value: Auth.website, name: $_('profile.authType.options.website') },
@@ -110,6 +111,7 @@
           id="profile.upstreams"
           type="text"
           bind:value={form.upstreams}
+          original={origUpstreams}
           placeholder={$_('profile.upstreams.placeholder')} />
       </Col>
     </Row>
@@ -119,20 +121,22 @@
     {#if authType === Auth.header || authType === Auth.noauth}
       <Row>
         <Col md={8}>
-          <Input id="profile.header" type="select" bind:value={form.header}>
+          <Input
+            id="profile.header"
+            type="select"
+            bind:value={form.header}
+            original={$profile?.upstreamHeader || ''}>
             {#each Object.entries($profile?.headers || {}) as [key, value]}
               {#each value! as val}
-                <option
-                  value={key}
-                  selected={form.header.toLowerCase() === key.toLowerCase()}>
+                <option value={key}>
                   {key} ({val})
                 </option>
               {/each}
             {/each}
             {#if form.header === ''}
-              <option value={form.header} selected>(none)</option>
+              <option value={form.header}>(none)</option>
             {:else if !$profile?.headers?.[form.header]}
-              <option value={form.header} selected>
+              <option value={form.header}>
                 {form.header} (other)
               </option>
             {/if}
@@ -146,12 +150,17 @@
             id="profile.newPass"
             name="noautofill"
             type="password"
-            bind:value={form.newPass} />
+            bind:value={form.newPass}
+            original="" />
         </Col>
       </Row>
       <Row>
         <Col md={8}>
-          <Input id="profile.username" type="text" bind:value={form.username} />
+          <Input
+            id="profile.username"
+            type="text"
+            bind:value={form.username}
+            original={$profile?.username || ''} />
         </Col>
       </Row>
     {/if}
@@ -164,7 +173,8 @@
             id="profile.password"
             name="password"
             type="password"
-            bind:value={form.password} />
+            bind:value={form.password}
+            showChanged={false} />
         </Col>
       </Row>
     {/if}


### PR DESCRIPTION
## Summary
- Add `showChanged` so scratch fields can skip dirty highlighting without passing `original={null}`.
- Wire profile form `original` values; keep current-password off dirty highlighting.

## Test plan
- [ ] Profile fields highlight when changed and clear after save/reset.
- [ ] Test regex fields do not show dirty highlighting.
- [ ] Current password never shows as changed.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>