### PR TITLE
Stop Svelte form loops from Input validate and reload effects

### DIFF
--- a/frontend/src/includes/Input.svelte.spec.ts
+++ b/frontend/src/includes/Input.svelte.spec.ts
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/svelte'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Config } from '../api/notifiarrConfig'
 import { profile } from '../api/profile.svelte'
+import { FormListTracker, type App } from './formsTracker.svelte'
 import Input from './Input.svelte'
 
 vi.mock('../api/profile.svelte', async () => {
@@ -9,9 +11,9 @@ vi.mock('../api/profile.svelte', async () => {
 })
 
 function setProfile(environment: Record<string, string>) {
-  ;(profile as unknown as { set: (v: { environment: Record<string, string> }) => void }).set({
-    environment,
-  })
+  ;(
+    profile as unknown as { set: (v: { environment: Record<string, string> }) => void }
+  ).set({ environment })
 }
 
 describe('Input', () => {
@@ -105,23 +107,30 @@ describe('Input', () => {
     expect(select.selectedOptions[0].textContent?.trim()).toBe('Enabled')
   })
 
-  it('derives validation feedback without mutating caller state', () => {
-    const seen: string[] = []
+  it('derives validation feedback from a FormListTracker without mutating $state', () => {
+    type Row = { name: string }
+    const app: App<Row> = {
+      id: 'Test.App',
+      name: 'Test',
+      logo: '',
+      envPrefix: 'TEST',
+      empty: { name: '' },
+      merge: () => ({}) as Config,
+      validator: (_id, value) => (value === 'bad' ? 'nope' : ''),
+    }
+    const flt = new FormListTracker([{ name: 'bad' }], app)
+
     render(Input, {
       props: {
-        id: 'test.plain',
+        id: 'Test.App.name',
         value: 'bad',
         original: 'bad',
-        validate: (_id: string, value: string) => {
-          seen.push(value)
-          return value === 'bad' ? 'nope' : ''
-        },
+        validate: (id: string, value: string) => flt.validate(id, value, 0),
       },
     })
 
     expect(screen.getByText('nope')).toBeTruthy()
     expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true')
-    expect(seen).toContain('bad')
+    expect(flt.invalid).toBe(true)
   })
 })
-

--- a/frontend/src/includes/Input.svelte.spec.ts
+++ b/frontend/src/includes/Input.svelte.spec.ts
@@ -104,4 +104,24 @@ describe('Input', () => {
     expect(select.value).toBe('true')
     expect(select.selectedOptions[0].textContent?.trim()).toBe('Enabled')
   })
+
+  it('derives validation feedback without mutating caller state', () => {
+    const seen: string[] = []
+    render(Input, {
+      props: {
+        id: 'test.plain',
+        value: 'bad',
+        original: 'bad',
+        validate: (_id: string, value: string) => {
+          seen.push(value)
+          return value === 'bad' ? 'nope' : ''
+        },
+      },
+    })
+
+    expect(screen.getByText('nope')).toBeTruthy()
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true')
+    expect(seen).toContain('bad')
+  })
 })
+

--- a/frontend/src/includes/Instance.svelte
+++ b/frontend/src/includes/Instance.svelte
@@ -52,7 +52,6 @@
     if (form !== busIdsForm) {
       busIdsForm = form
       busIds = form.busIDs?.join('\n') ?? ''
-      return
     }
     const ids = busIds.split(/\s+/).filter((id: string) => id.length)
     const next = ids.length ? ids : ['']

--- a/frontend/src/includes/Instance.svelte
+++ b/frontend/src/includes/Instance.svelte
@@ -44,11 +44,14 @@
   let busIds: string = $state(form?.busIDs?.join('\n') ?? '')
   const rows = $derived(Math.min(Math.max(busIds.split('\n').length, 1), 10))
 
-  function applyBusIds() {
+  $effect(() => {
     if (!form || typeof form.smiPath === 'undefined') return
     const ids = busIds.split(/\s+/).filter((id: string) => id.length)
-    form.busIDs = ids.length ? ids : ['']
-  }
+    const next = ids.length ? ids : ['']
+    // Only write when contents change. A new array every run retriggers this effect.
+    if (deepEqual(form.busIDs, next)) return
+    form.busIDs = next
+  })
 
   function resetInstance() {
     reset?.()
@@ -257,7 +260,6 @@
             original={original?.busIDs?.join('\n') ?? ''}
             envVar={envPrefix + '_BUS_IDS'}
             disabled={app.disabled?.includes('busIds')}
-            oninput={applyBusIds}
             {validate} />
         </Col>
       {/if}

--- a/frontend/src/includes/Instance.svelte
+++ b/frontend/src/includes/Instance.svelte
@@ -43,9 +43,17 @@
   /** Array converted to newline-separated string for textarea. */
   let busIds: string = $state(form?.busIDs?.join('\n') ?? '')
   const rows = $derived(Math.min(Math.max(busIds.split('\n').length, 1), 10))
+  // The Nvidia tab remounts `form` on profile reload. Seed from the new object
+  // instead of writing the previous textarea back over the reloaded bus IDs.
+  let busIdsForm: typeof form | undefined
 
   $effect(() => {
     if (!form || typeof form.smiPath === 'undefined') return
+    if (form !== busIdsForm) {
+      busIdsForm = form
+      busIds = form.busIDs?.join('\n') ?? ''
+      return
+    }
     const ids = busIds.split(/\s+/).filter((id: string) => id.length)
     const next = ids.length ? ids : ['']
     // Only write when contents change. A new array every run retriggers this effect.

--- a/frontend/src/includes/Instance.svelte.spec.ts
+++ b/frontend/src/includes/Instance.svelte.spec.ts
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen } from '@testing-library/svelte'
+import { tick } from 'svelte'
+import { describe, expect, it, vi } from 'vitest'
+import type { Config } from '../api/notifiarrConfig'
+import { FormListTracker, type App } from './formsTracker.svelte'
+import Instance from './Instance.svelte'
+
+vi.mock('../api/profile.svelte', async () => {
+  const { writable } = await import('svelte/store')
+  return { profile: writable({ environment: {} as Record<string, string> }) }
+})
+
+type Nvidia = { smiPath: string; busIDs: string[]; disabled: boolean }
+
+const nvidiaApp: App<Nvidia> = {
+  id: 'SnapshotApps.Nvidia',
+  name: 'Nvidia',
+  logo: '',
+  envPrefix: 'SNAPSHOT_NVIDIA',
+  hidden: ['deletes'],
+  empty: { busIDs: [''], smiPath: '', disabled: false },
+  merge: () => ({}) as Config,
+}
+
+describe('Instance Nvidia bus IDs', () => {
+  it('writes textarea edits onto form.busIDs', async () => {
+    const flt = new FormListTracker(
+      [{ smiPath: '', busIDs: ['GPU-old'], disabled: false }],
+      nvidiaApp,
+    )
+    const form = flt.instances[0]
+
+    render(Instance, {
+      props: {
+        form,
+        original: { smiPath: '', busIDs: ['GPU-old'], disabled: false },
+        app: nvidiaApp,
+        index: 0,
+        indexed: false,
+        validate: (id: string, value: string) => flt.validate(id, value, 0),
+      },
+    })
+
+    await tick()
+    const box = screen.getByLabelText('Bus IDs')
+    await fireEvent.input(box, { target: { value: 'GPU-new-1\nGPU-new-2' } })
+    await tick()
+    await tick()
+
+    expect(form.busIDs).toEqual(['GPU-new-1', 'GPU-new-2'])
+    expect(flt.formChanged).toBe(true)
+  })
+
+  it('reseeds the textarea when the form object is replaced', async () => {
+    const first = { smiPath: '', busIDs: ['GPU-old'], disabled: false }
+    const flt = new FormListTracker([first], nvidiaApp)
+
+    const { rerender } = render(Instance, {
+      props: {
+        form: flt.instances[0],
+        original: { ...first },
+        app: nvidiaApp,
+        index: 0,
+        indexed: false,
+        validate: (id: string, value: string) => flt.validate(id, value, 0),
+      },
+    })
+
+    await tick()
+    await fireEvent.input(screen.getByLabelText('Bus IDs'), {
+      target: { value: 'GPU-typed' },
+    })
+    await tick()
+
+    const reloaded = { smiPath: '', busIDs: ['GPU-from-server'], disabled: false }
+    flt.instances = [reloaded]
+    await rerender({
+      form: flt.instances[0],
+      original: { ...reloaded },
+      app: nvidiaApp,
+      index: 0,
+      indexed: false,
+      validate: (id: string, value: string) => flt.validate(id, value, 0),
+    })
+    await tick()
+    await tick()
+
+    expect(flt.instances[0].busIDs).toEqual(['GPU-from-server'])
+    expect((screen.getByLabelText('Bus IDs') as HTMLTextAreaElement).value).toBe(
+      'GPU-from-server',
+    )
+  })
+})

--- a/frontend/src/includes/formsTracker.svelte.spec.ts
+++ b/frontend/src/includes/formsTracker.svelte.spec.ts
@@ -40,4 +40,25 @@ describe('FormListTracker', () => {
     expect(flt.instances[0].name).toBe('ok')
     expect(flt.invalid).toBe(false)
   })
+
+  it('skips hidden keys when aggregating validity', () => {
+    type Downloader = Row & { apiKey: string }
+    const hiddenApp: App<Downloader> = {
+      ...app,
+      hidden: ['apiKey'],
+      empty: { name: 'ok', url: 'http://x', apiKey: '' },
+      validator: (id, value) => {
+        if (id.endsWith('.apiKey') && (value?.length ?? 0) < 32)
+          return 'api key too short'
+        return ''
+      },
+    }
+    const flt = new FormListTracker(
+      [{ name: 'ok', url: 'http://x', apiKey: '' }],
+      hiddenApp,
+    )
+    expect(flt.validate('Test.App.apiKey', '', 0)).toBe('api key too short')
+    expect(flt.isValid(0)).toBe(true)
+    expect(flt.invalid).toBe(false)
+  })
 })

--- a/frontend/src/includes/formsTracker.svelte.spec.ts
+++ b/frontend/src/includes/formsTracker.svelte.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import type { Config } from '../api/notifiarrConfig'
+import { FormListTracker, type App } from './formsTracker.svelte'
+
+type Row = { name: string; url: string }
+
+const app: App<Row> = {
+  id: 'Test.App',
+  name: 'Test',
+  logo: '',
+  envPrefix: 'TEST',
+  empty: { name: '', url: '' },
+  merge: () => ({}) as Config,
+  validator: (id, value) => {
+    if (id.endsWith('.name') && !value) return 'name required'
+    return ''
+  },
+}
+
+describe('FormListTracker', () => {
+  it('reports invalid from instance values without writing a feedback map', () => {
+    const flt = new FormListTracker([{ name: '', url: 'http://x' }], app)
+    expect(flt.validate('Test.App.name', '', 0)).toBe('name required')
+    expect(flt.isValid(0)).toBe(false)
+    expect(flt.invalid).toBe(true)
+  })
+
+  it('is valid when every field passes', () => {
+    const flt = new FormListTracker([{ name: 'ok', url: 'http://x' }], app)
+    expect(flt.validate('Test.App.name', 'ok', 0)).toBe('')
+    expect(flt.isValid(0)).toBe(true)
+    expect(flt.invalid).toBe(false)
+  })
+
+  it('recomputes invalid after resetAll', () => {
+    const flt = new FormListTracker([{ name: 'ok', url: 'http://x' }], app)
+    flt.instances[0].name = ''
+    expect(flt.invalid).toBe(true)
+    flt.resetAll()
+    expect(flt.instances[0].name).toBe('ok')
+    expect(flt.invalid).toBe(false)
+  })
+})

--- a/frontend/src/includes/formsTracker.svelte.ts
+++ b/frontend/src/includes/formsTracker.svelte.ts
@@ -131,9 +131,16 @@ export class FormListTracker<T> {
   public isValid = (index: number): boolean => {
     const inst = this.instances[index]
     if (inst == null) return true
-    return Object.keys(inst).every(
-      k => !this.app.validator?.(this.app.id + '.' + k, inst[k as keyof T], index, this.instances),
-    )
+    const hidden = this.app.hidden ?? []
+    return Object.keys(inst).every(k => {
+      if (hidden.includes(k)) return true
+      return !this.app.validator?.(
+        this.app.id + '.' + k,
+        inst[k as keyof T],
+        index,
+        this.instances,
+      )
+    })
   }
 
   /** Standard form validator for an integrated instance (plex, sonarr, etc).

--- a/frontend/src/includes/formsTracker.svelte.ts
+++ b/frontend/src/includes/formsTracker.svelte.ts
@@ -54,13 +54,11 @@ export type App<T> = {
 /**
  * FormListTracker is a class that tracks multiple forms (across accordions generally).
  * it keeps track of the original list of instances, the form-bound list of instances,
- * the removed instances, the invalid instances, and the feedback for the instances.
+ * the removed instances, and whether any instance is invalid.
  * @param instances - The form-bound list of instances in our tabs.
  * @param app - The app we're validating.
  */
 export class FormListTracker<T> {
-  /** List of invalid instances. */
-  private feedback: Record<number, Record<string, string | undefined>>
   /** The form-bound list of instances in our tabs. */
   public instances: T[]
   /** Count of deleted saved instances. Use .length for the Deleted badge. Indexes are not stable. */
@@ -69,7 +67,7 @@ export class FormListTracker<T> {
   public readonly original: T[]
   /** Data about the app we're validating. */
   public readonly app: App<T>
-  /** If any instance in the list has non-empty feedback the form is invalid. */
+  /** If any instance in the list fails validation the form is invalid. */
   public readonly invalid: boolean
   /** If the form has changed from the original values. */
   public readonly formChanged: boolean
@@ -80,15 +78,13 @@ export class FormListTracker<T> {
     this.instances = $state(deepCopy(instances ?? []))
     this.original = $state(deepCopy(instances ?? []))
     this.app = app
-    this.feedback = $state({})
     this.removed = $state([])
     this.active = $state(0)
     this.formChanged = $derived(
       this.removed.length > 0 || !deepEqual(this.instances, this.original),
     )
-    this.invalid = $derived(
-      Object.values(this.feedback).some(v => Object.values(v).some(v => !!v)),
-    )
+    // Must not write $state from validate(): Input derives feedback from it.
+    this.invalid = $derived(this.instances.some((_, i) => !this.isValid(i)))
   }
 
   /** Add a new instance to the list. */
@@ -111,8 +107,6 @@ export class FormListTracker<T> {
     }
     // Remove the instance from the form (delete the accordion).
     this.instances.splice(index, 1)
-    // Reset the feedback for the instance.
-    this.feedback = {}
     // Re-open a remaining instance. Never select index 0 on an empty list:
     // {#key flt.active} would remount children bound to undefined form and freeze the UI.
     this.active = this.instances.length
@@ -124,7 +118,6 @@ export class FormListTracker<T> {
   public resetAll = () => {
     this.instances = deepCopy(this.original)
     this.removed = []
-    this.validateAll()
   }
 
   /** Reset a single instance to the original values. Call this when reset button is clicked. */
@@ -132,31 +125,24 @@ export class FormListTracker<T> {
     this.instances[index] = deepCopy(this.original[index] ?? this.app.empty!)
   }
 
-  /** Validate all instances. Call this after a form has been submitted to re-validate any backend changes. */
-  private validateAll = () => {
-    this.instances.forEach((m, i) => {
-      Object.keys(m ?? {}).forEach(k => {
-        this.validate(this.app.id + '.' + k, m?.[k as keyof T], i)
-      })
-    })
-  }
-
   /** Check if an instance is valid.
    * @param index - The index of the current instance the instances list. (0)
    */
   public isValid = (index: number): boolean => {
-    return Object.values(this.feedback[index] ?? {}).every(v => !v)
+    const inst = this.instances[index]
+    if (inst == null) return true
+    return Object.keys(inst).every(
+      k => !this.app.validator?.(this.app.id + '.' + k, inst[k as keyof T], index, this.instances),
+    )
   }
 
-  /** Standard form validator for an integrated instance (plex, sonarr, etc)
+  /** Standard form validator for an integrated instance (plex, sonarr, etc).
+   * Pure: Input calls this from `$derived`, so it must not write `$state`.
    * @param id - The id of the form field. (anything.here.url)
    * @param value - The value of the form field. (http://localhost:8080)
    * @param index - The index of the current instance the instances list. (0)
-   * @updates The feedback for the instance.
    */
   public validate = (id: string, value: any, index: number): string | undefined => {
-    if (!this.feedback[index]) this.feedback[index] = {}
-    this.feedback[index][id] = this.app.validator?.(id, value, index, this.instances)
-    return this.feedback[index][id]
+    return this.app.validator?.(id, value, index, this.instances)
   }
 }

--- a/frontend/src/navigation/Index.svelte
+++ b/frontend/src/navigation/Index.svelte
@@ -87,16 +87,18 @@
 <!-- This uses global variables to show a modal whenever any (connected)
      form has changes and you might lose them by navigating away. -->
 <Nodal
-  isOpen={nav.showUnsavedAlert !== ''}
+  isOpen={nav.showUnsavedAlert !== null}
   title="navigation.titles.UnsavedChanges"
-  follow={() => (nav.showUnsavedAlert = '')}
+  follow={() => (nav.showUnsavedAlert = null)}
   esc>
   <T id="phrases.LeavePage" />
   {#snippet footer()}
-    <Button color="primary" onclick={() => (nav.showUnsavedAlert = '')}>
+    <Button color="primary" onclick={() => (nav.showUnsavedAlert = null)}>
       <T id="buttons.NoStayHere" />
     </Button>
-    <Button color="danger" onclick={() => nav.goto(nav.forceEvent, nav.showUnsavedAlert)}>
+    <Button
+      color="danger"
+      onclick={() => nav.goto(nav.forceEvent, nav.showUnsavedAlert ?? '')}>
       <T id="buttons.YesDeleteMyChanges" />
     </Button>
   {/snippet}

--- a/frontend/src/navigation/nav.svelte.ts
+++ b/frontend/src/navigation/nav.svelte.ts
@@ -22,10 +22,11 @@ class Navigator {
   private activePage = $state('')
   /** This is set to true if any form has changes. */
   public formChanged = $state(false)
-  /** This is set to the page id if there are unsaved changes. */
-  public showUnsavedAlert = $state('')
+  /** Pending destination while the unsaved-changes modal is open.
+   * `null` means closed. `''` is the landing page (Notifiarr Client title). */
+  public showUnsavedAlert = $state<string | null>(null)
   /** This is used to force a navigation event even if there are unsaved changes. */
-  public forceEvent = { type: 'force', preventDefault: () => { } } as Event
+  public forceEvent = { type: 'force', preventDefault: () => {} } as Event
 
   /** Call this in the onMount function of the parent component to set the initial page. */
   public onMount = () => {
@@ -65,7 +66,7 @@ class Navigator {
       return
     }
 
-    this.showUnsavedAlert = ''
+    this.showUnsavedAlert = null
     this.formChanged = false
     pid = this.setActivePage(pid)
     closeSidebar()

--- a/frontend/src/pages/configuration/Index.svelte
+++ b/frontend/src/pages/configuration/Index.svelte
@@ -33,10 +33,12 @@
   }
 
   const reset = (ok: boolean) => {
-    if (ok) {
-      config = $profile.config
-      extraKeys = config.extraKeys?.join('\n') ?? ''
-    }
+    if (!ok) return
+    // Read the store once. Assigning `config` then reading `config.extraKeys` made
+    // `$effect(() => reset(!!profile.updated))` depend on the $state it just wrote.
+    const next = $profile.config
+    config = next
+    extraKeys = next.extraKeys?.join('\n') ?? ''
   }
 
   // Reset config when profile is updated (when reload button is clicked).

--- a/frontend/src/pages/endpoints/CronScheduler.svelte
+++ b/frontend/src/pages/endpoints/CronScheduler.svelte
@@ -3,9 +3,9 @@
   import T, { _ } from '../../includes/Translate.svelte'
   /** Call this from the validator method you pass in to the module to validate its values. */
   export const validator = (id: string, value: any): string => {
-    if (id.endsWith('daysOfWeek') && !value)
+    if (id.endsWith('daysOfWeek') && (!value || value.length === 0))
       return get(_)('scheduler.required.daysOfWeek')
-    if (id.endsWith('daysOfMonth') && !value)
+    if (id.endsWith('daysOfMonth') && (!value || value.length === 0))
       return get(_)('scheduler.required.daysOfMonth')
     if (id.endsWith('atTimes') && (!value || value.length === 0))
       return get(_)('scheduler.required.atTimes')

--- a/frontend/src/pages/endpoints/cronFields.spec.ts
+++ b/frontend/src/pages/endpoints/cronFields.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { Frequency } from '../../api/notifiarrConfig'
+import { cronFieldVisible } from './schedule'
+
+describe('cronFieldVisible', () => {
+  it('hides every cron field when the schedule is disabled', () => {
+    expect(cronFieldVisible('atTimes', Frequency.DeadCron)).toBe(false)
+    expect(cronFieldVisible('daysOfWeek', Frequency.DeadCron)).toBe(false)
+    expect(cronFieldVisible('daysOfMonth', Frequency.DeadCron)).toBe(false)
+  })
+
+  it('shows only atTimes for daily', () => {
+    expect(cronFieldVisible('atTimes', Frequency.Daily)).toBe(true)
+    expect(cronFieldVisible('daysOfWeek', Frequency.Daily)).toBe(false)
+    expect(cronFieldVisible('daysOfMonth', Frequency.Daily)).toBe(false)
+  })
+
+  it('shows atTimes and daysOfWeek for weekly, not daysOfMonth', () => {
+    expect(cronFieldVisible('atTimes', Frequency.Weekly)).toBe(true)
+    expect(cronFieldVisible('daysOfWeek', Frequency.Weekly)).toBe(true)
+    expect(cronFieldVisible('daysOfMonth', Frequency.Weekly)).toBe(false)
+  })
+})

--- a/frontend/src/pages/endpoints/cronFields.spec.ts
+++ b/frontend/src/pages/endpoints/cronFields.spec.ts
@@ -18,7 +18,7 @@ const weekly = (daysOfWeek: number[]): Endpoint => ({
   validSsl: true,
   atTimes: [[0, 0, 0]],
   daysOfWeek,
-  daysOfMonth: null,
+  daysOfMonth: [],
 })
 
 describe('cronFieldVisible', () => {

--- a/frontend/src/pages/endpoints/cronFields.spec.ts
+++ b/frontend/src/pages/endpoints/cronFields.spec.ts
@@ -1,6 +1,25 @@
 import { describe, expect, it } from 'vitest'
-import { Frequency } from '../../api/notifiarrConfig'
+import { Frequency, type Endpoint } from '../../api/notifiarrConfig'
+import { FormListTracker } from '../../includes/formsTracker.svelte'
+import { validator as cronValidator } from './CronScheduler.svelte'
+import { app } from './page.svelte'
 import { cronFieldVisible } from './schedule'
+
+const weekly = (daysOfWeek: number[]): Endpoint => ({
+  name: 'weekly',
+  url: 'https://example.com',
+  method: 'GET',
+  body: '',
+  template: 'ok',
+  follow: false,
+  frequency: Frequency.Weekly,
+  interval: 0,
+  timeout: '0s',
+  validSsl: true,
+  atTimes: [[0, 0, 0]],
+  daysOfWeek,
+  daysOfMonth: null,
+})
 
 describe('cronFieldVisible', () => {
   it('hides every cron field when the schedule is disabled', () => {
@@ -19,5 +38,29 @@ describe('cronFieldVisible', () => {
     expect(cronFieldVisible('atTimes', Frequency.Weekly)).toBe(true)
     expect(cronFieldVisible('daysOfWeek', Frequency.Weekly)).toBe(true)
     expect(cronFieldVisible('daysOfMonth', Frequency.Weekly)).toBe(false)
+  })
+})
+
+describe('cronValidator', () => {
+  it('rejects empty day lists the same way it rejects a zero count', () => {
+    expect(cronValidator('daysOfWeek', [])).not.toBe('')
+    expect(cronValidator('daysOfMonth', [])).not.toBe('')
+    expect(cronValidator('daysOfWeek', 0)).not.toBe('')
+    expect(cronValidator('daysOfWeek', [1])).toBe('')
+    expect(cronValidator('daysOfWeek', 2)).toBe('')
+  })
+})
+
+describe('endpoint isValid', () => {
+  it('treats a weekly endpoint with no days as invalid', () => {
+    const flt = new FormListTracker([weekly([])], app)
+    expect(flt.isValid(0)).toBe(false)
+    expect(flt.invalid).toBe(true)
+  })
+
+  it('treats a weekly endpoint with days as valid', () => {
+    const flt = new FormListTracker([weekly([1])], app)
+    expect(flt.isValid(0)).toBe(true)
+    expect(flt.invalid).toBe(false)
   })
 })

--- a/frontend/src/pages/endpoints/page.svelte.ts
+++ b/frontend/src/pages/endpoints/page.svelte.ts
@@ -6,6 +6,7 @@ import { profile } from '../../api/profile.svelte'
 import { deepCopy } from '../../includes/util'
 import LinkSimple from 'phosphor-svelte/lib/LinkSimple'
 import { validator as cronValidator } from './CronScheduler.svelte'
+import { cronFieldVisible } from './schedule'
 
 export const page = { id: 'Endpoints' }
 
@@ -56,9 +57,12 @@ const validator = (
       : get(_)('phrases.URLMustBeginWithHttp')
   } else if (id === 'template') {
     return value ? '' : get(_)('Endpoints.template.required')
+  } else if (id === 'atTimes' || id === 'daysOfWeek' || id === 'daysOfMonth') {
+    if (!cronFieldVisible(id, instances[index]?.frequency)) return ''
+    return cronValidator(id, value)
   }
 
-  return cronValidator(id, value)
+  return ''
 }
 
 export const app: App<Endpoint> = {

--- a/frontend/src/pages/endpoints/schedule.ts
+++ b/frontend/src/pages/endpoints/schedule.ts
@@ -3,6 +3,18 @@ import { get } from 'svelte/store'
 import type { CronJob } from '../../api/notifiarrConfig'
 import { _ } from '../../includes/Translate.svelte'
 
+/** CronScheduler only renders these fields for some frequencies. */
+export const cronFieldVisible = (
+  id: string,
+  frequency: Frequency | undefined,
+): boolean => {
+  if (frequency == null || frequency === Frequency.DeadCron) return false
+  if (id === 'atTimes') return true
+  if (id === 'daysOfWeek') return frequency === Frequency.Weekly
+  if (id === 'daysOfMonth') return frequency === Frequency.Monthly
+  return false
+}
+
 /** Pad a number with a leading zero. */
 const pad = (n: number) => n.toString().padStart(2, '0')
 


### PR DESCRIPTION
## Summary
- **#1324 `state_unsafe_mutation`:** `Input` derives feedback from `validate()`, but `FormListTracker.validate` wrote a `$state` feedback map. Media Apps and Starr Apps froze. `validate` is now pure; `invalid` / `isValid` derive from the instance validators.
- **#1330 `effect_update_depth_exceeded`:** Configuration `extraKeys` and Snapshot Nvidia `busIDs` were assigned from `$effect`s that also read those `$state` values (plus `oninput={applyBusIds}` stole `bind:value` on Nvidia). Reload now snapshots the store once, and Nvidia writes `busIDs` only when contents change.

## Test plan
- [ ] Hard-refresh the UI, then open **Media Apps** and **Starr Apps** — no `state_unsafe_mutation`, forms stay interactive
- [ ] Open **Configuration** and click reload — no `effect_update_depth_exceeded`
- [ ] Open **Snapshot → Nvidia**, edit bus IDs, then reload — field settles, no infinite effect loop
- [ ] `cd frontend && npx vitest --run src/includes/formsTracker.svelte.spec.ts src/includes/Input.svelte.spec.ts`


Made with [Cursor](https://cursor.com)