### PR TITLE
Wire svelte-select v6 callbacks and bind:value.

### DIFF
--- a/frontend/src/pages/endpoints/CronScheduler.svelte
+++ b/frontend/src/pages/endpoints/CronScheduler.svelte
@@ -65,7 +65,7 @@
   }
 
   const dayItems = $derived(
-    Object.entries(weekdays()).map(([v, label]) => ({ label, value: Number(v) })),
+    Object.entries(weekdays($_)).map(([v, label]) => ({ label, value: Number(v) })),
   )
   const monthItems = Array.from({ length: 31 }, (_, i) => ({
     value: i + 1,
@@ -84,10 +84,21 @@
     }
   }
 
+  const selectId = (v: unknown): number | undefined => {
+    if (v && typeof v === 'object' && 'value' in v)
+      return selectId((v as { value: unknown }).value)
+    if (typeof v === 'number' && Number.isInteger(v)) return v
+    if (typeof v === 'string' && v.trim() !== '') {
+      const n = Number(v)
+      return Number.isInteger(n) ? n : undefined
+    }
+    return undefined
+  }
+
   const idsFromSelect = (value: unknown): number[] => {
     if (value == null) return []
     const list = Array.isArray(value) ? value : [value]
-    return list.map(Number).filter(n => !Number.isNaN(n))
+    return list.map(selectId).filter((n): n is number => n !== undefined)
   }
 
   /** oninput receives the new value after bind updates (select, chip X, and usually full clear). */

--- a/frontend/src/pages/endpoints/CronScheduler.svelte
+++ b/frontend/src/pages/endpoints/CronScheduler.svelte
@@ -101,21 +101,13 @@
     return list.map(selectId).filter((n): n is number => n !== undefined)
   }
 
