### PR TITLE
Stop Windows upgrades from waiting 75s after the old process exits

### DIFF
--- a/pkg/update/pid_others.go
+++ b/pkg/update/pid_others.go
@@ -1,0 +1,38 @@
+//go:build !windows
+
+package update
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+const parentWaitPollTime = 500 * time.Millisecond
+
+// waitForPidToExit blocks until pid exits, or parentWaitTimeout elapses.
+// Unix FindProcess always succeeds, so existence is probed with Signal(0).
+func waitForPidToExit(pid int) {
+	if pid <= 0 {
+		return
+	}
+
+	deadline := time.Now().Add(parentWaitTimeout)
+
+	for time.Now().Before(deadline) {
+		if !isPidRunning(pid) {
+			return
+		}
+
+		time.Sleep(parentWaitPollTime)
+	}
+}
+
+func isPidRunning(pid int) bool {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+
+	return process.Signal(syscall.Signal(0)) == nil
+}

--- a/pkg/update/pid_test.go
+++ b/pkg/update/pid_test.go
@@ -1,0 +1,78 @@
+package update //nolint:testpackage
+
+import (
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func startPauseProcess(t *testing.T) *exec.Cmd {
+	t.Helper()
+
+	cmd := exec.CommandContext(t.Context(), "sleep", "60")
+	if runtime.GOOS == "windows" {
+		cmd = exec.CommandContext(t.Context(), "ping", "-n", "60", "127.0.0.1")
+	}
+
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	return cmd
+}
+
+func TestWaitForPidToExitInvalid(t *testing.T) {
+	t.Parallel()
+
+	start := time.Now()
+	waitForPidToExit(-1)
+	waitForPidToExit(0)
+	require.Less(t, time.Since(start), time.Second)
+}
+
+func TestWaitForPidToExitAlreadyGone(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.CommandContext(t.Context(), "true")
+	if runtime.GOOS == "windows" {
+		cmd = exec.CommandContext(t.Context(), "cmd", "/c", "exit", "0")
+	}
+
+	require.NoError(t, cmd.Run())
+
+	start := time.Now()
+	waitForPidToExit(cmd.Process.Pid)
+	require.Less(t, time.Since(start), time.Second)
+}
+
+func TestWaitForPidToExitAfterKill(t *testing.T) {
+	t.Parallel()
+
+	cmd := startPauseProcess(t)
+	done := make(chan struct{})
+
+	go func() {
+		waitForPidToExit(cmd.Process.Pid)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("waitForPidToExit returned while the process was still running")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	require.NoError(t, cmd.Process.Kill())
+	_ = cmd.Wait()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("waitForPidToExit did not return after the process exited")
+	}
+}

--- a/pkg/update/pid_windows.go
+++ b/pkg/update/pid_windows.go
@@ -1,0 +1,25 @@
+package update
+
+import (
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// waitForPidToExit blocks until pid exits, or parentWaitTimeout elapses.
+// OpenProcess(SYNCHRONIZE) plus WaitForSingleObject is signaled when the
+// process actually exits, even if the kernel object is still around.
+func waitForPidToExit(pid int) {
+	if pid <= 0 {
+		return
+	}
+
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
+	if err != nil {
+		return
+	}
+
+	defer func() { _ = windows.CloseHandle(handle) }()
+
+	_, _ = windows.WaitForSingleObject(handle, uint32(parentWaitTimeout/time.Millisecond))
+}

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -19,7 +19,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/Notifiarr/notifiarr/pkg/mnd"
@@ -27,9 +26,10 @@ import (
 )
 
 const (
-	downloadTimeout  = 5 * time.Minute
-	backupTimeFormat = "060102T150405"
-	dotExe           = ".exe"
+	downloadTimeout   = 5 * time.Minute
+	backupTimeFormat  = "060102T150405"
+	dotExe            = ".exe"
+	parentWaitTimeout = 75 * time.Second
 )
 
 // Command is the input data to perform an in-place update.
@@ -66,40 +66,10 @@ func Restart(ctx context.Context, cmd *Command, waitForPid int) error {
 	return nil
 }
 
-func waitForPidToExit(pid int) {
-	const (
-		sleepTime = 500 * time.Millisecond
-		loopCount = 150 // 75 seconds
-	)
-
-	for range loopCount {
-		if !isPidRunning(pid) {
-			break
-		}
-
-		time.Sleep(sleepTime)
-	}
-}
-
-func isPidRunning(pid int) bool {
-	process, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-
-	_ = process.Release()
-
-	if mnd.IsWindows {
-		return true
-	}
-
-	return process.Signal(syscall.Signal(0)) == nil
-}
-
 // Now downloads the new file to a temp name in the same folder as the running file.
 // Moves the running file to a backup name in the same folder.
 // Moves the new file to the same location that the running file was at.
-// Triggers another invocation of the app that sleeps 5 seconds then restarts.
+// Triggers another invocation of the app that waits for this process to exit, then restarts.
 // The running app must exit after this returns!
 // The restart command can trigger the above Restart() procedure.
 // And that procedure relaunches the app; this allows "in-place" upgrades.


### PR DESCRIPTION
## Summary
- Windows in-place updates spawn a `--restart` helper that waits for the old PID before launching the new client.
- `isPidRunning` treated any successful `OpenProcess` as still running (`return true` on Windows), so the helper always burned the 75s cap. That matches the ~74s goodbye-to-start gap after flipping GitHub → unstable.
- Wait on a `SYNCHRONIZE` handle instead (`WaitForSingleObject`). It is signaled when the process actually exits. Unix still polls `Signal(0)`.

## Test plan
- [x] `go test ./pkg/update/`
- [x] `GOOS=windows go test ./pkg/update/ -c`
- [x] `golangci-lint run ./pkg/update/` (darwin and `GOOS=windows`)
- [ ] Windows: upgrade GitHub → unstable and confirm the tray comes back in a second or two after goodbye, not ~75s


Made with [Cursor](https://cursor.com)