### PR TITLE
Log the version-check body when JSON decode fails

### DIFF
--- a/pkg/update/check.go
+++ b/pkg/update/check.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"runtime"
 	"strings"
@@ -25,7 +26,8 @@ var OSsuffixMap = map[string]string{ //nolint:gochecknoglobals
 
 // Custom errors.
 var (
-	ErrNoFile = errors.New("no downloadable file found in release")
+	ErrNoFile       = errors.New("no downloadable file found in release")
+	ErrBodyTooLarge = errors.New("response body too large")
 )
 
 // LatestGH is where we find the latest release.
@@ -72,11 +74,43 @@ func GetRelease(ctx context.Context, uri string) (*GitHubReleasesLatest, error) 
 	defer resp.Body.Close()
 
 	var release GitHubReleasesLatest
-	if err = json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return nil, fmt.Errorf("decoding github response: %w", err)
+	if err = decodeJSONBody(ctx, resp, uri, &release); err != nil {
+		return nil, err
 	}
 
 	return &release, nil
+}
+
+const (
+	maxDecodeBody = 1 << 20
+	maxLogBody    = 4 << 10
+)
+
+func decodeJSONBody(ctx context.Context, resp *http.Response, uri string, dest any) error {
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxDecodeBody+1))
+	if err != nil {
+		return fmt.Errorf("reading %s response: %w", uri, err)
+	}
+
+	if len(body) > maxDecodeBody {
+		return fmt.Errorf("%w: %s", ErrBodyTooLarge, uri)
+	}
+
+	if err = json.Unmarshal(body, dest); err != nil {
+		logged := body
+		if len(logged) > maxLogBody {
+			logged = logged[:maxLogBody]
+		}
+
+		if mnd.Log != nil {
+			mnd.Log.Errorf(mnd.GetID(ctx), "[UPDATE] decoding %s: status %d type %q body %q: %v",
+				uri, resp.StatusCode, resp.Header.Get("Content-Type"), logged, err)
+		}
+
+		return fmt.Errorf("decoding %s response: %w", uri, err)
+	}
+
+	return nil
 }
 
 // FillUpdate compares a current version with the latest GitHub release.

--- a/pkg/update/check.go
+++ b/pkg/update/check.go
@@ -26,8 +26,9 @@ var OSsuffixMap = map[string]string{ //nolint:gochecknoglobals
 
 // Custom errors.
 var (
-	ErrNoFile    = errors.New("no downloadable file found in release")
-	ErrBadStatus = errors.New("unexpected http status")
+	ErrNoFile       = errors.New("no downloadable file found in release")
+	ErrBadStatus    = errors.New("unexpected http status")
+	ErrBodyTooLarge = errors.New("response body too large")
 )
 
 // LatestGH is where we find the latest release.
@@ -84,10 +85,13 @@ func GetRelease(ctx context.Context, uri string) (*GitHubReleasesLatest, error) 
 const (
 	unstableJSONLimit = 1024
 	githubJSONLimit   = 1024 * 1024
+	maxLogBody        = 4 * 1024
 )
 
 func decodeJSONBody(ctx context.Context, resp *http.Response, uri string, dest any, maxBody int) error {
-	body, err := io.ReadAll(io.LimitReader(resp.Body, int64(maxBody)))
+	readLimit := max(maxBody, maxLogBody)
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, int64(readLimit)+1))
 	if err != nil {
 		return fmt.Errorf("reading %s response: %w", uri, err)
 	}
