### PR TITLE
Count PowerShell cmdlet errors as custom-command failures

### DIFF
--- a/frontend/src/pages/commands/Output.svelte
+++ b/frontend/src/pages/commands/Output.svelte
@@ -23,14 +23,16 @@
   let { index, active, form }: Props = $props()
 
   let output = $state<Stats | null>()
+  /** null = auto (show output after a failure); otherwise the user's last toggle. */
+  let pinned: boolean | null = $state(null)
   /** Whether the output is visible. */
-  let showOutput = $state(false)
+  let showOutput = $derived(pinned ?? Boolean(output?.output?.startsWith('error:')))
   /** The last time the output data was refreshed. */
   let lastRefreshed = $state(Date.now())
   /** How long ago the output data was refreshed. Dynamically updated. */
   let timeDuration = $state('')
   /** Toggle the output visibility. */
-  const toggleOutput = (e?: Event) => (e?.preventDefault(), (showOutput = !showOutput))
+  const toggleOutput = (e?: Event) => (e?.preventDefault(), (pinned = !showOutput))
 
   /** Retrieve the command output and update the last refreshed time. */
   export const getStats = async (e?: Event) => {

--- a/pkg/triggers/commands/builder.go
+++ b/pkg/triggers/commands/builder.go
@@ -50,8 +50,7 @@ func (c *cmdBuilder) getCmd(ctx context.Context) ([]string, *exec.Cmd, error) {
 		cmd = exec.CommandContext(ctx, builtArgs[0], builtArgs[1:]...)
 	}
 
-	// This call hides the cmd window on Windows.
-	// snapshot.SysCallSettings(cmd)
+	hideWindow(cmd)
 
 	return builtArgs, cmd, nil
 }
@@ -87,5 +86,5 @@ func (c *cmdBuilder) getArgs() ([]string, error) {
 		return append([]string{"cmd", "/C"}, builtArgs...), nil
 	}
 
-	return builtArgs, nil
+	return wrapPowerShell(builtArgs), nil
 }

--- a/pkg/triggers/commands/hidewindow_others.go
+++ b/pkg/triggers/commands/hidewindow_others.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package commands
+
+import (
+	"os/exec"
+)
+
+func hideWindow(_ *exec.Cmd) {}

--- a/pkg/triggers/commands/hidewindow_windows.go
+++ b/pkg/triggers/commands/hidewindow_windows.go
@@ -1,0 +1,12 @@
+package commands
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+const createNoWindow = 0x08000000 // CREATE_NO_WINDOW
+
+func hideWindow(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: createNoWindow}
+}

--- a/pkg/triggers/commands/powershell.go
+++ b/pkg/triggers/commands/powershell.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 )
 
-// psParamName is a PowerShell parameter token that must stay unquoted so it
+// psParamName is a PowerShell parameter name that must stay unquoted so it
 // binds like `powershell.exe -File script.ps1 -Force`. Quoted `'-Force'` is a
-// string and lands positionally. The pattern is tight: no whitespace, quote, or
-// `$` can reach the synthesized -Command string.
-var psParamName = regexp.MustCompile(`^-[A-Za-z][A-Za-z0-9]*(:[^'"$\s]+)?$`)
+// string and lands positionally. Colon values are quoted separately so `;|&()`
+// cannot splice into the synthesized -Command string.
+var psParamName = regexp.MustCompile(`^-[A-Za-z][A-Za-z0-9]*$`)
 
 // wrapPowerShell makes powershell.exe -File failures visible to cmd.Run().
 // Windows PowerShell treats cmdlet errors (Start-Process, etc.) as non-terminating,
