### PR TITLE
Type service checks and MySQL nulls as they actually JSON-encode

### DIFF
--- a/frontend/src/api/generate.go
+++ b/frontend/src/api/generate.go
@@ -15,6 +15,8 @@ import (
 	"github.com/Notifiarr/notifiarr/pkg/checkapp"
 	"github.com/Notifiarr/notifiarr/pkg/client"
 	"github.com/Notifiarr/notifiarr/pkg/configfile"
+	"github.com/Notifiarr/notifiarr/pkg/services"
+	"github.com/Notifiarr/notifiarr/pkg/snapshot"
 	"github.com/Notifiarr/notifiarr/pkg/triggers/commands"
 	"github.com/Notifiarr/notifiarr/pkg/triggers/common/scheduler"
 	"golift.io/cnfg"
@@ -41,8 +43,12 @@ func main() {
 		},
 		Docs: docs,
 		Overrides: goty.Overrides{
-			cnfg.Duration{}:                 {Type: "string"},
-			reflect.TypeFor[time.Weekday](): {Comment: "The day of the week."},
+			cnfg.Duration{}: {Type: "string"},
+			// JSON is always a quoted string, including the sentinel "NULL".
+			snapshot.NullString{}: {Type: "string"},
+			// JSON is the check output string; fields are *Output so override the pointer.
+			reflect.TypeFor[*services.Output](): {Type: "string", Optional: true},
+			reflect.TypeFor[time.Weekday]():     {Comment: "The day of the week."},
 		},
 	})
 
