### PR TITLE
Match the Renovate config to xtractr.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,23 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    "default:automergeDigest",
+    "helpers:pinGitHubActionDigestsToSemver"
+  ],
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
+  "packageRules": [
+    {
+      "description": "Automerge non-major Go module updates when checks pass",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "description": "Automerge GitHub Actions updates, including majors, when checks pass",
+      "matchManagers": ["github-actions"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Copy [xtractr's Renovate config](https://github.com/golift/xtractr/blob/main/.github/renovate.json): 7-day release age, digest automerge, Action digest pins, automerge Go non-majors and GitHub Actions when checks pass.
- npm majors (TypeScript 7, React 19, and similar) still wait for a human.

## Test plan
- [ ] After merge, confirm the [dependency dashboard](https://github.com/Notifiarr/notifiarr/issues/406) picks up the new extends.
- [ ] Next Go patch / Actions bump should automerge once CI is green.


Made with [Cursor](https://cursor.com)