@@ -95,6 +99,11 @@ func decodeJSONBody(ctx context.Context, resp *http.Response, uri string, dest a
 	if resp.StatusCode != http.StatusOK {
 		logUpdateBody(ctx, resp, uri, body, nil)
 		return fmt.Errorf("%w: %s: %d", ErrBadStatus, uri, resp.StatusCode)
+	}
+
+	if len(body) > maxBody {
+		logUpdateBody(ctx, resp, uri, body, ErrBodyTooLarge)
+		return fmt.Errorf("%w: %s (%d bytes)", ErrBodyTooLarge, uri, len(body))
 	}
 
 	if err = json.Unmarshal(body, dest); err != nil {
@@ -110,14 +119,19 @@ func logUpdateBody(ctx context.Context, resp *http.Response, uri string, body []
 		return
 	}
 
+	logged := body
+	if len(logged) > maxLogBody {
+		logged = logged[:maxLogBody]
+	}
+
 	if decodeErr != nil {
 		mnd.Log.Errorf(mnd.GetID(ctx), "[UPDATE] decoding %s: status %d type %q body %q: %v",
-			uri, resp.StatusCode, resp.Header.Get("Content-Type"), body, decodeErr)
+			uri, resp.StatusCode, resp.Header.Get("Content-Type"), logged, decodeErr)
 		return
 	}
 
 	mnd.Log.Errorf(mnd.GetID(ctx), "[UPDATE] %s: status %d type %q body %q",
-		uri, resp.StatusCode, resp.Header.Get("Content-Type"), body)
+		uri, resp.StatusCode, resp.Header.Get("Content-Type"), logged)
 }
 
 // FillUpdate compares a current version with the latest GitHub release.

