### PR TITLE
Modernize leftover Svelte 4 event, slot, and bind patterns.

### DIFF
--- a/frontend/src/Login.svelte
+++ b/frontend/src/Login.svelte
@@ -18,7 +18,7 @@
   let password = $state('')
   let isLoading = $state(false)
   let helpModal = $state<Nodal>()
-  let { error } = $props()
+  let { error = $bindable('') } = $props()
 
   async function onsubmit(e: Event) {
     e.preventDefault()

--- a/frontend/src/includes/Fa.svelte
+++ b/frontend/src/includes/Fa.svelte
@@ -132,7 +132,14 @@
     flip === true || flip === 'h' || flip === 'horizontal' || flip === 'both',
   )
   const flipV = $derived(flip === 'v' || flip === 'vertical' || flip === 'both')
-  const handleClick = (e: Event) => (e.preventDefault(), onclick?.())
+  const handleClick = (e: Event) => {
+    if (onclick) {
+      e.preventDefault()
+      onclick()
+      return
+    }
+    if (!href || href === '#anotherPage') e.preventDefault()
+  }
 </script>
 
 {#snippet glyph()}
@@ -150,7 +157,7 @@
         'has-c1': !!primaryColor,
       },
     ]}
-    id={id != null ? 'fa-icon' + id : undefined}
+    id,
     style="--icon-c1: {primaryColor ??
       'currentColor'}; --icon-c2: {secondaryColor ??
       'currentColor'}; font-size: {size}; {style}">

--- a/frontend/src/includes/Nodal.svelte
+++ b/frontend/src/includes/Nodal.svelte
@@ -136,11 +136,12 @@
       <ButtonGroup class="float-end">
         {#if get}
           <Button
+            type="button"
             id="refreshM"
             outline
             color="secondary"
             size="sm"
-            on:click={refresh}
+            onclick={refresh}
             aria-label={$_('Nodal.button.refresh')}
             title={$_('Nodal.button.refresh')}>
             <Fa
@@ -156,11 +157,12 @@
           </Popover>
           {#if resp && resp.ok}
             <Button
+              type="button"
               id="rawM"
               outline
               color="secondary"
               size="sm"
-              on:click={() => (showRaw = !showRaw)}>
+              onclick={() => (showRaw = !showRaw)}>
               <Fa i={ArrowsLeftRight} c1="steelblue" c2="firebrick" d2="pink" btn />
             </Button>
             <Popover target="rawM" trigger="hover" theme={$theme}>
@@ -170,11 +172,12 @@
         {/if}
 
         <Button
+          type="button"
           id="fullscreenM"
           outline
           color="secondary"
           size="sm"
-          on:click={() => (fullscreen = !fullscreen)}
+          onclick={() => (fullscreen = !fullscreen)}
           aria-label={$_('Nodal.button.fullscreen')}
           title={$_('Nodal.button.fullscreen')}>
           <Fa
@@ -189,13 +192,14 @@
         </Popover>
 
         <Button
+          type="button"
           id="closeM"
           outline
           color="secondary"
           size="sm"
           title={$_('buttons.Close')}
           aria-label={$_('buttons.Close')}
-          on:click={close}
+          onclick={close}
           {disabled}>
           <Fa i={X} c2="orange" d2="gold" btn />
         </Button>

--- a/frontend/src/navigation/ProfileMenu.svelte
+++ b/frontend/src/navigation/ProfileMenu.svelte
@@ -19,8 +19,11 @@
   import { page as LanguagesPage } from '../pages/stubs/Languages.svelte'
   import { closeSidebar } from './Index.svelte'
 
-  let newLang = $derived(locale.current)
-  const onchange = () => (locale.set(newLang), closeSidebar())
+  const onchange = (e: Event) => {
+    const code = (e.currentTarget as HTMLSelectElement).value
+    locale.set(code)
+    closeSidebar()
+  }
 </script>
 
 <Nav vertical pills class="nav-custom" theme={$theme}>
@@ -42,9 +45,9 @@
         {$_('navigation.titles.' + ProfilePage.id)}
       </DropdownItem>
       <span class="lang-wrapper">
-        <Input type="select" bind:value={newLang} {onchange}>
+        <Input type="select" value={locale.current} {onchange}>
           {#each Object.entries($profile.languages?.[locale.current] || {}) as [code, lang]}
-            <option value={code} selected={code === locale.current}>
+            <option value={code}>
               {Flags[code]}&nbsp;&nbsp; {lang.name}
             </option>
           {/each}

--- a/frontend/src/pages/commands/Command.svelte
+++ b/frontend/src/pages/commands/Command.svelte
@@ -138,14 +138,15 @@
     <p><b class="text-primary font-monospace">{form.command}</b></p>
     {#each form.argValues ?? [] as arg, i}
       <FormGroup floating>
-        <div slot="label">
-          <Badge>{i + 1}</Badge> &nbsp; <b class="text-primary font-monospace">{arg}</b>
-        </div>
         <Box
+          id="cmd-arg-{i}"
           tabindex={i + 1}
           bind:value={runArgs[i]}
           invalid={!checkRegex(runArgs[i], i)}
           feedback={$_('Commands.regexMismatch')} />
+        <label for="cmd-arg-{i}">
+          <Badge>{i + 1}</Badge> &nbsp; <b class="text-primary font-monospace">{arg}</b>
+        </label>
       </FormGroup>
     {/each}
     {#snippet footer()}


### PR DESCRIPTION
## Summary
- Nodal header buttons use `onclick` and `type="button"` so they do not submit forms.
- Command args use a real `<label for>` instead of a Svelte 4 slot; language select no longer binds a derived value; Login error is bindable; Fa only preventDefaults when it has a click handler.

## Test plan
- [ ] Modal header buttons do not submit the page form.
- [ ] Command argument labels click-focus the matching input.
- [ ] Language picker still changes locale.
- [ ] Fa help/link marks still navigate or fire onclick.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>