### PR TITLE
Derive the page header description from the current locale.

### DIFF
--- a/frontend/src/includes/Header.svelte
+++ b/frontend/src/includes/Header.svelte
@@ -13,8 +13,8 @@
   }
   let { badge = undefined, page, children, description, onclick }: Props = $props()
 
-  const fallback = $derived($_('navigation.pageDescription.' + page.id))
-  const missing = $derived('navigation.pageDescription.' + page.id)
+  const key = $derived('navigation.pageDescription.' + page.id)
+  const fallback = $derived($_(key))
 </script>
 
 <CardHeader>
@@ -30,9 +30,9 @@
       </a>
     {/if}
   </h2>
-  {#if typeof description === 'string' && description != missing}
+  {#if typeof description === 'string' && description != key}
     {@html description}
-  {:else if description === undefined && fallback != missing}
+  {:else if description === undefined && fallback != key}
     {@html fallback}
   {:else if typeof description !== 'string' && description !== undefined}
     {@render description()}

--- a/frontend/src/includes/Header.svelte
+++ b/frontend/src/includes/Header.svelte
@@ -3,7 +3,6 @@
   import Fa from './Fa.svelte'
   import Code from 'phosphor-svelte/lib/Code'
   import { _ } from './Translate.svelte'
-  import { get } from 'svelte/store'
   import type { Snippet } from 'svelte'
   type Props = {
     badge?: string
@@ -12,13 +11,10 @@
     description?: string | Snippet
     onclick?: () => void
   }
-  let {
-    badge = undefined,
-    page,
-    children,
-    description = get(_)('navigation.pageDescription.' + page.id),
-    onclick,
-  }: Props = $props()
+  let { badge = undefined, page, children, description, onclick }: Props = $props()
+
+  const fallback = $derived($_('navigation.pageDescription.' + page.id))
+  const missing = $derived('navigation.pageDescription.' + page.id)
 </script>
 
 <CardHeader>
@@ -34,8 +30,10 @@
       </a>
     {/if}
   </h2>
-  {#if typeof description === 'string' && description != 'navigation.pageDescription.' + page.id}
+  {#if typeof description === 'string' && description != missing}
     {@html description}
+  {:else if description === undefined && fallback != missing}
+    {@html fallback}
   {:else if typeof description !== 'string' && description !== undefined}
     {@render description()}
   {/if}

--- a/frontend/src/includes/Header.svelte.spec.ts
+++ b/frontend/src/includes/Header.svelte.spec.ts
@@ -1,0 +1,78 @@
+import { render, screen, waitFor } from '@testing-library/svelte'
+import { addMessages, locale } from 'svelte-i18n'
+import { createRawSnippet } from 'svelte'
+import { afterEach, describe, expect, it } from 'vitest'
+import Header from './Header.svelte'
+
+const ZZ_DESC = 'ZZ-BESCHREIBUNG'
+const title = () => document.querySelector('h2.page-title')?.textContent ?? ''
+const body = () => document.body.textContent ?? ''
+
+describe('Header description', () => {
+  afterEach(async () => {
+    await locale.set('en')
+  })
+
+  it('renders the en pageDescription when no description prop is passed', async () => {
+    render(Header, { props: { page: { id: 'Configuration' } } })
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Configure your Notifiarr client settings here\./),
+      ).toBeTruthy(),
+    )
+  })
+
+  it('updates the description when the locale changes', async () => {
+    render(Header, { props: { page: { id: 'Configuration' } } })
+    await waitFor(() => expect(title()).toContain('Configuration'))
+    await addMessages('zz', {
+      navigation: {
+        titles: { Configuration: 'ZZ-TITEL' },
+        pageDescription: { Configuration: ZZ_DESC },
+      },
+    })
+    await locale.set('zz')
+    await waitFor(() => expect(screen.getByText(ZZ_DESC)).toBeTruthy(), { timeout: 2000 })
+    expect(title()).toContain('ZZ-TITEL')
+  })
+
+  it('renders nothing extra for a page with no pageDescription key', async () => {
+    render(Header, { props: { page: { id: 'ApiDocs' } } })
+    await waitFor(() => expect(title()).toContain('Client API Documentation'))
+    expect(body()).not.toContain('navigation.pageDescription')
+  })
+
+  it('honors an explicit string description', async () => {
+    render(Header, {
+      props: { page: { id: 'Configuration' }, description: 'CUSTOM-STRING' },
+    })
+    await waitFor(() => expect(screen.getByText('CUSTOM-STRING')).toBeTruthy())
+    expect(body()).not.toContain('Configure your Notifiarr')
+  })
+
+  it('honors an explicit snippet description', async () => {
+    const snip = createRawSnippet(() => ({ render: () => '<p>SNIPPET-DESC</p>' }))
+    render(Header, { props: { page: { id: 'Configuration' }, description: snip } })
+    await waitFor(() => expect(screen.getByText('SNIPPET-DESC')).toBeTruthy())
+    expect(body()).not.toContain('Configure your Notifiarr')
+  })
+
+  it('keeps html links from the locale string', async () => {
+    render(Header, { props: { page: { id: 'SiteTunnel' } } })
+    await waitFor(() =>
+      expect(
+        document.querySelector('a[href="https://github.com/golift/mulery"]'),
+      ).toBeTruthy(),
+    )
+  })
+
+  it('falls back cleanly when a locale lacks the key entirely', async () => {
+    await locale.set('en')
+    render(Header, { props: { page: { id: 'Configuration' } } })
+    await waitFor(() => expect(title()).toContain('Configuration'))
+    await addMessages('yy', { navigation: { titles: { Configuration: 'YY-TITEL' } } })
+    await locale.set('yy')
+    await waitFor(() => expect(title()).toContain('YY-TITEL'), { timeout: 2000 })
+    expect(body()).not.toContain('navigation.pageDescription')
+  })
+})


### PR DESCRIPTION
## Summary
- Header page copy was `get(_)(...)` once at init, so a locale change left the description stale.
- Derive the fallback from `$_('navigation.pageDescription.' + page.id)` and still honor an explicit `description` string or snippet.

## Test plan
- [ ] A page with a `navigation.pageDescription.*` string still shows it under the title.
- [ ] Switching UI language updates the description without a reload of the component tree if the locale store updates.
- [ ] Pages that pass a custom `description` snippet/string are unchanged.

---

<sub>Stacked on #1340. Do not merge out of order.</sub>