### PR TITLE
Retry version checks after Cloudflare 521 and log non-JSON bodies

### DIFF
--- a/pkg/update/check.go
+++ b/pkg/update/check.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"runtime"
 	"strings"
@@ -25,7 +26,8 @@ var OSsuffixMap = map[string]string{ //nolint:gochecknoglobals
 
 // Custom errors.
 var (
-	ErrNoFile = errors.New("no downloadable file found in release")
+	ErrNoFile       = errors.New("no downloadable file found in release")
+	ErrBodyTooLarge = errors.New("response body too large")
 )
 
 // LatestGH is where we find the latest release.
@@ -72,11 +74,43 @@ func GetRelease(ctx context.Context, uri string) (*GitHubReleasesLatest, error) 
 	defer resp.Body.Close()
 
 	var release GitHubReleasesLatest
-	if err = json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return nil, fmt.Errorf("decoding github response: %w", err)
+	if err = decodeJSONBody(ctx, resp, uri, &release); err != nil {
+		return nil, err
 	}
 
 	return &release, nil
+}
+
+const (
+	maxDecodeBody = 1 << 20
+	maxLogBody    = 4 << 10
+)
+
+func decodeJSONBody(ctx context.Context, resp *http.Response, uri string, dest any) error {
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxDecodeBody+1))
+	if err != nil {
+		return fmt.Errorf("reading %s response: %w", uri, err)
+	}
+
+	if len(body) > maxDecodeBody {
+		return fmt.Errorf("%w: %s", ErrBodyTooLarge, uri)
+	}
+
+	if err = json.Unmarshal(body, dest); err != nil {
+		logged := body
+		if len(logged) > maxLogBody {
+			logged = logged[:maxLogBody]
+		}
+
+		if mnd.Log != nil {
+			mnd.Log.Errorf(mnd.GetID(ctx), "[UPDATE] decoding %s: status %d type %q body %q: %v",
+				uri, resp.StatusCode, resp.Header.Get("Content-Type"), logged, err)
+		}
+
+		return fmt.Errorf("decoding %s response: %w", uri, err)
+	}
+
+	return nil
 }
 
 // FillUpdate compares a current version with the latest GitHub release.

