### PR TITLE
Make the process list wrap button actually toggle wrap.

### DIFF
--- a/frontend/src/pages/stubs/ProcessList.svelte
+++ b/frontend/src/pages/stubs/ProcessList.svelte
@@ -27,7 +27,7 @@
         <T id="{page.id}.footer" count={resp.body.split('\n').length} />
       </small>
     {/if}
-    <Button outline color="warning" size="sm" on:click={() => (wrap = !wrap)}>
+    <Button outline color="warning" size="sm" onclick={() => (wrap = !wrap)}>
       <T id="{page.id}.button.{wrap ? 'wrapOff' : 'wrapOn'}" />
     </Button>
   {/snippet}


### PR DESCRIPTION
## Summary
- sveltestrap `Button` never saw the wrap toggle because it was still using Svelte 4 `on:click`.
- Switch the process-list wrap control to `onclick` so wrap on/off actually works.

## Test plan
- [ ] Open Process List, click wrap on/off, and confirm the `<pre>` wrapping class toggles.
- [ ] Closing the modal still works.

---

<sub>Stacked on `main`. Do not merge out of order.</sub>