### PR TITLE
Derive the user info icon and stop spreading Fa.logo into Helem.

### DIFF
--- a/frontend/src/includes/Helem.svelte
+++ b/frontend/src/includes/Helem.svelte
@@ -6,7 +6,7 @@
 
   type Props = {
     id: string
-    /** Image URL shorthand (same as `i` with a PNG/SVG import). */
+    /** Image URL shorthand (same as `i` with a PNG/SVG import). Not `Fa.logo`. */
     logo?: string
     i?: IconSource
     page?: string

--- a/frontend/src/pages/system/UserInfo.svelte
+++ b/frontend/src/pages/system/UserInfo.svelte
@@ -30,11 +30,7 @@
       }
     }
     if (user?.patron) {
-      return {
-        i: user.devAllowed ? BugBeetle : Butterfly,
-        c1: 'orange',
-        c2: 'wheat',
-      }
+      return { i: user.devAllowed ? BugBeetle : Butterfly, c1: 'orange', c2: 'wheat' }
     }
     if (user?.devAllowed) {
       return { i: Bird, c1: 'purple', c2: 'coral' }

--- a/frontend/src/pages/system/UserInfo.svelte
+++ b/frontend/src/pages/system/UserInfo.svelte
@@ -15,23 +15,32 @@
     $profile.apiKeyValid === false && $profile.config?.apiKey?.length === 36,
   )
 
-  let icon: Props = { i: Bug, c1: 'green', c2: 'lightgreen', d2: 'white' }
+  /** Fa.logo is a boolean size flag; Helem.logo is an image URL. Do not spread logo. */
+  type Icon = Omit<Props, 'logo' | 'page' | 'children'>
 
-  if ($profile.clientInfo?.user?.subscriber) {
-    icon.i = $profile.clientInfo?.user?.devAllowed ? Horse : Cat
-    icon.c1 = 'darkgoldenrod'
-    icon.c2 = 'lightcoral'
-    icon.d1 = 'goldenrod'
-    icon.d2 = 'azure'
-  } else if ($profile.clientInfo?.user?.patron) {
-    icon.i = $profile.clientInfo?.user?.devAllowed ? BugBeetle : Butterfly
-    icon.c1 = 'orange'
-    icon.c2 = 'wheat'
-  } else if ($profile.clientInfo?.user?.devAllowed) {
-    icon.i = Bird
-    icon.c1 = 'purple'
-    icon.c2 = 'coral'
-  }
+  const icon = $derived.by((): Icon => {
+    const user = $profile.clientInfo?.user
+    if (user?.subscriber) {
+      return {
+        i: user.devAllowed ? Horse : Cat,
+        c1: 'darkgoldenrod',
+        c2: 'lightcoral',
+        d1: 'goldenrod',
+        d2: 'azure',
+      }
+    }
+    if (user?.patron) {
+      return {
+        i: user.devAllowed ? BugBeetle : Butterfly,
+        c1: 'orange',
+        c2: 'wheat',
+      }
+    }
+    if (user?.devAllowed) {
+      return { i: Bird, c1: 'purple', c2: 'coral' }
+    }
+    return { i: Bug, c1: 'green', c2: 'lightgreen', d2: 'white' }
+  })
 </script>
 
 <!-- User Section -->


### PR DESCRIPTION
## Summary
- User info patron/dev icon was assigned once, so it did not follow `clientInfo` after load.
- Derive the icon from the profile user flags.
- Do not spread `Fa` props (where `logo` is a boolean size flag) into Helem (where `logo` is an image URL).

## Test plan
- [ ] System → user section shows Bug / Cat / Horse / Butterfly / Bird according to patron, subscriber, and dev flags after client info arrives.
- [ ] Client information header still uses the Notifiarr SVG via Helem `logo`.
- [ ] `cd frontend && npm run check` no longer reports the Helem `logo` boolean vs string clash.

---

<sub>Stacked on #1341. Do not merge out of order.</sub>