@@ -70,6 +76,19 @@ func main() {
 		{Name: "Daily", Value: scheduler.Daily},
 		{Name: "Weekly", Value: scheduler.Weekly},
 		{Name: "Monthly", Value: scheduler.Monthly},
+	})
+	goat.Enums([]goty.Enum{
+		{Name: "http", Value: services.CheckHTTP},
+		{Name: "tcp", Value: services.CheckTCP},
+		{Name: "ping", Value: services.CheckPING},
+		{Name: "icmp", Value: services.CheckICMP},
+		{Name: "process", Value: services.CheckPROC},
+	})
+	goat.Enums([]goty.Enum{
+		{Name: "OK", Value: services.StateOK},
+		{Name: "Warning", Value: services.StateWarning},
+		{Name: "Critical", Value: services.StateCritical},
+		{Name: "Unknown", Value: services.StateUnknown},
 	})
 	log.Println("==> parsing config structs")
 	goat.Parse(

--- a/frontend/src/api/notifiarrConfig.ts
+++ b/frontend/src/api/notifiarrConfig.ts
@@ -42,6 +42,27 @@ export enum Frequency {
 };
 
 /**
+ * @see golang: <github.com/Notifiarr/notifiarr/pkg/services.CheckType>
+ */
+export enum CheckType {
+  http    = "http",
+  tcp     = "tcp",
+  ping    = "ping",
+  icmp    = "icmp",
+  process = "process",
+};
+
+/**
+ * @see golang: <github.com/Notifiarr/notifiarr/pkg/services.CheckState>
+ */
+export enum CheckState {
+  OK       = 0,
+  Warning  = 1,
+  Critical = 2,
+  Unknown  = 3,
+};
+
+/**
  * Integrations is the data returned by the UI integrations endpoint.
  * @see golang: <github.com/Notifiarr/notifiarr/pkg/client.Integrations>
  */
@@ -308,25 +329,12 @@ export interface MySQLProcess {
   id: number;
   user: string;
   host: string;
-  db: NullString;
+  db: string;
   command: string;
   time: number;
   state: string;
-  info: NullString;
+  info: string;
   progress: number;
-};
-
-/**
- * @see golang: <github.com/Notifiarr/notifiarr/pkg/snapshot.NullString>
- */
-export interface NullString extends SqlNullString {};
-
-/**
- * @see golang: <database/sql.NullString>
- */
-export interface SqlNullString {
-  String: string;
-  Valid: boolean;
 };
 
 /**
@@ -1454,7 +1462,7 @@ export interface ServicesConfig {
  */
 export interface ServiceConfig {
   name: string;
-  type: string;
+  type: CheckType;
   value: string;
   expect: string;
   timeout: string;
@@ -2045,19 +2053,14 @@ export interface ClientServicesConfig {
  */
 export interface CheckResult {
   name: string;
-  state: number;
-  output?: Output;
-  type: string;
+  state: CheckState;
+  output?: string;
+  type: CheckType;
   time: Date;
   since: Date;
   interval: number;
   metadata?: Record<string, null | any>;
 };
-
-/**
- * @see golang: <github.com/Notifiarr/notifiarr/pkg/services.Output>
- */
-export interface Output {};
 
 /**
  * ProfilePost is the data sent to the profile POST endpoint when updating the trust profile.
@@ -2150,39 +2153,38 @@ export interface BrowseDir {
 };
 
 // Packages parsed:
-//   1. database/sql
-//   2. github.com/Notifiarr/notifiarr/frontend
-//   3. github.com/Notifiarr/notifiarr/pkg/apps
-//   4. github.com/Notifiarr/notifiarr/pkg/apps/apppkg/plex
-//   5. github.com/Notifiarr/notifiarr/pkg/apps/apppkg/sabnzbd
-//   6. github.com/Notifiarr/notifiarr/pkg/apps/apppkg/tautulli
-//   7. github.com/Notifiarr/notifiarr/pkg/checkapp
-//   8. github.com/Notifiarr/notifiarr/pkg/client
-//   9. github.com/Notifiarr/notifiarr/pkg/configfile
-//  10. github.com/Notifiarr/notifiarr/pkg/logs
-//  11. github.com/Notifiarr/notifiarr/pkg/mnd
-//  12. github.com/Notifiarr/notifiarr/pkg/services
-//  13. github.com/Notifiarr/notifiarr/pkg/snapshot
-//  14. github.com/Notifiarr/notifiarr/pkg/triggers/commands
-//  15. github.com/Notifiarr/notifiarr/pkg/triggers/commands/cmdconfig
-//  16. github.com/Notifiarr/notifiarr/pkg/triggers/common
-//  17. github.com/Notifiarr/notifiarr/pkg/triggers/common/scheduler
-//  18. github.com/Notifiarr/notifiarr/pkg/triggers/crontimer
-//  19. github.com/Notifiarr/notifiarr/pkg/triggers/dashboard
-//  20. github.com/Notifiarr/notifiarr/pkg/triggers/endpoints/epconfig
-//  21. github.com/Notifiarr/notifiarr/pkg/triggers/filewatch
-//  22. github.com/Notifiarr/notifiarr/pkg/website/clientinfo
-//  23. github.com/shirou/gopsutil/v4/cpu
-//  24. github.com/shirou/gopsutil/v4/disk
-//  25. github.com/shirou/gopsutil/v4/host
-//  26. github.com/shirou/gopsutil/v4/load
-//  27. golift.io/deluge
-//  28. golift.io/mulery/client
-//  29. golift.io/nzbget
-//  30. golift.io/qbit
-//  31. golift.io/starr
-//  32. golift.io/starr/lidarr
-//  33. golift.io/starr/prowlarr
-//  34. golift.io/starr/radarr
-//  35. golift.io/starr/readarr
-//  36. golift.io/starr/sonarr
+//   1. github.com/Notifiarr/notifiarr/frontend
+//   2. github.com/Notifiarr/notifiarr/pkg/apps
+//   3. github.com/Notifiarr/notifiarr/pkg/apps/apppkg/plex
+//   4. github.com/Notifiarr/notifiarr/pkg/apps/apppkg/sabnzbd
+//   5. github.com/Notifiarr/notifiarr/pkg/apps/apppkg/tautulli
+//   6. github.com/Notifiarr/notifiarr/pkg/checkapp
+//   7. github.com/Notifiarr/notifiarr/pkg/client
+//   8. github.com/Notifiarr/notifiarr/pkg/configfile
+//   9. github.com/Notifiarr/notifiarr/pkg/logs
+//  10. github.com/Notifiarr/notifiarr/pkg/mnd
+//  11. github.com/Notifiarr/notifiarr/pkg/services
+//  12. github.com/Notifiarr/notifiarr/pkg/snapshot
+//  13. github.com/Notifiarr/notifiarr/pkg/triggers/commands
+//  14. github.com/Notifiarr/notifiarr/pkg/triggers/commands/cmdconfig
+//  15. github.com/Notifiarr/notifiarr/pkg/triggers/common
+//  16. github.com/Notifiarr/notifiarr/pkg/triggers/common/scheduler
+//  17. github.com/Notifiarr/notifiarr/pkg/triggers/crontimer
+//  18. github.com/Notifiarr/notifiarr/pkg/triggers/dashboard
+//  19. github.com/Notifiarr/notifiarr/pkg/triggers/endpoints/epconfig
+//  20. github.com/Notifiarr/notifiarr/pkg/triggers/filewatch
+//  21. github.com/Notifiarr/notifiarr/pkg/website/clientinfo
+//  22. github.com/shirou/gopsutil/v4/cpu
+//  23. github.com/shirou/gopsutil/v4/disk
+//  24. github.com/shirou/gopsutil/v4/host
+//  25. github.com/shirou/gopsutil/v4/load
+//  26. golift.io/deluge
+//  27. golift.io/mulery/client
+//  28. golift.io/nzbget
+//  29. golift.io/qbit
+//  30. golift.io/starr
+//  31. golift.io/starr/lidarr
+//  32. golift.io/starr/prowlarr
+//  33. golift.io/starr/radarr
+//  34. golift.io/starr/readarr
+//  35. golift.io/starr/sonarr

--- a/frontend/src/pages/monitoring/page.svelte.ts
+++ b/frontend/src/pages/monitoring/page.svelte.ts
@@ -2,7 +2,7 @@ import { getUi } from '../../api/fetch'
 import { delay, success, warning } from '../../includes/util'
 import { get } from 'svelte/store'
 import { _ } from 'svelte-i18n'
-import type { ClientServicesConfig as ServicesConfig } from '../../api/notifiarrConfig'
+import { CheckState, type ClientServicesConfig as ServicesConfig } from '../../api/notifiarrConfig'
 
 export const page = { id: 'Monitoring' }
 
@@ -11,17 +11,17 @@ class Mon {
   public checking = $state<Record<string, boolean>>({})
   public config = $state<ServicesConfig>({ results: [], running: true, disabled: false })
 
-  public states: Record<number, string> = {
-    0: 'OK',
-    1: 'Warning',
-    2: 'Critical',
-    3: 'Unknown',
+  public states: Record<CheckState, string> = {
+    [CheckState.OK]: 'OK',
+    [CheckState.Warning]: 'Warning',
+    [CheckState.Critical]: 'Critical',
+    [CheckState.Unknown]: 'Unknown',
   }
-  public colors: Record<number, string> = {
-    0: 'success',
-    1: 'warning',
-    2: 'danger',
-    3: 'info',
+  public colors: Record<CheckState, string> = {
+    [CheckState.OK]: 'success',
+    [CheckState.Warning]: 'warning',
+    [CheckState.Critical]: 'danger',
+    [CheckState.Unknown]: 'info',
   }
 
   public updateBackend = async (e: Event) => {

--- a/frontend/src/pages/serviceChecks/Check.svelte
+++ b/frontend/src/pages/serviceChecks/Check.svelte
@@ -2,7 +2,7 @@
   import Input from '../../includes/Input.svelte'
   import { Col, Row } from '@sveltestrap/sveltestrap'
   import { _ } from '../../includes/Translate.svelte'
-  import { type ServiceConfig } from '../../api/notifiarrConfig'
+  import { CheckType, type ServiceConfig } from '../../api/notifiarrConfig'
   import type { ChildProps } from '../../includes/Instances.svelte'
   import { profile } from '../../api/profile.svelte'
   import { slide } from 'svelte/transition'
@@ -61,31 +61,37 @@
           original={original?.type}
           {onchange}
           {validate}
-          options={['process', 'http', 'tcp', 'ping', 'icmp'].map(type => ({
+          options={[
+            CheckType.process,
+            CheckType.http,
+            CheckType.tcp,
+            CheckType.ping,
+            CheckType.icmp,
+          ].map(type => ({
             name: $_(`ServiceChecks.type.options.${type}`),
             value: type,
-            disabled: type === 'ping' && $profile.isWindows,
+            disabled: type === CheckType.ping && $profile.isWindows,
           }))} />
       </Col>
     </Row>
 
-    {#if form.type === 'http'}
+    {#if form.type === CheckType.http}
       <div class="row" transition:slide>
         <Http {form} {original} {app} {index} {validate} bind:this={pages.http} />
       </div>
-    {:else if form.type === 'process'}
+    {:else if form.type === CheckType.process}
       <div class="row" transition:slide>
         <Proc {form} {original} {app} {index} {validate} bind:this={pages.process} />
       </div>
-    {:else if form.type === 'icmp'}
+    {:else if form.type === CheckType.icmp}
       <div class="row" transition:slide>
         <Ping {form} {original} {app} {index} {validate} bind:this={pages.icmp} />
       </div>
-    {:else if form.type === 'ping'}
+    {:else if form.type === CheckType.ping}
       <div class="row" transition:slide>
         <Ping {form} {original} {app} {index} {validate} bind:this={pages.ping} />
       </div>
-    {:else if form.type === 'tcp'}
+    {:else if form.type === CheckType.tcp}
       <div class="row" transition:slide>
         <Tcp {form} {original} {app} {index} {validate} bind:this={pages.tcp} />
       </div>

--- a/frontend/src/pages/serviceChecks/Index.svelte
+++ b/frontend/src/pages/serviceChecks/Index.svelte
@@ -11,7 +11,7 @@
   import { FormListTracker } from '../../includes/formsTracker.svelte'
   import { profile } from '../../api/profile.svelte'
   import { nav } from '../../navigation/nav.svelte'
-  import type { ServiceConfig } from '../../api/notifiarrConfig'
+  import { CheckType, type ServiceConfig } from '../../api/notifiarrConfig'
   import { get } from 'svelte/store'
   import type { App } from '../../includes/formsTracker.svelte'
   import { type IconSource } from '../../includes/Fa.svelte'
@@ -52,13 +52,13 @@
         }
       })
       return val ? found : get(_)('phrases.NameMustNotBeEmpty')
-    } else if (c?.[idx]?.type === 'http') {
+    } else if (c?.[idx]?.type === CheckType.http) {
       return httpValidator(id, val)
-    } else if (c?.[idx]?.type === 'process') {
+    } else if (c?.[idx]?.type === CheckType.process) {
       return processValidator(id, val)
-    } else if (['ping', 'icmp'].includes(c?.[idx]?.type)) {
+    } else if (c?.[idx]?.type === CheckType.ping || c?.[idx]?.type === CheckType.icmp) {
       return pingValidator(id, val)
-    } else if (c?.[idx]?.type === 'tcp') {
+    } else if (c?.[idx]?.type === CheckType.tcp) {
       return tcpValidator(id, val)
     } else {
       return ''
@@ -85,12 +85,12 @@
   })
 
   // Shown next to the check name in each accordion header.
-  const icons: Record<string, IconSource> = {
-    http: Globe,
-    process: Cpu,
-    ping: PingPong,
-    icmp: PingPong,
-    tcp: PlugsConnected,
+  const icons: Record<CheckType, IconSource> = {
+    [CheckType.http]: Globe,
+    [CheckType.process]: Cpu,
+    [CheckType.ping]: PingPong,
+    [CheckType.icmp]: PingPong,
+    [CheckType.tcp]: PlugsConnected,
   }
 </script>
 
@@ -118,9 +118,10 @@
   <!-- Services Section -->
   <Instances {flt} Child={Check} deleteButton={app.id + '.DeleteCheck'}>
     {#snippet headerActive(index)}
+      {@const type = flt.original?.[index]?.type}
       <Fa
-        flip={flt.original?.[index]?.type === 'icmp'}
-        i={icons[flt.original?.[index]?.type]}
+        flip={type === CheckType.icmp}
+        i={type && icons[type]}
         c1="#0E6655"
         c2="#0B5345"
         d1="#9FE2BF"

--- a/frontend/src/pages/serviceChecks/page.svelte.ts
+++ b/frontend/src/pages/serviceChecks/page.svelte.ts
@@ -1,4 +1,4 @@
-import type { Config, ServiceConfig } from '../../api/notifiarrConfig'
+import { CheckType, type Config, type ServiceConfig } from '../../api/notifiarrConfig'
 import { deepCopy } from '../../includes/util'
 import { get } from 'svelte/store'
 import { profile } from '../../api/profile.svelte'
@@ -10,7 +10,7 @@ export const empty: ServiceConfig = {
   name: '',
   interval: '5m0s',
   timeout: '10s',
-  type: 'http',
+  type: CheckType.http,
   value: '',
   expect: '200',
   tags: {},


### PR DESCRIPTION
## Summary
- Generate `CheckType` and `CheckState` enums from the Go service-check constants, matching the existing `AuthType` pattern.
- Override `snapshot.NullString` and `*services.Output` to TypeScript `string`, which is what those types actually JSON-encode as (including the `"NULL"` sentinel).
- Point the service-check and monitoring UI at those types so selects, validators, icons, and state colors stay aligned with the generated model.

## Test plan
- [ ] Confirm `frontend/src/api/notifiarrConfig.ts` has `CheckType`/`CheckState`, `MySQLProcess.db`/`info` as `string`, and `CheckResult.output?: string`.
- [ ] On Service Checks, switch a check among http/process/tcp/ping/icmp and confirm the matching form still appears; ping stays disabled on Windows.
- [ ] On Monitoring, confirm state colors/labels still map OK/Warning/Critical/Unknown and check output still renders as text.


Made with [Cursor](https://cursor.com)