-  /** oninput receives the new value after bind updates (select, chip X, and usually full clear). */
+  /** oninput receives the new value after bind updates (select, chip X, and full clear). */
   const daysChanged = (value: unknown) => {
     const list = idsFromSelect(value)
     if (cron.frequency === Frequency.Weekly) cron.daysOfWeek = list
     else if (cron.frequency === Frequency.Monthly) cron.daysOfMonth = list
     sortDays()
     validateDays(0)
-  }
-
-  /**
-   * handleClear calls onclear(previousValue) *before* value = undefined, so bind still
-   * has the old days. Chip X calls onclear(removedItem) *after* bind already dropped it.
-   */
-  const daysCleared = (cleared: unknown) => {
-    if (Array.isArray(cleared)) daysChanged(null)
   }
 
   export const reset = () => {
@@ -247,7 +239,6 @@
 
   {#if cron.frequency === Frequency.Weekly}
     <Select
-      onclear={daysCleared}
       oninput={daysChanged}
       class="form-control multiselect {cron.daysOfWeek?.length &&
       deepEqual(cron.daysOfWeek, original.daysOfWeek)
@@ -264,7 +255,6 @@
     <span class="text-danger">{feedback['daysOfWeek']}</span>
   {:else if cron.frequency === Frequency.Monthly}
     <Select
-      onclear={daysCleared}
       oninput={daysChanged}
       class="form-control multiselect {cron.daysOfMonth?.length &&
       deepEqual(cron.daysOfMonth, original.daysOfMonth)

--- a/frontend/src/pages/endpoints/CronScheduler.svelte
+++ b/frontend/src/pages/endpoints/CronScheduler.svelte
@@ -218,8 +218,7 @@
 
   {#if cron.frequency === Frequency.Weekly}
     <Select
-      onclear={daysChanged}
-      onchange={daysChanged}
+      oninput={daysChanged}
       class="form-control multiselect {cron.daysOfWeek?.length &&
       deepEqual(cron.daysOfWeek, original.daysOfWeek)
         ? ''
@@ -235,8 +234,7 @@
     <span class="text-danger">{feedback['daysOfWeek']}</span>
   {:else if cron.frequency === Frequency.Monthly}
     <Select
-      onclear={daysChanged}
-      onchange={daysChanged}
+      oninput={daysChanged}
       class="form-control multiselect {cron.daysOfMonth?.length &&
       deepEqual(cron.daysOfMonth, original.daysOfMonth)
         ? ''

--- a/frontend/src/pages/endpoints/CronScheduler.svelte
+++ b/frontend/src/pages/endpoints/CronScheduler.svelte
@@ -84,9 +84,27 @@
     }
   }
 
-  const daysChanged = () => {
+  const idsFromSelect = (value: unknown): number[] => {
+    if (value == null) return []
+    const list = Array.isArray(value) ? value : [value]
+    return list.map(Number).filter(n => !Number.isNaN(n))
+  }
+
+  /** oninput receives the new value after bind updates (select, chip X, and usually full clear). */
+  const daysChanged = (value: unknown) => {
+    const list = idsFromSelect(value)
+    if (cron.frequency === Frequency.Weekly) cron.daysOfWeek = list
+    else if (cron.frequency === Frequency.Monthly) cron.daysOfMonth = list
     sortDays()
     validateDays(0)
+  }
+
+  /**
+   * handleClear calls onclear(previousValue) *before* value = undefined, so bind still
+   * has the old days. Chip X calls onclear(removedItem) *after* bind already dropped it.
+   */
+  const daysCleared = (cleared: unknown) => {
+    if (Array.isArray(cleared)) daysChanged(null)
   }
 
   export const reset = () => {
@@ -218,6 +236,7 @@
 
   {#if cron.frequency === Frequency.Weekly}
     <Select
+      onclear={daysCleared}
       oninput={daysChanged}
       class="form-control multiselect {cron.daysOfWeek?.length &&
       deepEqual(cron.daysOfWeek, original.daysOfWeek)
@@ -234,6 +253,7 @@
     <span class="text-danger">{feedback['daysOfWeek']}</span>
   {:else if cron.frequency === Frequency.Monthly}
     <Select
+      onclear={daysCleared}
       oninput={daysChanged}
       class="form-control multiselect {cron.daysOfMonth?.length &&
       deepEqual(cron.daysOfMonth, original.daysOfMonth)

--- a/frontend/src/pages/endpoints/CronScheduler.svelte
+++ b/frontend/src/pages/endpoints/CronScheduler.svelte
@@ -64,7 +64,13 @@
     feedback['atTimes'] = validate?.('cron.atTimes', cron.atTimes?.length ?? 0) ?? ''
   }
 
-  let dayVal = Object.entries(weekdays).map(([v, label]) => ({ label, value: Number(v) }))
+  const dayItems = $derived(
+    Object.entries(weekdays()).map(([v, label]) => ({ label, value: Number(v) })),
+  )
+  const monthItems = Array.from({ length: 31 }, (_, i) => ({
+    value: i + 1,
+    label: `${i + 1}`,
+  }))
 
   const validateDays = (subtract: number) => {
     if (cron.frequency === Frequency.Weekly) {
@@ -78,11 +84,9 @@
     }
   }
 
-  const clear = (e: any) => {
-    let cleared = e.detail
-    if (!Array.isArray(cleared)) cleared = [cleared]
-    validateDays(cleared.length)
+  const daysChanged = () => {
     sortDays()
+    validateDays(0)
   }
 
   export const reset = () => {
@@ -96,16 +100,27 @@
     cron.daysOfMonth = cron.daysOfMonth?.sort((a, b) => a - b)
   }
 
+  const timeLabel = (v: unknown): string => {
+    if (typeof v === 'string') return v
+    if (v && typeof v === 'object' && 'value' in v)
+      return String((v as { value: unknown }).value)
+    return String(v ?? '')
+  }
+
+  const parseClock = (label: string): number[] => {
+    let v = label
+    if (v.length === 2) v = '0:0:' + v
+    else if (v.length === 5) v = '0:' + v
+    return v.split(':').map(Number)
+  }
+
   /** Remove a time from the list of times. */
-  const deleteTime = (e: CustomEvent<any>) => {
-    let value = e.detail
-    if (!Array.isArray(value)) value = [e.detail]
-    for (let v of value) {
-      v = v.value
-      if (v.length === 2) v = '0:0:' + v
-      if (v.length === 5) v = '0:' + v
+  const deleteTime = (cleared: unknown) => {
+    const items = Array.isArray(cleared) ? cleared : [cleared]
+    for (const item of items) {
+      const t = parseClock(timeLabel(item))
       cron.atTimes = cron.atTimes
-        ?.filter(t => !deepEqual(t, v.split(':').map(Number)))
+        ?.filter(existing => !deepEqual(existing, t))
         .sort((a, b) => a[0] - b[0] || a[1] - b[1] || a[2] - b[2])
     }
   }
@@ -135,7 +150,7 @@
 
   {#snippet timeInput(idx: number, max: number, disabled: boolean)}
     <Input type="select" bind:value={newTime[idx]} min={0} {max} {disabled} class="tp">
-      {#each Array.from({ length: max }, (_, i) => i) as i}
+      {#each Array.from({ length: max }, (_, i) => i) as i (i)}
         <option value={i}>{i.toString().padStart(2, '0')}</option>
       {/each}
     </Input>
@@ -174,7 +189,7 @@
             <!-- Input box with times. Used to delete them (by clicking the x). -->
             <div class="time-container p-0">
               <Select
-                on:input={() =>
+                oninput={() =>
                   (feedback['atTimes'] =
                     validate?.('cron.atTimes', cron.atTimes?.length ?? 0) ?? '')}
                 class="multiselect {cron.atTimes?.length &&
@@ -187,7 +202,7 @@
                 multiFullItemClearable={false}
                 inputAttributes={{ readonly: true }}
                 placeholder="⬅ {$_('scheduler.AddATime')}"
-                on:clear={deleteTime}
+                onclear={deleteTime}
                 value={cronTimes(cron)} />
             </div>
           </td>
@@ -203,43 +218,45 @@
 
   {#if cron.frequency === Frequency.Weekly}
     <Select
-      on:clear={clear}
-      on:change={() => (sortDays(), validateDays(0))}
+      onclear={daysChanged}
+      onchange={daysChanged}
       class="form-control multiselect {cron.daysOfWeek?.length &&
       deepEqual(cron.daysOfWeek, original.daysOfWeek)
         ? ''
         : 'changed ' + (cron.daysOfWeek?.length ? 'is-valid' : 'is-invalid')}"
       placeholder={$_('scheduler.daysOfWeek')}
-      bind:justValue={cron.daysOfWeek}
-      value={cron.daysOfWeek?.map(d => ({ value: d, label: weekdays()[d] })) ?? undefined}
+      valueMode="id"
+      bind:value={cron.daysOfWeek}
       multiple
       searchable
       clearable
-      items={dayVal}>
-      <div slot="empty"><p class="text-center mt-3">{$_('scheduler.empty')}</p></div>
-    </Select>
+      items={dayItems}
+      {empty} />
     <span class="text-danger">{feedback['daysOfWeek']}</span>
   {:else if cron.frequency === Frequency.Monthly}
     <Select
-      on:clear={clear}
-      on:change={() => (sortDays(), validateDays(0))}
+      onclear={daysChanged}
+      onchange={daysChanged}
       class="form-control multiselect {cron.daysOfMonth?.length &&
       deepEqual(cron.daysOfMonth, original.daysOfMonth)
         ? ''
         : 'changed ' + (cron.daysOfMonth?.length ? 'is-valid' : 'is-invalid')}"
       placeholder={$_('scheduler.daysOfMonth')}
-      bind:justValue={cron.daysOfMonth}
-      value={cron.daysOfMonth?.map(d => ({ value: d, label: `${d}` })) ?? undefined}
+      valueMode="id"
+      bind:value={cron.daysOfMonth}
       multiple
       searchable
       clearable
       placeholderAlwaysShow={true}
-      items={Array.from({ length: 31 }, (_, i) => i + 1)}>
-      <div slot="empty"><p class="text-center mt-3">{$_('scheduler.empty')}</p></div>
-    </Select>
+      items={monthItems}
+      {empty} />
     <span class="text-danger">{feedback['daysOfMonth']}</span>
   {/if}
 </div>
+
+{#snippet empty()}
+  <p class="text-center mt-3">{$_('scheduler.empty')}</p>
+{/snippet}
 
 <style>
   /* Make the stuff match other pages. */

--- a/frontend/src/pages/endpoints/schedule.ts
+++ b/frontend/src/pages/endpoints/schedule.ts
@@ -15,15 +15,17 @@ export const cronTimes = (cron: CronJob): string[] => {
   return cron.atTimes?.map(t => t.map(l => pad(l)).join(':')) ?? []
 }
 
-/** The weekdays, localized. */
-export const weekdays = () => ({
-  [Weekday.Sunday]: get(_)('words.clock.days.Sunday'),
-  [Weekday.Monday]: get(_)('words.clock.days.Monday'),
-  [Weekday.Tuesday]: get(_)('words.clock.days.Tuesday'),
-  [Weekday.Wednesday]: get(_)('words.clock.days.Wednesday'),
-  [Weekday.Thursday]: get(_)('words.clock.days.Thursday'),
-  [Weekday.Friday]: get(_)('words.clock.days.Friday'),
-  [Weekday.Saturday]: get(_)('words.clock.days.Saturday'),
+/** The weekdays, localized. Pass `$_` from a component so labels update with locale. */
+export const weekdays = (
+  t: (id: string) => string = id => String(get(_)(id) ?? id),
+): Record<number, string> => ({
+  [Weekday.Sunday]: t('words.clock.days.Sunday'),
+  [Weekday.Monday]: t('words.clock.days.Monday'),
+  [Weekday.Tuesday]: t('words.clock.days.Tuesday'),
+  [Weekday.Wednesday]: t('words.clock.days.Wednesday'),
+  [Weekday.Thursday]: t('words.clock.days.Thursday'),
+  [Weekday.Friday]: t('words.clock.days.Friday'),
+  [Weekday.Saturday]: t('words.clock.days.Saturday'),
 })
 
 /** Turns a cron job into a human readable, localized string. */

--- a/frontend/src/pages/serviceChecks/HTTP.svelte
+++ b/frontend/src/pages/serviceChecks/HTTP.svelte
@@ -60,8 +60,8 @@
     return {
       url: value.split('|')[0] ?? '',
       headers: value.split('|').slice(1)?.join('\n') ?? '',
-      codes: selectIds(tokens.filter(s => s !== 'SSL')),
-      validSsl: tokens.includes('SSL'),
+      codes: selectIds(tokens.filter(s => s.toUpperCase() !== 'SSL')),
+      validSsl: tokens.some(s => s.toUpperCase() === 'SSL'),
     }
   }
 

--- a/frontend/src/pages/serviceChecks/HTTP.svelte
+++ b/frontend/src/pages/serviceChecks/HTTP.svelte
@@ -73,14 +73,13 @@
     return list.map(Number).filter(c => !Number.isNaN(c))
   }
 
-  const updateExpect = (codes = httpCheck.codes, validSsl = httpCheck.validSsl) => {
+  const updateExpect = (codes = httpCheck.codes) => {
     const list = Array.isArray(codes) ? codes : []
     httpCheck.codes = list
-    form.expect = list.join(',') + (validSsl ? ',SSL' : '')
     codeFeedback = validate?.(app.id + '.http.codes', list)
   }
 
-  const onCodes = (value: unknown) => updateExpect(codesFromSelect(value), httpCheck.validSsl)
+  const onCodes = (value: unknown) => updateExpect(codesFromSelect(value))
 
   const merge = (index: number) => app.merge(index, form)
 
@@ -91,6 +90,13 @@
   })
 
   updateExpect()
+
+  // CheckedInput toggles validSsl on https URLs. Sync form.expect from codes + SSL
+  // without rewriting codes (that would fight bind:value).
+  $effect(() => {
+    const codes = httpCheck.codes ?? []
+    form.expect = codes.join(',') + (httpCheck.validSsl ? ',SSL' : '')
+  })
 </script>
 
 <Col lg={6}>
@@ -130,7 +136,6 @@
       valueMode="id"
       bind:value={httpCheck.codes}
       oninput={onCodes}
-      onclear={() => onCodes([])}
       multiple
       searchable
       clearable

--- a/frontend/src/pages/serviceChecks/HTTP.svelte
+++ b/frontend/src/pages/serviceChecks/HTTP.svelte
@@ -73,13 +73,18 @@
     return list.map(Number).filter(c => !Number.isNaN(c))
   }
 
-  const updateExpect = (codes = httpCheck.codes) => {
-    const list = Array.isArray(codes) ? codes : []
-    httpCheck.codes = list
+  const updateExpect = (codes = httpCheck.codes, validSsl = httpCheck.validSsl) => {
+    const list = Array.isArray(codes)
+      ? codes
+      : codes == null
+        ? []
+        : [Number(codes)].filter(n => !Number.isNaN(n))
+    form.expect = list.join(',') + (validSsl ? ',SSL' : '')
     codeFeedback = validate?.(app.id + '.http.codes', list)
   }
 
-  const onCodes = (value: unknown) => updateExpect(codesFromSelect(value))
+  const onCodes = (value: unknown) =>
+    updateExpect(codesFromSelect(value), httpCheck.validSsl)
 
   const merge = (index: number) => app.merge(index, form)
 
@@ -89,13 +94,10 @@
     validate?.(app.id + '.http.codes', [200])
   })
 
-  updateExpect()
-
-  // CheckedInput toggles validSsl on https URLs. Sync form.expect from codes + SSL
-  // without rewriting codes (that would fight bind:value).
+  // CheckedInput toggles validSsl on https URLs. Do not assign httpCheck.codes here
+  // (that fights bind:value); only rewrite the persisted expect string.
   $effect(() => {
-    const codes = httpCheck.codes ?? []
-    form.expect = codes.join(',') + (httpCheck.validSsl ? ',SSL' : '')
+    updateExpect(httpCheck.codes, httpCheck.validSsl)
   })
 </script>
 

--- a/frontend/src/pages/serviceChecks/HTTP.svelte
+++ b/frontend/src/pages/serviceChecks/HTTP.svelte
@@ -35,15 +35,33 @@
     validate,
   }: ChildProps<ServiceConfig> = $props()
 
+  const selectId = (v: unknown): number | undefined => {
+    if (v && typeof v === 'object' && 'value' in v)
+      return selectId((v as { value: unknown }).value)
+    if (typeof v === 'number' && Number.isInteger(v)) return v
+    if (typeof v === 'string' && v.trim() !== '') {
+      const n = Number(v)
+      return Number.isInteger(n) ? n : undefined
+    }
+    return undefined
+  }
+
+  const selectIds = (value: unknown): number[] => {
+    if (value == null) return []
+    const list = Array.isArray(value) ? value : [value]
+    return list.map(selectId).filter((n): n is number => n !== undefined)
+  }
+
   const setData = (value: string, expect: string) => {
+    const tokens = expect
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean)
     return {
       url: value.split('|')[0] ?? '',
       headers: value.split('|').slice(1)?.join('\n') ?? '',
-      codes: expect
-        .split(',')
-        .map(Number)
-        .filter(c => !isNaN(c)),
-      validSsl: expect.split(',').includes('SSL') ?? false,
+      codes: selectIds(tokens.filter(s => s !== 'SSL')),
+      validSsl: tokens.includes('SSL'),
     }
   }
 
@@ -67,24 +85,13 @@
     return id ? (validate?.(id, value) ?? '') : ''
   }
 
-  const codesFromSelect = (value: unknown): number[] => {
-    if (value == null) return []
-    const list = Array.isArray(value) ? value : [value]
-    return list.map(Number).filter(c => !Number.isNaN(c))
-  }
-
   const updateExpect = (codes = httpCheck.codes, validSsl = httpCheck.validSsl) => {
-    const list = Array.isArray(codes)
-      ? codes
-      : codes == null
-        ? []
-        : [Number(codes)].filter(n => !Number.isNaN(n))
-    form.expect = list.join(',') + (validSsl ? ',SSL' : '')
+    const list = selectIds(codes)
+    form.expect = [...list, ...(validSsl ? ['SSL'] : [])].join(',')
     codeFeedback = validate?.(app.id + '.http.codes', list)
   }
 
-  const onCodes = (value: unknown) =>
-    updateExpect(codesFromSelect(value), httpCheck.validSsl)
+  const onCodes = (value: unknown) => updateExpect(selectIds(value), httpCheck.validSsl)
 
   const merge = (index: number) => app.merge(index, form)
 

--- a/frontend/src/pages/serviceChecks/HTTP.svelte
+++ b/frontend/src/pages/serviceChecks/HTTP.svelte
@@ -67,10 +67,20 @@
     return id ? (validate?.(id, value) ?? '') : ''
   }
 
-  const updateExpect = (codes = httpCheck.codes, validSsl = httpCheck.validSsl) => {
-    form.expect = (codes?.join?.(',') ?? '') + (validSsl ? ',SSL' : '')
-    codeFeedback = validate?.(app.id + '.http.codes', codes)
+  const codesFromSelect = (value: unknown): number[] => {
+    if (value == null) return []
+    const list = Array.isArray(value) ? value : [value]
+    return list.map(Number).filter(c => !Number.isNaN(c))
   }
+
+  const updateExpect = (codes = httpCheck.codes, validSsl = httpCheck.validSsl) => {
+    const list = Array.isArray(codes) ? codes : []
+    httpCheck.codes = list
+    form.expect = list.join(',') + (validSsl ? ',SSL' : '')
+    codeFeedback = validate?.(app.id + '.http.codes', list)
+  }
+
+  const onCodes = (value: unknown) => updateExpect(codesFromSelect(value), httpCheck.validSsl)
 
   const merge = (index: number) => app.merge(index, form)
 
@@ -80,9 +90,7 @@
     validate?.(app.id + '.http.codes', [200])
   })
 
-  $effect(() => {
-    updateExpect(httpCheck.codes, httpCheck.validSsl)
-  })
+  updateExpect()
 </script>
 
 <Col lg={6}>
@@ -119,11 +127,10 @@
         ? ''
         : 'changed ' + (httpCheck.codes?.length ? 'is-valid' : 'is-invalid')}"
       placeholder={$_(app.id + '.http.codes.label')}
-      bind:justValue={httpCheck.codes}
-      value={httpCheck.codes?.map?.(c => ({
-        label: httpCodes.find(h => h.value === c)?.label,
-        value: c,
-      }))}
+      valueMode="id"
+      bind:value={httpCheck.codes}
+      oninput={onCodes}
+      onclear={() => onCodes([])}
       multiple
       searchable
       clearable


### PR DESCRIPTION
## Summary
- Installed `svelte-select` is v6 (Svelte 5): `on:change` / `on:clear` / `bind:justValue` / `slot="empty"` do not type or run.
- HTTP expected-codes and the cron scheduler now use `valueMode="id"`, `bind:value`, `oninput`, and an `empty` snippet.
- Weekly/monthly day selects sync via `oninput` (runs after value updates, including full clear). HTTP chip-clear uses `oninput` only so one chip X does not wipe every code.
- `form.expect` is synced from codes + SSL in an `$effect` that does not rewrite `httpCheck.codes`.
- Weekly day items were `Object.entries(weekdays)` (the function). They now come from `weekdays()`.

## Test plan
- [ ] Service check HTTP: add/remove expected status codes (chip X must not clear the rest); `expect` and dirty CSS update; empty selection shows required feedback.
- [ ] HTTP: toggle Validate SSL on an `https://` URL and confirm `,SSL` is added/removed on `expect`.
- [ ] Endpoint cron: add/remove times with the chip X; weekly/monthly full-clear shows required feedback; weekly days list is localized; monthly days 1–31 search and clear.
- [ ] `cd frontend && npm run check` no longer reports svelte-select type errors.

---

<sub>Stacked on #1339 (merged). Do not merge the rest of the stack out of order.</sub>