--- a/pkg/update/check.go
+++ b/pkg/update/check.go
@@ -34,8 +34,29 @@ var (
 // LatestGH is where we find the latest release.
 const LatestGH = "https://api.github.com/repos/%s/releases/latest"
 
-// GitHub API and JSON unmarshal timeout.
-const timeout = 10 * time.Second
+const (
+	// timeout is the per-attempt budget for a GitHub/unstable version check.
+	timeout = 10 * time.Second
+	// versionCheckAttempts is 1 try plus retries for Cloudflare 5xx blips.
+	versionCheckAttempts = 3
+)
+
+// versionCheckRetry is the pause between version-check attempts.
+var versionCheckRetry = time.Second
+
+// httpStatusError is an HTTP status that was not 200.
+type httpStatusError struct {
+	URI    string
+	Status int
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("%s: %s: %d", ErrBadStatus, e.URI, e.Status)
+}
+
+func (e *httpStatusError) Unwrap() error {
+	return ErrBadStatus
+}
 
 // Update contains running Version, Current version and Download URL for Current version.
 // Outdate is true if the running version is older than the current version.
@@ -60,22 +81,8 @@ func CheckGitHub(ctx context.Context, userRepo string, version string) (*Update,
 
 // GetRelease returns a GitHub release. See Check for an example on how to use it.
 func GetRelease(ctx context.Context, uri string) (*GitHubReleasesLatest, error) {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
-	if err != nil {
-		return nil, fmt.Errorf("requesting github: %w", err)
-	}
-
-	resp, err := (&http.Client{}).Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("querying github: %w", err)
-	}
-	defer resp.Body.Close()
-
 	var release GitHubReleasesLatest
-	if err = decodeJSONBody(ctx, resp, uri, &release, githubJSONLimit); err != nil {
+	if err := doVersionCheck(ctx, uri, &release, githubJSONLimit, nil); err != nil {
 		return nil, err
 	}
 
@@ -98,7 +105,7 @@ func decodeJSONBody(ctx context.Context, resp *http.Response, uri string, dest a
 
 	if resp.StatusCode != http.StatusOK {
 		logUpdateBody(ctx, resp, uri, body, nil)
-		return fmt.Errorf("%w: %s: %d", ErrBadStatus, uri, resp.StatusCode)
+		return &httpStatusError{URI: uri, Status: resp.StatusCode}
 	}
 
 	if len(body) > maxBody {
@@ -132,6 +139,79 @@ func logUpdateBody(ctx context.Context, resp *http.Response, uri string, body []
 
 	mnd.Log.Errorf(mnd.GetID(ctx), "[UPDATE] %s: status %d type %q body %q",
 		uri, resp.StatusCode, resp.Header.Get("Content-Type"), logged)
+}
+
+func doVersionCheck(ctx context.Context, uri string, dest any, maxBody int, after func(*http.Response)) error {
+	var lastErr error
+
+	for attempt := 1; attempt <= versionCheckAttempts; attempt++ {
+		err := doVersionCheckOnce(ctx, uri, dest, maxBody, after)
+		if err == nil {
+			return nil
+		}
+
+		lastErr = err
+		if attempt == versionCheckAttempts || !retryableVersionCheck(err) {
+			return err
+		}
+
+		if mnd.Log != nil {
+			mnd.Log.Errorf(mnd.GetID(ctx), "[UPDATE] [%d/%d] version check failed, retrying in %s: %v",
+				attempt, versionCheckAttempts, versionCheckRetry, err)
+		}
+
+		timer := time.NewTimer(versionCheckRetry)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("version check: %w", ctx.Err())
+		case <-timer.C:
+		}
+	}
+
+	return lastErr
+}
+
+func doVersionCheckOnce(ctx context.Context, uri string, dest any, maxBody int, after func(*http.Response)) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return fmt.Errorf("requesting %s: %w", uri, err)
+	}
+
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return fmt.Errorf("querying %s: %w", uri, err)
+	}
+	defer resp.Body.Close()
+
+	if err = decodeJSONBody(ctx, resp, uri, dest, maxBody); err != nil {
+		return err
+	}
+
+	if after != nil {
+		after(resp)
+	}
+
+	return nil
+}
+
+func retryableVersionCheck(err error) bool {
+	switch {
+	case err == nil, errors.Is(err, context.Canceled), errors.Is(err, ErrBodyTooLarge):
+		return false
+	}
+
+	if statusErr, ok := errors.AsType[*httpStatusError](err); ok {
+		return statusErr.Status >= http.StatusInternalServerError ||
+			statusErr.Status == http.StatusTooManyRequests ||
+			statusErr.Status == http.StatusRequestTimeout
+	}
+
+	// Transport errors, per-attempt timeouts, and Cloudflare 200 error pages.
+	return true
 }
 
 // FillUpdate compares a current version with the latest GitHub release.

--- a/pkg/update/check.go
+++ b/pkg/update/check.go
@@ -103,14 +103,15 @@ func decodeJSONBody(ctx context.Context, resp *http.Response, uri string, dest a
 		return fmt.Errorf("reading %s response: %w", uri, err)
 	}
 
-	if len(body) > maxBody {
-		logUpdateBody(ctx, resp, uri, body, ErrBodyTooLarge)
-		return fmt.Errorf("%w: %s (%d bytes)", ErrBodyTooLarge, uri, len(body))
-	}
-
+	// Cloudflare error pages are several KB; the sidecar cap only applies to 200 JSON.
 	if resp.StatusCode != http.StatusOK {
 		logUpdateBody(ctx, resp, uri, body, nil)
 		return &httpStatusError{URI: uri, Status: resp.StatusCode}
+	}
+
+	if len(body) > maxBody {
+		logUpdateBody(ctx, resp, uri, body, ErrBodyTooLarge)
+		return fmt.Errorf("%w: %s (%d bytes)", ErrBodyTooLarge, uri, len(body))
 	}
 
 	if err = json.Unmarshal(body, dest); err != nil {

--- a/pkg/update/check.go
+++ b/pkg/update/check.go
@@ -26,8 +26,9 @@ var OSsuffixMap = map[string]string{ //nolint:gochecknoglobals
 
 // Custom errors.
 var (
-	ErrNoFile    = errors.New("no downloadable file found in release")
-	ErrBadStatus = errors.New("unexpected http status")
+	ErrNoFile       = errors.New("no downloadable file found in release")
+	ErrBadStatus    = errors.New("unexpected http status")
+	ErrBodyTooLarge = errors.New("response body too large")
 )
 
 // LatestGH is where we find the latest release.
@@ -84,10 +85,13 @@ func GetRelease(ctx context.Context, uri string) (*GitHubReleasesLatest, error) 
 const (
 	unstableJSONLimit = 1024
 	githubJSONLimit   = 1024 * 1024
+	maxLogBody        = 4 * 1024
 )
 
 func decodeJSONBody(ctx context.Context, resp *http.Response, uri string, dest any, maxBody int) error {
-	body, err := io.ReadAll(io.LimitReader(resp.Body, int64(maxBody)))
+	readLimit := max(maxBody, maxLogBody)
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, int64(readLimit)+1))
 	if err != nil {
 		return fmt.Errorf("reading %s response: %w", uri, err)
 	}
@@ -95,6 +99,11 @@ func decodeJSONBody(ctx context.Context, resp *http.Response, uri string, dest a
 	if resp.StatusCode != http.StatusOK {
 		logUpdateBody(ctx, resp, uri, body, nil)
 		return fmt.Errorf("%w: %s: %d", ErrBadStatus, uri, resp.StatusCode)
+	}
+
+	if len(body) > maxBody {
+		logUpdateBody(ctx, resp, uri, body, ErrBodyTooLarge)
+		return fmt.Errorf("%w: %s (%d bytes)", ErrBodyTooLarge, uri, len(body))
 	}
 
 	if err = json.Unmarshal(body, dest); err != nil {
@@ -110,14 +119,19 @@ func logUpdateBody(ctx context.Context, resp *http.Response, uri string, body []
 		return
 	}
 
+	logged := body
+	if len(logged) > maxLogBody {
+		logged = logged[:maxLogBody]
+	}
+
 	if decodeErr != nil {
 		mnd.Log.Errorf(mnd.GetID(ctx), "[UPDATE] decoding %s: status %d type %q body %q: %v",
-			uri, resp.StatusCode, resp.Header.Get("Content-Type"), body, decodeErr)
+			uri, resp.StatusCode, resp.Header.Get("Content-Type"), logged, decodeErr)
 		return
 	}
 
 	mnd.Log.Errorf(mnd.GetID(ctx), "[UPDATE] %s: status %d type %q body %q",
-		uri, resp.StatusCode, resp.Header.Get("Content-Type"), body)
+		uri, resp.StatusCode, resp.Header.Get("Content-Type"), logged)
 }
 
 // FillUpdate compares a current version with the latest GitHub release.

--- a/pkg/update/check.go
+++ b/pkg/update/check.go
@@ -26,8 +26,8 @@ var OSsuffixMap = map[string]string{ //nolint:gochecknoglobals
 
 // Custom errors.
 var (
-	ErrNoFile       = errors.New("no downloadable file found in release")
-	ErrBodyTooLarge = errors.New("response body too large")
+	ErrNoFile    = errors.New("no downloadable file found in release")
+	ErrBadStatus = errors.New("unexpected http status")
 )
 
 // LatestGH is where we find the latest release.
@@ -74,7 +74,7 @@ func GetRelease(ctx context.Context, uri string) (*GitHubReleasesLatest, error) 
 	defer resp.Body.Close()
 
 	var release GitHubReleasesLatest
-	if err = decodeJSONBody(ctx, resp, uri, &release); err != nil {
+	if err = decodeJSONBody(ctx, resp, uri, &release, githubJSONLimit); err != nil {
 		return nil, err
 	}
 
@@ -82,35 +82,42 @@ func GetRelease(ctx context.Context, uri string) (*GitHubReleasesLatest, error) 
 }
 
 const (
-	maxDecodeBody = 1 << 20
-	maxLogBody    = 4 << 10
+	unstableJSONLimit = 1024
+	githubJSONLimit   = 1024 * 1024
 )
 
-func decodeJSONBody(ctx context.Context, resp *http.Response, uri string, dest any) error {
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxDecodeBody+1))
+func decodeJSONBody(ctx context.Context, resp *http.Response, uri string, dest any, maxBody int) error {
+	body, err := io.ReadAll(io.LimitReader(resp.Body, int64(maxBody)))
 	if err != nil {
 		return fmt.Errorf("reading %s response: %w", uri, err)
 	}
 
-	if len(body) > maxDecodeBody {
-		return fmt.Errorf("%w: %s", ErrBodyTooLarge, uri)
+	if resp.StatusCode != http.StatusOK {
+		logUpdateBody(ctx, resp, uri, body, nil)
+		return fmt.Errorf("%w: %s: %d", ErrBadStatus, uri, resp.StatusCode)
 	}
 
 	if err = json.Unmarshal(body, dest); err != nil {
-		logged := body
-		if len(logged) > maxLogBody {
-			logged = logged[:maxLogBody]
-		}
-
-		if mnd.Log != nil {
-			mnd.Log.Errorf(mnd.GetID(ctx), "[UPDATE] decoding %s: status %d type %q body %q: %v",
-				uri, resp.StatusCode, resp.Header.Get("Content-Type"), logged, err)
-		}
-
+		logUpdateBody(ctx, resp, uri, body, err)
 		return fmt.Errorf("decoding %s response: %w", uri, err)
 	}
 
 	return nil
+}
+
+func logUpdateBody(ctx context.Context, resp *http.Response, uri string, body []byte, decodeErr error) {
+	if mnd.Log == nil {
+		return
+	}
+
+	if decodeErr != nil {
+		mnd.Log.Errorf(mnd.GetID(ctx), "[UPDATE] decoding %s: status %d type %q body %q: %v",
+			uri, resp.StatusCode, resp.Header.Get("Content-Type"), body, decodeErr)
+		return
+	}
+
+	mnd.Log.Errorf(mnd.GetID(ctx), "[UPDATE] %s: status %d type %q body %q",
+		uri, resp.StatusCode, resp.Header.Get("Content-Type"), body)
 }
 
 // FillUpdate compares a current version with the latest GitHub release.

--- a/pkg/update/check.go
+++ b/pkg/update/check.go
@@ -103,14 +103,14 @@ func decodeJSONBody(ctx context.Context, resp *http.Response, uri string, dest a
 		return fmt.Errorf("reading %s response: %w", uri, err)
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		logUpdateBody(ctx, resp, uri, body, nil)
-		return &httpStatusError{URI: uri, Status: resp.StatusCode}
-	}
-
 	if len(body) > maxBody {
 		logUpdateBody(ctx, resp, uri, body, ErrBodyTooLarge)
 		return fmt.Errorf("%w: %s (%d bytes)", ErrBodyTooLarge, uri, len(body))
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		logUpdateBody(ctx, resp, uri, body, nil)
+		return &httpStatusError{URI: uri, Status: resp.StatusCode}
 	}
 
 	if err = json.Unmarshal(body, dest); err != nil {

--- a/pkg/update/unstable.go
+++ b/pkg/update/unstable.go
@@ -54,31 +54,18 @@ func CheckUnstable(ctx context.Context, app string, revision string) (*Update, e
 
 // GetUnstable returns an unstable release. See CheckUnstable for an example on how to use it.
 func GetUnstable(ctx context.Context, uri string) (*UnstableFile, error) {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	// we use stamp to bust the cloudflare cache.
 	// If you remove or rename `stamp` then also update decompressFile().
 	stamp := "?stamp=" + time.Now().UTC().Format("2006-01-02-15")
 	release := UnstableFile{File: uri + stamp}
 	uri += ".txt" + stamp
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
+	err := doVersionCheck(ctx, uri, &release, unstableJSONLimit, func(resp *http.Response) {
+		release.Time, _ = time.Parse(time.RFC1123, resp.Header.Get("Last-Modified"))
+	})
 	if err != nil {
-		return nil, fmt.Errorf("requesting %s: %w", uri, err)
-	}
-
-	resp, err := (&http.Client{}).Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("querying %s: %w", uri, err)
-	}
-	defer resp.Body.Close()
-
-	if err = decodeJSONBody(ctx, resp, uri, &release, unstableJSONLimit); err != nil {
 		return nil, err
 	}
-
-	release.Time, _ = time.Parse(time.RFC1123, resp.Header.Get("Last-Modified"))
 
 	return &release, nil
 }

--- a/pkg/update/unstable.go
+++ b/pkg/update/unstable.go
@@ -74,7 +74,7 @@ func GetUnstable(ctx context.Context, uri string) (*UnstableFile, error) {
 	}
 	defer resp.Body.Close()
 
-	if err = decodeJSONBody(ctx, resp, uri, &release); err != nil {
+	if err = decodeJSONBody(ctx, resp, uri, &release, unstableJSONLimit); err != nil {
 		return nil, err
 	}
 

--- a/pkg/update/unstable.go
+++ b/pkg/update/unstable.go
@@ -2,7 +2,6 @@ package update
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"runtime"
@@ -75,8 +74,8 @@ func GetUnstable(ctx context.Context, uri string) (*UnstableFile, error) {
 	}
 	defer resp.Body.Close()
 
-	if err = json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return nil, fmt.Errorf("decoding %s response: %w", uri, err)
+	if err = decodeJSONBody(ctx, resp, uri, &release); err != nil {
+		return nil, err
 	}
 
 	release.Time, _ = time.Parse(time.RFC1123, resp.Header.Get("Last-Modified"))

--- a/pkg/update/unstable_test.go
+++ b/pkg/update/unstable_test.go
@@ -1,0 +1,59 @@
+package update //nolint:testpackage
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUnstableDecodesJSON(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		if !strings.HasSuffix(req.URL.Path, ".txt") {
+			http.Error(writer, "missing txt suffix", http.StatusNotFound)
+			return
+		}
+
+		if req.URL.Query().Get("stamp") == "" {
+			http.Error(writer, "missing stamp", http.StatusBadRequest)
+			return
+		}
+
+		writer.Header().Set("Content-Type", "text/plain")
+		writer.Header().Set("Last-Modified", "Mon, 07 Sep 2026 00:24:33 GMT")
+		_ = json.NewEncoder(writer).Encode(map[string]any{
+			"version":  "0.9.8",
+			"revision": 3416,
+			"size":     14075099,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	got, err := GetUnstable(context.Background(), srv.URL+"/notifiarr.amd64.exe.zip")
+	require.NoError(t, err)
+	require.Equal(t, "0.9.8", got.Ver)
+	require.Equal(t, 3416, got.Rev)
+	require.Equal(t, int64(14075099), got.Size)
+}
+
+func TestGetUnstableNonJSONBody(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("error code: 522"))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := GetUnstable(context.Background(), srv.URL+"/notifiarr.amd64.exe.zip")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decoding")
+	require.Contains(t, err.Error(), "invalid character 'e'")
+}

--- a/pkg/update/unstable_test.go
+++ b/pkg/update/unstable_test.go
@@ -187,3 +187,23 @@ func TestGetUnstableDoesNotRetryNotFound(t *testing.T) {
 	require.Contains(t, err.Error(), "404")
 	require.Equal(t, int32(1), hits.Load())
 }
+
+func TestGetUnstableOversized5xxDoesNotRetry(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int32
+
+	body := strings.Repeat("A", unstableJSONLimit+1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		writer.Header().Set("Content-Type", "text/plain")
+		writer.WriteHeader(http.StatusBadGateway)
+		_, _ = writer.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := GetUnstable(context.Background(), srv.URL+"/notifiarr.amd64.exe.zip")
+	require.ErrorIs(t, err, ErrBodyTooLarge)
+	require.Equal(t, int32(1), hits.Load())
+}

--- a/pkg/update/unstable_test.go
+++ b/pkg/update/unstable_test.go
@@ -6,13 +6,25 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/stretchr/testify/require"
 )
+
+const cloudflareOriginDown = 521 // Cloudflare 521: web server is down.
+
+func TestMain(m *testing.M) {
+	orig := versionCheckRetry
+	versionCheckRetry = 0
+	code := m.Run()
+	versionCheckRetry = orig
+	os.Exit(code)
+}
 
 type captureLog struct {
 	mnd.Logger
@@ -91,7 +103,10 @@ func TestGetUnstableNonJSONBody(t *testing.T) { //nolint:paralleltest
 func TestGetUnstableNonOKStatus(t *testing.T) {
 	t.Parallel()
 
+	var hits atomic.Int32
+
 	srv := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
 		writer.Header().Set("Content-Type", "text/plain")
 		writer.WriteHeader(http.StatusBadGateway)
 		_, _ = writer.Write([]byte("error code: 522"))
@@ -101,6 +116,7 @@ func TestGetUnstableNonOKStatus(t *testing.T) {
 	_, err := GetUnstable(context.Background(), srv.URL+"/notifiarr.amd64.exe.zip")
 	require.ErrorIs(t, err, ErrBadStatus)
 	require.Contains(t, err.Error(), "502")
+	require.Equal(t, int32(versionCheckAttempts), hits.Load())
 }
 
 func TestGetUnstableBodyTooLarge(t *testing.T) { //nolint:paralleltest
@@ -123,4 +139,51 @@ func TestGetUnstableBodyTooLarge(t *testing.T) { //nolint:paralleltest
 	require.Contains(t, clog.msg, `type "text/plain"`)
 	require.Contains(t, clog.msg, strings.Repeat("A", maxLogBody))
 	require.NotContains(t, clog.msg, uniqueTail)
+}
+
+func TestGetUnstableRetriesCloudflare521(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		if hits.Add(1) < versionCheckAttempts {
+			writer.Header().Set("Content-Type", "text/plain")
+			writer.WriteHeader(cloudflareOriginDown)
+			_, _ = writer.Write([]byte("error code: 521"))
+			return
+		}
+
+		writer.Header().Set("Content-Type", "text/plain")
+		writer.Header().Set("Last-Modified", "Mon, 07 Sep 2026 00:24:33 GMT")
+		_ = json.NewEncoder(writer).Encode(map[string]any{
+			"version":  "0.9.8",
+			"revision": 3416,
+			"size":     14075099,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	got, err := GetUnstable(context.Background(), srv.URL+"/notifiarr.amd64.exe.zip")
+	require.NoError(t, err)
+	require.Equal(t, int32(versionCheckAttempts), hits.Load())
+	require.Equal(t, "0.9.8", got.Ver)
+	require.Equal(t, 3416, got.Rev)
+}
+
+func TestGetUnstableDoesNotRetryNotFound(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		writer.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := GetUnstable(context.Background(), srv.URL+"/notifiarr.amd64.exe.zip")
+	require.ErrorIs(t, err, ErrBadStatus)
+	require.Contains(t, err.Error(), "404")
+	require.Equal(t, int32(1), hits.Load())
 }

--- a/pkg/update/unstable_test.go
+++ b/pkg/update/unstable_test.go
@@ -3,13 +3,36 @@ package update //nolint:testpackage
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/Notifiarr/notifiarr/pkg/mnd"
 	"github.com/stretchr/testify/require"
 )
+
+type captureLog struct {
+	mnd.Logger
+	msg string
+}
+
+func (clog *captureLog) Errorf(_ string, msg string, args ...any) {
+	clog.msg = fmt.Sprintf(msg, args...)
+}
+
+func withCaptureLog(t *testing.T) *captureLog {
+	t.Helper()
+
+	orig := mnd.Log
+	clog := &captureLog{}
+	mnd.Log = clog
+	t.Cleanup(func() { mnd.Log = orig })
+
+	return clog
+}
 
 func TestGetUnstableDecodesJSON(t *testing.T) {
 	t.Parallel()
@@ -40,10 +63,14 @@ func TestGetUnstableDecodesJSON(t *testing.T) {
 	require.Equal(t, "0.9.8", got.Ver)
 	require.Equal(t, 3416, got.Rev)
 	require.Equal(t, int64(14075099), got.Size)
+
+	wantTime, err := time.Parse(http.TimeFormat, "Mon, 07 Sep 2026 00:24:33 GMT")
+	require.NoError(t, err)
+	require.True(t, got.Time.Equal(wantTime))
 }
 
-func TestGetUnstableNonJSONBody(t *testing.T) {
-	t.Parallel()
+func TestGetUnstableNonJSONBody(t *testing.T) { //nolint:paralleltest
+	clog := withCaptureLog(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.Header().Set("Content-Type", "text/plain")
@@ -56,6 +83,9 @@ func TestGetUnstableNonJSONBody(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "decoding")
 	require.Contains(t, err.Error(), "invalid character 'e'")
+	require.Contains(t, clog.msg, `status 200`)
+	require.Contains(t, clog.msg, `type "text/plain"`)
+	require.Contains(t, clog.msg, `body "error code: 522"`)
 }
 
 func TestGetUnstableNonOKStatus(t *testing.T) {
@@ -71,4 +101,26 @@ func TestGetUnstableNonOKStatus(t *testing.T) {
 	_, err := GetUnstable(context.Background(), srv.URL+"/notifiarr.amd64.exe.zip")
 	require.ErrorIs(t, err, ErrBadStatus)
 	require.Contains(t, err.Error(), "502")
+}
+
+func TestGetUnstableBodyTooLarge(t *testing.T) { //nolint:paralleltest
+	clog := withCaptureLog(t)
+
+	const uniqueTail = "UNIQUE_TAIL"
+
+	body := strings.Repeat("A", maxLogBody) + uniqueTail
+
+	srv := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "text/plain")
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := GetUnstable(context.Background(), srv.URL+"/notifiarr.amd64.exe.zip")
+	require.ErrorIs(t, err, ErrBodyTooLarge)
+	require.Contains(t, clog.msg, `status 200`)
+	require.Contains(t, clog.msg, `type "text/plain"`)
+	require.Contains(t, clog.msg, strings.Repeat("A", maxLogBody))
+	require.NotContains(t, clog.msg, uniqueTail)
 }

--- a/pkg/update/unstable_test.go
+++ b/pkg/update/unstable_test.go
@@ -45,10 +45,10 @@ func TestGetUnstableDecodesJSON(t *testing.T) {
 func TestGetUnstableNonJSONBody(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("error code: 522"))
+	srv := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "text/plain")
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write([]byte("error code: 522"))
 	}))
 	t.Cleanup(srv.Close)
 
@@ -56,4 +56,19 @@ func TestGetUnstableNonJSONBody(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "decoding")
 	require.Contains(t, err.Error(), "invalid character 'e'")
+}
+
+func TestGetUnstableNonOKStatus(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "text/plain")
+		writer.WriteHeader(http.StatusBadGateway)
+		_, _ = writer.Write([]byte("error code: 522"))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := GetUnstable(context.Background(), srv.URL+"/notifiarr.amd64.exe.zip")
+	require.ErrorIs(t, err, ErrBadStatus)
+	require.Contains(t, err.Error(), "502")
 }

--- a/pkg/update/unstable_test.go
+++ b/pkg/update/unstable_test.go
@@ -188,22 +188,24 @@ func TestGetUnstableDoesNotRetryNotFound(t *testing.T) {
 	require.Equal(t, int32(1), hits.Load())
 }
 
-func TestGetUnstableOversized5xxDoesNotRetry(t *testing.T) {
+func TestGetUnstableRetriesOversizedCloudflarePage(t *testing.T) {
 	t.Parallel()
 
 	var hits atomic.Int32
 
-	body := strings.Repeat("A", unstableJSONLimit+1)
+	// Live Cloudflare error pages are several KB (measured ~8 KB), well past unstableJSONLimit.
+	body := strings.Repeat("A", 8313)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		hits.Add(1)
-		writer.Header().Set("Content-Type", "text/plain")
-		writer.WriteHeader(http.StatusBadGateway)
+		writer.Header().Set("Content-Type", "text/html")
+		writer.WriteHeader(cloudflareOriginDown)
 		_, _ = writer.Write([]byte(body))
 	}))
 	t.Cleanup(srv.Close)
 
 	_, err := GetUnstable(context.Background(), srv.URL+"/notifiarr.amd64.exe.zip")
-	require.ErrorIs(t, err, ErrBodyTooLarge)
-	require.Equal(t, int32(1), hits.Load())
+	require.ErrorIs(t, err, ErrBadStatus)
+	require.Contains(t, err.Error(), "521")
+	require.Equal(t, int32(versionCheckAttempts), hits.Load())
 }


### PR DESCRIPTION
## Summary
- Includes [#1362](https://github.com/Notifiarr/notifiarr/pull/1362): read the GitHub/unstable version-check body and log status, content-type, and a truncated body when decode fails or the status is not 200.
- Retry the version check 3 times (1s apart) on Cloudflare 5xx (521/522/502/…), 429, transport errors, and 200 error pages that fail JSON decode.
- 4xx (404, etc.) and oversized bodies still fail on the first response. Each attempt gets its own 10s timeout.

## Test plan
- [x] `go test ./pkg/update/`
- [x] `golangci-lint run ./pkg/update/` (darwin and `GOOS=windows`)
- [ ] Trigger an Unstable version check while origin returns 521, then 200; confirm the log shows `[1/3] version check failed, retrying` and the check succeeds.
- [ ] On a non-JSON 200, confirm the log line includes `body %q`.