@@ -92,7 +92,7 @@ func psQuote(s string) string {
 // psScript keeps -File path resolution: a bare name is found in the current
 // directory by -File, but the call operator needs an explicit relative path.
 func psScript(s string) string {
-	if strings.ContainsAny(s, `/\:`) || strings.HasPrefix(s, ".") {
+	if strings.ContainsAny(s, `/\:`) {
 		return psQuote(s)
 	}
 
@@ -100,9 +100,22 @@ func psScript(s string) string {
 }
 
 func psArg(arg string) string {
+	if name, value, ok := strings.Cut(arg, ":"); ok && psParamName.MatchString(name) {
+		return name + ":" + psColonValue(value)
+	}
+
 	if psParamName.MatchString(arg) {
 		return arg
 	}
 
 	return psQuote(arg)
+}
+
+func psColonValue(value string) string {
+	switch strings.ToLower(value) {
+	case "$true", "$false", "$null":
+		return value
+	default:
+		return psQuote(value)
+	}
 }

--- a/pkg/triggers/commands/powershell.go
+++ b/pkg/triggers/commands/powershell.go
@@ -1,0 +1,82 @@
+package commands
+
+import (
+	"slices"
+	"strings"
+)
+
+// wrapPowerShell makes powershell.exe -File failures visible to cmd.Run().
+// Windows PowerShell treats cmdlet errors (Start-Process, etc.) as non-terminating,
+// so powershell.exe -File exits 0 and custom commands show 0 failures.
+// Rewriting -File into -Command with $ErrorActionPreference='Stop' turns those
+// into a non-zero process exit. Existing -Command / -EncodedCommand is left alone.
+func wrapPowerShell(args []string) []string {
+	if len(args) < 2 || !isPowerShell(args[0]) {
+		return args
+	}
+
+	flags := args[1:]
+	if hasPSSwitch(flags, "command", "c", "encodedcommand", "e", "ec") {
+		return args
+	}
+
+	fileIdx := indexPSSwitch(flags, "file", "f")
+	if fileIdx < 0 || fileIdx+1 >= len(flags) {
+		return args
+	}
+
+	script := flags[fileIdx+1]
+	extra := flags[fileIdx+2:]
+	kept := append([]string{}, flags[:fileIdx]...)
+
+	if !hasPSSwitch(kept, "noninteractive") {
+		kept = append(kept, "-NonInteractive")
+	}
+
+	var cmd strings.Builder
+	cmd.WriteString("$ErrorActionPreference='Stop'; & ")
+	cmd.WriteString(psQuote(script))
+
+	for _, arg := range extra {
+		cmd.WriteByte(' ')
+		cmd.WriteString(psQuote(arg))
+	}
+
+	return append(append([]string{args[0]}, kept...), "-Command", cmd.String())
+}
+
+func isPowerShell(exe string) bool {
+	name := exe
+	if idx := strings.LastIndexAny(exe, `/\`); idx >= 0 {
+		name = exe[idx+1:]
+	}
+
+	switch strings.ToLower(name) {
+	case "powershell.exe", "powershell", "pwsh.exe", "pwsh":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizePSArg(arg string) string {
+	return strings.ToLower(strings.TrimLeft(arg, "-/"))
+}
+
+func hasPSSwitch(args []string, names ...string) bool {
+	return indexPSSwitch(args, names...) >= 0
+}
+
+func indexPSSwitch(args []string, names ...string) int {
+	for idx, arg := range args {
+		if slices.Contains(names, normalizePSArg(arg)) {
+			return idx
+		}
+	}
+
+	return -1
+}
+
+func psQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}

--- a/pkg/triggers/commands/powershell.go
+++ b/pkg/triggers/commands/powershell.go
@@ -1,27 +1,35 @@
 package commands
 
 import (
+	"regexp"
 	"slices"
 	"strings"
 )
+
+// psParamName is a PowerShell parameter token that must stay unquoted so it
+// binds like `powershell.exe -File script.ps1 -Force`. Quoted `'-Force'` is a
+// string and lands positionally. The pattern is tight: no whitespace, quote, or
+// `$` can reach the synthesized -Command string.
+var psParamName = regexp.MustCompile(`^-[A-Za-z][A-Za-z0-9]*(:[^'"$\s]+)?$`)
 
 // wrapPowerShell makes powershell.exe -File failures visible to cmd.Run().
 // Windows PowerShell treats cmdlet errors (Start-Process, etc.) as non-terminating,
 // so powershell.exe -File exits 0 and custom commands show 0 failures.
 // Rewriting -File into -Command with $ErrorActionPreference='Stop' turns those
-// into a non-zero process exit. Existing -Command / -EncodedCommand is left alone.
+// into a non-zero process exit. Existing host-level -Command / -EncodedCommand
+// (before -File) is left alone; switches after -File belong to the script.
 func wrapPowerShell(args []string) []string {
 	if len(args) < 2 || !isPowerShell(args[0]) {
 		return args
 	}
 
 	flags := args[1:]
-	if hasPSSwitch(flags, "command", "c", "encodedcommand", "e", "ec") {
+	fileIdx := indexPSSwitch(flags, "file", "f")
+	if fileIdx < 0 || fileIdx+1 >= len(flags) {
 		return args
 	}
 
-	fileIdx := indexPSSwitch(flags, "file", "f")
-	if fileIdx < 0 || fileIdx+1 >= len(flags) {
+	if hasPSSwitch(flags[:fileIdx], "command", "c", "encodedcommand", "e", "ec") {
 		return args
 	}
 
@@ -35,11 +43,11 @@ func wrapPowerShell(args []string) []string {
 
 	var cmd strings.Builder
 	cmd.WriteString("$ErrorActionPreference='Stop'; & ")
-	cmd.WriteString(psQuote(script))
+	cmd.WriteString(psScript(script))
 
 	for _, arg := range extra {
 		cmd.WriteByte(' ')
-		cmd.WriteString(psQuote(arg))
+		cmd.WriteString(psArg(arg))
 	}
 
 	return append(append([]string{args[0]}, kept...), "-Command", cmd.String())
@@ -79,4 +87,22 @@ func indexPSSwitch(args []string, names ...string) int {
 
 func psQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+// psScript keeps -File path resolution: a bare name is found in the current
+// directory by -File, but the call operator needs an explicit relative path.
+func psScript(s string) string {
+	if strings.ContainsAny(s, `/\:`) || strings.HasPrefix(s, ".") {
+		return psQuote(s)
+	}
+
+	return psQuote("./" + s)
+}
+
+func psArg(arg string) string {
+	if psParamName.MatchString(arg) {
+		return arg
+	}
+
+	return psQuote(arg)
 }

--- a/pkg/triggers/commands/powershell_test.go
+++ b/pkg/triggers/commands/powershell_test.go
@@ -73,6 +73,60 @@ func TestWrapPowerShellFileExtras(t *testing.T) {
 	}
 }
 
+func TestWrapPowerShellFileBinding(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "named parameter stays bare",
+			in:   []string{"powershell.exe", "-File", `C:\build.ps1`, "-Task", "Default"},
+			want: []string{
+				"powershell.exe", "-NonInteractive", "-Command",
+				`$ErrorActionPreference='Stop'; & 'C:\build.ps1' -Task 'Default'`,
+			},
+		},
+		{
+			name: "bare script name gets a relative path",
+			in:   []string{"powershell.exe", "-File", "restart.ps1"},
+			want: []string{
+				"powershell.exe", "-NonInteractive", "-Command",
+				`$ErrorActionPreference='Stop'; & './restart.ps1'`,
+			},
+		},
+		{
+			name: "script arg minus c still wraps",
+			in:   []string{"pwsh", "-File", "build.ps1", "-c", "Release"},
+			want: []string{
+				"pwsh", "-NonInteractive", "-Command",
+				`$ErrorActionPreference='Stop'; & './build.ps1' -c 'Release'`,
+			},
+		},
+		{
+			name: "already relative script is unchanged",
+			in:   []string{"powershell.exe", "-File", `.\restart.ps1`},
+			want: []string{
+				"powershell.exe", "-NonInteractive", "-Command",
+				`$ErrorActionPreference='Stop'; & '.\restart.ps1'`,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := wrapPowerShell(test.in)
+			if !slices.Equal(got, test.want) {
+				t.Fatalf("wrapPowerShell() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
 func TestWrapPowerShellSkip(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/triggers/commands/powershell_test.go
+++ b/pkg/triggers/commands/powershell_test.go
@@ -1,0 +1,100 @@
+package commands //nolint:testpackage
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestWrapPowerShellFile(t *testing.T) {
+	t.Parallel()
+
+	exe := `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`
+	script := `C:\Users\ee\Desktop\clientCommands\plexRestart.ps1`
+
+	got := wrapPowerShell([]string{exe, "-File", script})
+	want := []string{exe, "-NonInteractive", "-Command", "$ErrorActionPreference='Stop'; & '" + script + "'"}
+
+	if !slices.Equal(got, want) {
+		t.Fatalf("wrapPowerShell() = %#v, want %#v", got, want)
+	}
+}
+
+func TestWrapPowerShellFileExtras(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "minus f with script args",
+			in:   []string{"powershell.exe", "-f", `C:\a.ps1`, "one", "two"},
+			want: []string{
+				"powershell.exe", "-NonInteractive", "-Command",
+				`$ErrorActionPreference='Stop'; & 'C:\a.ps1' 'one' 'two'`,
+			},
+		},
+		{
+			name: "preserves preceding flags",
+			in:   []string{"pwsh.exe", "-ExecutionPolicy", "Bypass", "-File", `D:\run.ps1`},
+			want: []string{
+				"pwsh.exe", "-ExecutionPolicy", "Bypass", "-NonInteractive", "-Command",
+				`$ErrorActionPreference='Stop'; & 'D:\run.ps1'`,
+			},
+		},
+		{
+			name: "does not duplicate noninteractive",
+			in:   []string{"powershell", "-NonInteractive", "-File", `C:\x.ps1`},
+			want: []string{
+				"powershell", "-NonInteractive", "-Command",
+				`$ErrorActionPreference='Stop'; & 'C:\x.ps1'`,
+			},
+		},
+		{
+			name: "escapes single quotes in path",
+			in:   []string{"powershell.exe", "-File", `C:\O'Brien\run.ps1`},
+			want: []string{
+				"powershell.exe", "-NonInteractive", "-Command",
+				`$ErrorActionPreference='Stop'; & 'C:\O''Brien\run.ps1'`,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := wrapPowerShell(test.in)
+			if !slices.Equal(got, test.want) {
+				t.Fatalf("wrapPowerShell() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestWrapPowerShellSkip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []string
+	}{
+		{name: "not powershell", in: []string{"taskkill", "/IM", "Plex Media Server.exe", "/F"}},
+		{name: "minus command", in: []string{"powershell.exe", "-Command", "Get-Process"}},
+		{name: "minus c", in: []string{"pwsh", "-c", "Get-Date"}},
+		{name: "encoded command", in: []string{"powershell.exe", "-EncodedCommand", "QQA="}},
+		{name: "file without path", in: []string{"powershell.exe", "-File"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := wrapPowerShell(test.in)
+			if !slices.Equal(got, test.in) {
+				t.Fatalf("wrapPowerShell() = %#v, want unchanged %#v", got, test.in)
+			}
+		})
+	}
+}

--- a/pkg/triggers/commands/powershell_test.go
+++ b/pkg/triggers/commands/powershell_test.go
@@ -127,6 +127,60 @@ func TestWrapPowerShellFileBinding(t *testing.T) {
 	}
 }
 
+func TestWrapPowerShellColonValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "colon value is quoted",
+			in:   []string{"powershell.exe", "-File", "echoarg.ps1", "-A:x;[Environment]::Exit(42)"},
+			want: []string{
+				"powershell.exe", "-NonInteractive", "-Command",
+				`$ErrorActionPreference='Stop'; & './echoarg.ps1' -A:'x;[Environment]::Exit(42)'`,
+			},
+		},
+		{
+			name: "colon path value is quoted",
+			in:   []string{"pwsh", "-File", `C:\build.ps1`, `-Path:C:\build\out`},
+			want: []string{
+				"pwsh", "-NonInteractive", "-Command",
+				`$ErrorActionPreference='Stop'; & 'C:\build.ps1' -Path:'C:\build\out'`,
+			},
+		},
+		{
+			name: "colon bool stays a bool",
+			in:   []string{"powershell.exe", "-File", "run.ps1", "-Force:$true"},
+			want: []string{
+				"powershell.exe", "-NonInteractive", "-Command",
+				`$ErrorActionPreference='Stop'; & './run.ps1' -Force:$true`,
+			},
+		},
+		{
+			name: "dotfile script gets a relative path",
+			in:   []string{"powershell.exe", "-File", ".hidden.ps1"},
+			want: []string{
+				"powershell.exe", "-NonInteractive", "-Command",
+				`$ErrorActionPreference='Stop'; & './.hidden.ps1'`,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := wrapPowerShell(test.in)
+			if !slices.Equal(got, test.want) {
+				t.Fatalf("wrapPowerShell() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
 func TestWrapPowerShellSkip(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Wrap direct `powershell.exe`/`pwsh -File` invocations with `$ErrorActionPreference='Stop'` so cmdlet errors (like `Start-Process` failing) exit non-zero and increment Failures.
- Hide the Windows console for custom commands so Test no longer flashes a PowerShell window.
- Auto-expand last command output when the last run stored an `error:` result.

Docs: https://github.com/Notifiarr/mkdocs-wiki/pull/68

## Test plan
- [ ] On Windows, add a command that runs `powershell.exe -File` against a script whose `Start-Process` path is wrong; Test should increment Failures and show the error output.
- [ ] Confirm a successful `-File` script still counts as 0 failures.
- [ ] Confirm `powershell.exe -Command ...` is not rewritten.
- [ ] Confirm Test does not pop a visible console window.
- [ ] Leave **Shell** off for powershell.exe commands.