### PR TITLE
Let bind:value own the API docs and tunnel selects.

### DIFF
--- a/frontend/src/pages/siteTunnel/Index.svelte
+++ b/frontend/src/pages/siteTunnel/Index.svelte
@@ -72,7 +72,7 @@
   <h4><T id="SiteTunnel.phrases.PrimaryTunnel" /></h4>
   <Table size="sm" hover={true} borderless>
     <tbody class="primary-tunnels">
-      {#each $profile.clientInfo?.user.mulery ?? [] as mule, idx}
+      {#each $profile.clientInfo?.user.mulery ?? [] as mule, idx (mule?.socket)}
         <tr
           onclick={() => (primaryTunnel = mule?.socket)}
           style="cursor:pointer;"
@@ -82,8 +82,7 @@
               type="radio"
               style="cursor:pointer;"
               bind:group={primaryTunnel}
-              value={mule?.socket}
-              checked={primaryTunnel === mule?.socket} />
+              value={mule?.socket} />
           </td>
           <td class="location">{mule?.location}</td>
           <td style="width:1%;" class="text-info">{pingOutput[idx]}</td>
@@ -112,8 +111,8 @@
       bind:value={backupTunnel}
       placeholder={$_('SiteTunnel.phrases.SelectTunnel')}
       class={backupTunnel != $profile.clientInfo?.user.tunnels?.[1] ? 'changed' : ''}>
-      {#each $profile.clientInfo?.user.mulery ?? [] as mule}
-        <option selected={backupTunnel === mule!.socket} value={mule!.socket}>
+      {#each $profile.clientInfo?.user.mulery ?? [] as mule (mule?.socket)}
+        <option value={mule!.socket}>
           {mule?.location} &nbsp; {mule?.socket}
         </option>
       {/each}

--- a/frontend/src/pages/stubs/ApiDocs.svelte
+++ b/frontend/src/pages/stubs/ApiDocs.svelte
@@ -129,8 +129,8 @@
   <p><T id="ApiDocs.Contrast" /></p>
   <Input type="select" bind:value={doc} onchange={loadSelected} class="mb-2">
     <option value={null} disabled><T id="ApiDocs.Choose" /></option>
-    {#each apiDocs as ad}
-      <option value={ad} selected={ad.id === doc.id}>
+    {#each apiDocs as ad (ad.id)}
+      <option value={ad}>
         <T id={`ApiDocs.${ad.id}.title`} basePath={$urlbase + ad.path} />
       </option>
     {/each}


### PR DESCRIPTION
## Summary
- `selected=` on `<option>` fights `bind:value` (same class of bug as Input selects).
- Drop it on API docs and the site-tunnel backup select; let `bind:value` / `bind:group` own the selection.
- Key the tunnel and docs `{#each}` blocks; drop the redundant radio `checked`.

## Test plan
- [ ] API Docs: switching Private/GUI docs still loads the right spec.
- [ ] Site Tunnel: picking a backup tunnel updates the select and dirty highlighting without jumping back.
- [ ] Primary tunnel radio still follows the selected row.

---

<sub>Stacked on #1338. Do not merge out of order.</sub>