--- a/pkg/update/check.go
+++ b/pkg/update/check.go
@@ -26,8 +26,8 @@ var OSsuffixMap = map[string]string{ //nolint:gochecknoglobals
 
 // Custom errors.
 var (
-	ErrNoFile       = errors.New("no downloadable file found in release")
-	ErrBodyTooLarge = errors.New("response body too large")
+	ErrNoFile    = errors.New("no downloadable file found in release")
+	ErrBadStatus = errors.New("unexpected http status")
 )
 
 // LatestGH is where we find the latest release.
@@ -74,7 +74,7 @@ func GetRelease(ctx context.Context, uri string) (*GitHubReleasesLatest, error) 
 	defer resp.Body.Close()
 
 	var release GitHubReleasesLatest
-	if err = decodeJSONBody(ctx, resp, uri, &release); err != nil {
+	if err = decodeJSONBody(ctx, resp, uri, &release, githubJSONLimit); err != nil {
 		return nil, err
 	}
 
@@ -82,35 +82,42 @@ func GetRelease(ctx context.Context, uri string) (*GitHubReleasesLatest, error) 
 }
 
 const (
-	maxDecodeBody = 1 << 20
-	maxLogBody    = 4 << 10
+	unstableJSONLimit = 1024
+	githubJSONLimit   = 1024 * 1024
 )
 
-func decodeJSONBody(ctx context.Context, resp *http.Response, uri string, dest any) error {
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxDecodeBody+1))
+func decodeJSONBody(ctx context.Context, resp *http.Response, uri string, dest any, maxBody int) error {
+	body, err := io.ReadAll(io.LimitReader(resp.Body, int64(maxBody)))
 	if err != nil {
 		return fmt.Errorf("reading %s response: %w", uri, err)
 	}
 
-	if len(body) > maxDecodeBody {
-		return fmt.Errorf("%w: %s", ErrBodyTooLarge, uri)
+	if resp.StatusCode != http.StatusOK {
+		logUpdateBody(ctx, resp, uri, body, nil)
+		return fmt.Errorf("%w: %s: %d", ErrBadStatus, uri, resp.StatusCode)
 	}
 
 	if err = json.Unmarshal(body, dest); err != nil {
-		logged := body
-		if len(logged) > maxLogBody {
-			logged = logged[:maxLogBody]
-		}
-
-		if mnd.Log != nil {
-			mnd.Log.Errorf(mnd.GetID(ctx), "[UPDATE] decoding %s: status %d type %q body %q: %v",
-				uri, resp.StatusCode, resp.Header.Get("Content-Type"), logged, err)
-		}
-
+		logUpdateBody(ctx, resp, uri, body, err)
 		return fmt.Errorf("decoding %s response: %w", uri, err)
 	}
 
 	return nil
+}
+
+func logUpdateBody(ctx context.Context, resp *http.Response, uri string, body []byte, decodeErr error) {
+	if mnd.Log == nil {
+		return
+	}
+
+	if decodeErr != nil {
+		mnd.Log.Errorf(mnd.GetID(ctx), "[UPDATE] decoding %s: status %d type %q body %q: %v",
+			uri, resp.StatusCode, resp.Header.Get("Content-Type"), body, decodeErr)
+		return
+	}
+
+	mnd.Log.Errorf(mnd.GetID(ctx), "[UPDATE] %s: status %d type %q body %q",
+		uri, resp.StatusCode, resp.Header.Get("Content-Type"), body)
 }
 
 // FillUpdate compares a current version with the latest GitHub release.

--- a/pkg/update/unstable.go
+++ b/pkg/update/unstable.go
@@ -74,7 +74,7 @@ func GetUnstable(ctx context.Context, uri string) (*UnstableFile, error) {
 	}
 	defer resp.Body.Close()
 
-	if err = decodeJSONBody(ctx, resp, uri, &release); err != nil {
+	if err = decodeJSONBody(ctx, resp, uri, &release, unstableJSONLimit); err != nil {
 		return nil, err
 	}
 

--- a/pkg/update/unstable.go
+++ b/pkg/update/unstable.go
@@ -2,7 +2,6 @@ package update
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"runtime"
@@ -75,8 +74,8 @@ func GetUnstable(ctx context.Context, uri string) (*UnstableFile, error) {
 	}
 	defer resp.Body.Close()
 
-	if err = json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return nil, fmt.Errorf("decoding %s response: %w", uri, err)
+	if err = decodeJSONBody(ctx, resp, uri, &release); err != nil {
+		return nil, err
 	}
 
 	release.Time, _ = time.Parse(time.RFC1123, resp.Header.Get("Last-Modified"))

--- a/pkg/update/unstable_test.go
+++ b/pkg/update/unstable_test.go
@@ -1,0 +1,59 @@
+package update //nolint:testpackage
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUnstableDecodesJSON(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		if !strings.HasSuffix(req.URL.Path, ".txt") {
+			http.Error(writer, "missing txt suffix", http.StatusNotFound)
+			return
+		}
+
+		if req.URL.Query().Get("stamp") == "" {
+			http.Error(writer, "missing stamp", http.StatusBadRequest)
+			return
+		}
+
+		writer.Header().Set("Content-Type", "text/plain")
+		writer.Header().Set("Last-Modified", "Mon, 07 Sep 2026 00:24:33 GMT")
+		_ = json.NewEncoder(writer).Encode(map[string]any{
+			"version":  "0.9.8",
+			"revision": 3416,
+			"size":     14075099,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	got, err := GetUnstable(context.Background(), srv.URL+"/notifiarr.amd64.exe.zip")
+	require.NoError(t, err)
+	require.Equal(t, "0.9.8", got.Ver)
+	require.Equal(t, 3416, got.Rev)
+	require.Equal(t, int64(14075099), got.Size)
+}
+
+func TestGetUnstableNonJSONBody(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("error code: 522"))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := GetUnstable(context.Background(), srv.URL+"/notifiarr.amd64.exe.zip")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decoding")
+	require.Contains(t, err.Error(), "invalid character 'e'")
+}

--- a/pkg/update/unstable_test.go
+++ b/pkg/update/unstable_test.go
@@ -3,13 +3,36 @@ package update //nolint:testpackage
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/stretchr/testify/require"
 )
+
+type captureLog struct {
+	mnd.Logger
+	msg string
+}
+
+func (clog *captureLog) Errorf(_ string, msg string, args ...any) {
+	clog.msg = fmt.Sprintf(msg, args...)
+}
+
+func withCaptureLog(t *testing.T) *captureLog {
+	t.Helper()
+
+	orig := mnd.Log
+	clog := &captureLog{}
+	mnd.Log = clog
+	t.Cleanup(func() { mnd.Log = orig })
+
+	return clog
+}
 
 func TestGetUnstableDecodesJSON(t *testing.T) {
 	t.Parallel()
@@ -40,10 +63,14 @@ func TestGetUnstableDecodesJSON(t *testing.T) {
 	require.Equal(t, "0.9.8", got.Ver)
 	require.Equal(t, 3416, got.Rev)
 	require.Equal(t, int64(14075099), got.Size)
+
+	wantTime, err := time.Parse(http.TimeFormat, "Mon, 07 Sep 2026 00:24:33 GMT")
+	require.NoError(t, err)
+	require.True(t, got.Time.Equal(wantTime))
 }
 
-func TestGetUnstableNonJSONBody(t *testing.T) {
-	t.Parallel()
+func TestGetUnstableNonJSONBody(t *testing.T) { //nolint:paralleltest
+	clog := withCaptureLog(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.Header().Set("Content-Type", "text/plain")
@@ -56,6 +83,9 @@ func TestGetUnstableNonJSONBody(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "decoding")
 	require.Contains(t, err.Error(), "invalid character 'e'")
+	require.Contains(t, clog.msg, `status 200`)
+	require.Contains(t, clog.msg, `type "text/plain"`)
+	require.Contains(t, clog.msg, `body "error code: 522"`)
 }
 
 func TestGetUnstableNonOKStatus(t *testing.T) {
@@ -71,4 +101,26 @@ func TestGetUnstableNonOKStatus(t *testing.T) {
 	_, err := GetUnstable(context.Background(), srv.URL+"/notifiarr.amd64.exe.zip")
 	require.ErrorIs(t, err, ErrBadStatus)
 	require.Contains(t, err.Error(), "502")
+}
+
+func TestGetUnstableBodyTooLarge(t *testing.T) { //nolint:paralleltest
+	clog := withCaptureLog(t)
+
+	const uniqueTail = "UNIQUE_TAIL"
+
+	body := strings.Repeat("A", maxLogBody) + uniqueTail
+
+	srv := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "text/plain")
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := GetUnstable(context.Background(), srv.URL+"/notifiarr.amd64.exe.zip")
+	require.ErrorIs(t, err, ErrBodyTooLarge)
+	require.Contains(t, clog.msg, `status 200`)
+	require.Contains(t, clog.msg, `type "text/plain"`)
+	require.Contains(t, clog.msg, strings.Repeat("A", maxLogBody))
+	require.NotContains(t, clog.msg, uniqueTail)
 }

--- a/pkg/update/unstable_test.go
+++ b/pkg/update/unstable_test.go
@@ -45,10 +45,10 @@ func TestGetUnstableDecodesJSON(t *testing.T) {
 func TestGetUnstableNonJSONBody(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("error code: 522"))
+	srv := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "text/plain")
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write([]byte("error code: 522"))
 	}))
 	t.Cleanup(srv.Close)
 
@@ -56,4 +56,19 @@ func TestGetUnstableNonJSONBody(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "decoding")
 	require.Contains(t, err.Error(), "invalid character 'e'")
+}
+
+func TestGetUnstableNonOKStatus(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "text/plain")
+		writer.WriteHeader(http.StatusBadGateway)
+		_, _ = writer.Write([]byte("error code: 522"))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := GetUnstable(context.Background(), srv.URL+"/notifiarr.amd64.exe.zip")
+	require.ErrorIs(t, err, ErrBadStatus)
+	require.Contains(t, err.Error(), "502")
 }


### PR DESCRIPTION
## Summary
- Read the GitHub/unstable version-check response into memory and JSON-decode it.
- On decode failure, write status, content-type, and a truncated body to the log so a reply like \`error code: 522\` is not a mystery \`invalid character 'e'\`.

## Test plan
- [ ] \`go test -race ./pkg/update/\` passes.
- [ ] Trigger an Unstable version check against a host that returns non-JSON; confirm the log line includes \`body %q\` and the tray error still shows the decode failure.


Made with [Cursor](https://cursor.com)